### PR TITLE
Type memo summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,14 +215,15 @@ const blockHash = "b49bb1c06c697b7d6539c987082c5a0dc6d86d91208874517ab17da752472
 const blockSummary = await client.getBlockSummary(blockHash);
 const transactionSummaries = blockSummary.transactionSummaries;
 
-for (let transactionSummary of transactionSummaries) {
+for (const transactionSummary of transactionSummaries) {
     if (instanceOfTransferWithMemoTransactionSummary(transactionSummary)) {
         const [transferredEvent, memoEvent] = transactionSummary.result.events;
 
         const toAddress = transferredEvent.to.address;
+        const amount = transferredEvent.amount;
         const memo = memoEvent.memo;
 
-        // Apply business logic to toAddress and memo...
+        // Apply business logic to toAddress, amount and memo...
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ const bestBlock = consensusStatus.bestBlock;
 ...
 ```
 
+## Check block for transfers with memo
+The following example demonstrates how to check and parse a block 
+for transfers with a memo.
+```
+const blockHash = "b49bb1c06c697b7d6539c987082c5a0dc6d86d91208874517ab17da752472edf";
+const blockSummary = await client.getBlockSummary(blockHash);
+const transactionSummaries = blockSummary.transactionSummaries;
+
+for (let transactionSummary of transactionSummaries) {
+    if (instanceOfTransferWithMemoTransactionSummary(transactionSummary)) {
+        const [transferredEvent, memoEvent] = transactionSummary.result.events;
+
+        const toAddress = transferredEvent.to.address;
+        const memo = memoEvent.memo;
+
+        // Apply business logic to toAddress and memo...
+    }
+}
+```
+
 # Build
 
 ## Building for a release

--- a/src/accountTransactions.ts
+++ b/src/accountTransactions.ts
@@ -36,7 +36,11 @@ export class SimpleTransferWithMemoHandler
         const serializedToAddress = transfer.toAddress.decodedAddress;
         const serializedMemo = encodeMemo(transfer.memo);
         const serializedAmount = encodeWord64(transfer.amount.microGtuAmount);
-        return Buffer.concat([serializedToAddress, serializedMemo, serializedAmount]);
+        return Buffer.concat([
+            serializedToAddress,
+            serializedMemo,
+            serializedAmount,
+        ]);
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/';
 import { AccountAddress } from './types/accountAddress';
 import { GtuAmount } from './types/gtuAmount';
 import { Memo } from './types/Memo';
@@ -94,32 +93,71 @@ export interface TransferredEvent {
     from: AddressAccount;
 }
 
+export interface MemoEvent {
+    tag: 'TransferMemo';
+    memo: string;
+}
+
 export interface EventResult {
     outcome: string;
     // TODO Resolve the types completely.
-    events: (TransactionEvent | TransferredEvent | UpdatedEvent)[];
+    events: (TransactionEvent | TransferredEvent | UpdatedEvent | MemoEvent)[];
 }
 
-interface TransactionSummaryType {
+interface BaseTransactionSummaryType {
     type:
         | 'accountTransaction'
         | 'credentialDeploymentTransaction'
         | 'updateTransaction';
-    // TODO: Figure out if contents is always just a string.
+}
+
+export interface TransferWithMemoSummaryType
+    extends BaseTransactionSummaryType {
+    contents: 'transferWithMemo';
+}
+
+export interface GenericTransactionSummaryType
+    extends BaseTransactionSummaryType {
     contents: string;
 }
 
-export interface TransactionSummary {
+export interface BaseTransactionSummary {
     sender?: string;
     hash: string;
 
     cost: bigint;
     energyCost: bigint;
     index: bigint;
+}
 
-    type: TransactionSummaryType;
-
+interface GenericTransactionSummary extends BaseTransactionSummary {
+    type: GenericTransactionSummaryType;
     result: EventResult;
+}
+
+interface TransferWithMemoEventResult {
+    outcome: string;
+    events: [TransferredEvent, MemoEvent];
+}
+
+export interface TransferWithMemoTransactionSummary
+    extends BaseTransactionSummary {
+    type: TransferWithMemoSummaryType;
+    result: TransferWithMemoEventResult;
+}
+
+export type TransactionSummary =
+    | GenericTransactionSummary
+    | TransferWithMemoTransactionSummary;
+
+export function instanceOfTransferWithMemoTransactionSummary(
+    object: TransactionSummary
+): object is TransferWithMemoTransactionSummary {
+    return (
+        object.type !== undefined &&
+        object.type.contents !== undefined &&
+        object.type.contents === 'transferWithMemo'
+    );
 }
 
 export interface TransactionStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,9 +154,7 @@ export function instanceOfTransferWithMemoTransactionSummary(
     object: TransactionSummary
 ): object is TransferWithMemoTransactionSummary {
     return (
-        object.type !== undefined &&
-        object.type.contents !== undefined &&
-        object.type.contents === 'transferWithMemo'
+        object.type !== undefined && object.type.contents === 'transferWithMemo'
     );
 }
 

--- a/src/types/Memo.ts
+++ b/src/types/Memo.ts
@@ -10,7 +10,7 @@ export class Memo {
     constructor(memo: Buffer) {
         if (memo.length > 256) {
             throw new Error(
-                'A transaction memo\'s size cannot exceed 256 bytes'
+                "A transaction memo's size cannot exceed 256 bytes"
             );
         }
         this.memo = memo;


### PR DESCRIPTION
## Purpose
Add typing and a type guard specifically for transaction summaries containing a transfer with a memo.

## Changes
- Ran `lint --fix`
- Updated types for transfer with memo and added a type guard.
- Added an example of how to extract the memo and toAddress from a block containing a transfer with a memo.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.