### PR TITLE
Fix scheduled transfer parsing bug

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -146,6 +146,7 @@ export default class ConcordiumNodeClient {
             this.client.getAccountInfo,
             getAddressInfoRequest
         );
+        const datePropertyKeys: (keyof ReleaseSchedule)[] = ['timestamp'];
         const bigIntPropertyKeys: (
             | keyof AccountInfo
             | keyof AccountEncryptedAmount
@@ -161,7 +162,7 @@ export default class ConcordiumNodeClient {
         ];
         return unwrapJsonResponse<AccountInfo>(
             response,
-            buildJsonResponseReviver([], bigIntPropertyKeys),
+            buildJsonResponseReviver(datePropertyKeys, bigIntPropertyKeys),
             intToStringTransformer(bigIntPropertyKeys)
         );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,13 @@ export interface TransferredEvent {
     from: AddressAccount;
 }
 
+export interface TransferredWithScheduleEvent {
+    tag: 'TransferredWithSchedule';
+    to: AddressAccount;
+    from: AddressAccount;
+    amount: ReleaseSchedule[];
+}
+
 export interface MemoEvent {
     tag: 'TransferMemo';
     memo: string;
@@ -101,7 +108,13 @@ export interface MemoEvent {
 export interface EventResult {
     outcome: string;
     // TODO Resolve the types completely.
-    events: (TransactionEvent | TransferredEvent | UpdatedEvent | MemoEvent)[];
+    events: (
+        | TransactionEvent
+        | TransferredEvent
+        | UpdatedEvent
+        | MemoEvent
+        | TransferredWithScheduleEvent
+    )[];
 }
 
 interface BaseTransactionSummaryType {
@@ -357,12 +370,15 @@ export interface NextAccountNonce {
 export interface ReleaseSchedule {
     timestamp: Date;
     amount: bigint;
-    transactions: any;
+}
+
+export interface ReleaseScheduleWithTransactions extends ReleaseSchedule {
+    transactions: string[];
 }
 
 export interface AccountReleaseSchedule {
     total: bigint;
-    schedule: ReleaseSchedule[];
+    schedule: ReleaseScheduleWithTransactions[];
 }
 
 export interface AccountEncryptedAmount {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ReleaseSchedule } from '.';
 import { BoolResponse, JsonResponse } from '../grpc/concordium_p2p_rpc_pb';
 import { AccountTransactionSignature } from './types';
 
@@ -87,9 +88,13 @@ export function buildJsonResponseReviver<T>(
             // Handle the special case where amount is a scheduled amount,
             // which has an array structure.
             if (key === 'amount' && Array.isArray(value)) {
-                const result = [];
+                const result: ReleaseSchedule[] = [];
                 for (const entry of value) {
-                    result.push([BigInt(entry[0]), BigInt(entry[1])]);
+                    const schedule: ReleaseSchedule = {
+                        timestamp: new Date(entry[0]),
+                        amount: BigInt(entry[1]),
+                    };
+                    result.push(schedule);
                 }
                 return result;
             }

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,6 +84,15 @@ export function buildJsonResponseReviver<T>(
             // Note that we reduce the time precision from nano to milliseconds when doing this conversion.
             return new Date(value);
         } else if (bigIntPropertyKeys.includes(key as keyof T)) {
+            // Handle the special case where amount is a scheduled amount,
+            // which has an array structure.
+            if (key === 'amount' && Array.isArray(value)) {
+                const result = [];
+                for (const entry of value) {
+                    result.push([BigInt(entry[0]), BigInt(entry[1])]);
+                }
+                return result;
+            }
             return BigInt(value);
         }
         return value;


### PR DESCRIPTION
## Purpose
A block summary containing a transaction summary for a scheduled transfer failed by throwing an error.

## Changes
- Check if an `amount` field is an array if parsing it to a big int, if it is, then handle it as the `[timestamp, amount]` sets they consist of.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.