### PR TITLE
accountTransactionHandler change getBaseEnergyCost to getEnergyCost

### DIFF
--- a/src/accountTransactions.ts
+++ b/src/accountTransactions.ts
@@ -6,19 +6,25 @@ import {
     SimpleTransferPayload,
     SimpleTransferWithMemoPayload,
 } from './types';
+import { calculateEnergyCost } from './energyCost';
 
 interface AccountTransactionHandler<
     PayloadType extends AccountTransactionPayload = AccountTransactionPayload
 > {
     serialize: (payload: PayloadType) => Buffer;
-    getBaseEnergyCost: (payload?: PayloadType) => bigint;
+    getEnergyCost: (payload: PayloadType, signatureCount: bigint) => bigint;
 }
 
 export class SimpleTransferHandler
-    implements AccountTransactionHandler<SimpleTransferWithMemoPayload>
+    implements AccountTransactionHandler<SimpleTransferPayload>
 {
-    getBaseEnergyCost(): bigint {
-        return 300n;
+    getEnergyCost(payload: SimpleTransferPayload, signatureCount: bigint): bigint {
+        const baseEnergyCost = 300n;
+        return calculateEnergyCost(
+            signatureCount,
+            BigInt(this.serialize(payload).length + 1), // + 1 for the signatureKind
+            baseEnergyCost
+        );
     }
 
     serialize(transfer: SimpleTransferPayload): Buffer {

--- a/src/accountTransactions.ts
+++ b/src/accountTransactions.ts
@@ -18,7 +18,10 @@ interface AccountTransactionHandler<
 export class SimpleTransferHandler
     implements AccountTransactionHandler<SimpleTransferPayload>
 {
-    getEnergyCost(payload: SimpleTransferPayload, signatureCount: bigint): bigint {
+    getEnergyCost(
+        payload: SimpleTransferPayload,
+        signatureCount: bigint
+    ): bigint {
         const baseEnergyCost = 300n;
         return calculateEnergyCost(
             signatureCount,

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -23,7 +23,6 @@ import {
     CredentialDeploymentTransaction,
     CredentialDeploymentInformation,
 } from './types';
-import { calculateEnergyCost } from './energyCost';
 import { countSignatures } from './util';
 import { sha256 } from './hash';
 import * as wasm from '../pkg/node_sdk_helpers';
@@ -116,14 +115,8 @@ export function serializeAccountTransaction(
         accountTransaction.payload
     );
 
-    const baseEnergyCost = accountTransactionHandler.getBaseEnergyCost(
-        accountTransaction.payload
-    );
-    const energyCost = calculateEnergyCost(
-        countSignatures(signatures),
-        BigInt(serializedPayload.length + 1),
-        baseEnergyCost
-    );
+    const energyCost = accountTransactionHandler.getEnergyCost(accountTransaction.payload, countSignatures(signatures));
+
     const serializedHeader = serializeAccountTransactionHeader(
         accountTransaction.header,
         serializedPayload.length + 1,
@@ -172,16 +165,7 @@ export function getAccountTransactionSignDigest(
     const serializedPayload = accountTransactionHandler.serialize(
         accountTransaction.payload
     );
-
-    const baseEnergyCost = accountTransactionHandler.getBaseEnergyCost(
-        accountTransaction.payload
-    );
-    const energyCost = calculateEnergyCost(
-        signatureCount,
-        BigInt(serializedPayload.length + 1),
-        baseEnergyCost
-    );
-
+    const energyCost = accountTransactionHandler.getEnergyCost(accountTransaction.payload, signatureCount);
     return sha256([
         serializeAccountTransactionHeader(
             accountTransaction.header,

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -115,7 +115,10 @@ export function serializeAccountTransaction(
         accountTransaction.payload
     );
 
-    const energyCost = accountTransactionHandler.getEnergyCost(accountTransaction.payload, countSignatures(signatures));
+    const energyCost = accountTransactionHandler.getEnergyCost(
+        accountTransaction.payload,
+        countSignatures(signatures)
+    );
 
     const serializedHeader = serializeAccountTransactionHeader(
         accountTransaction.header,
@@ -165,7 +168,10 @@ export function getAccountTransactionSignDigest(
     const serializedPayload = accountTransactionHandler.serialize(
         accountTransaction.payload
     );
-    const energyCost = accountTransactionHandler.getEnergyCost(accountTransaction.payload, signatureCount);
+    const energyCost = accountTransactionHandler.getEnergyCost(
+        accountTransaction.payload,
+        signatureCount
+    );
     return sha256([
         serializeAccountTransactionHeader(
             accountTransaction.header,


### PR DESCRIPTION
## Purpose

Change the `accountTransactionHandler`'s `getBaseEnergyCost` to `getEnergyCost`, to support transaction types, whose cost can't be predetermined.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
