### PR TITLE
Add energyAmount to transaction header

### DIFF
--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -145,7 +145,10 @@ export function serializeAccountTransaction(
     const serializedAccountTransactionSignatures =
         serializeAccountTransactionSignature(signatures);
 
-    const serializedTransactionBase = serializeAccountTransactionBase(accountTransaction, countSignatures(signatures));
+    const serializedTransactionBase = serializeAccountTransactionBase(
+        accountTransaction,
+        countSignatures(signatures)
+    );
 
     return Buffer.concat([
         serializedBlockItemKind,
@@ -181,7 +184,10 @@ export function getAccountTransactionSignDigest(
     accountTransaction: AccountTransaction,
     signatureCount = 1n
 ): Buffer {
-    const serializedTransactionBase = serializeAccountTransactionBase(accountTransaction, signatureCount);
+    const serializedTransactionBase = serializeAccountTransactionBase(
+        accountTransaction,
+        signatureCount
+    );
 
     return sha256([serializedTransactionBase]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -632,6 +632,14 @@ export interface AccountTransactionHeader {
 
     /** expiration of the transaction */
     expiry: TransactionExpiry;
+
+    /**
+     * The maximum allowed energy to be spent on the transaction.
+     * This is allowed to be unspecified for transactions,
+     * whose energy cost can be determined from the payload.
+     * If it is insufficient, the transaction will fail.
+     */
+    energyAmount?: bigint;
 }
 
 export interface SimpleTransferPayload {


### PR DESCRIPTION
## Purpose

Support transaction types, whose cost can't be predetermined.

## Changes

Added energyAmount to header.
Refactored transaction serialization to remove duplication.
Transaction serialization now only calculates `energyCost` if `energyAmount` is missing from header.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

