### PR TITLE
Allow getAccountInfo to take credId as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,10 @@ const transactionStatus = await client.getTransactionStatus(transactionHash);
 ```
 
 ## getAccountInfo
-Retrieves information about an account. If no account exists with the provided address, then the node
-will check if any credential with that credential identifier exists and will return information
-about the credential instead. If neither an account or credential matches the address at the provided
+Retrieves information about an account. The function must be provided an account address or a credential registration id. 
+If a credential registration id is provided, then the node returns the information of the account, 
+which the corresponding credential is (or was) deployed to.
+If there is no account that matches the address or credential id at the provided
 block, then undefined will be returned.
 ```js
 const accountAddress = new AccountAddress("3sAHwfehRNEnXk28W7A3XB3GzyBiuQkXLNRmDwDGPUe8JsoAcU");

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { ChannelCredentials, Metadata, ServiceError } from '@grpc/grpc-js';
 import { P2PClient } from '../grpc/concordium_p2p_rpc_grpc_pb';
-import { AccountAddress as Address } from './types/accountAddress';
+import { AccountAddress as Address } from './types/accountAddress';i
+import { CredentialRegistrationId } from './types/CredentialRegistrationId';
 import {
     AccountAddress,
     BlockHash,
@@ -170,15 +171,16 @@ export default class ConcordiumNodeClient {
     /**
      * Retrieves the account info for the given account. If the provided block
      * hash is in a block prior to the finalization of the account, then the account
-     * information will not be available. If there is no account with the provided address,
-     * then the node will check if there exists any credential with that address and
-     * return information for that credential.
-     * @param accountAddress base58 account address to get the account info for
+     * information will not be available.
+     * A credential registration id can also be provided, instead of an address. In this case
+     * the node will return the account info of the account, which the corresponding credential
+     * is (or was) deployed to.
+     * @param accountAddress base58 account address (or a credential registration id) to get the account info for
      * @param blockHash the block hash to get the account info at
      * @returns the account info for the provided account address, undefined is the account does not exist
      */
     async getAccountInfo(
-        accountAddress: Address,
+        accountAddress: Address | CredentialRegistrationId,
         blockHash: string
     ): Promise<AccountInfo | undefined> {
         if (!isValidHash(blockHash)) {
@@ -186,8 +188,13 @@ export default class ConcordiumNodeClient {
         }
 
         const getAddressInfoRequest = new GetAddressInfoRequest();
-        getAddressInfoRequest.setAddress(accountAddress.address);
+        if (accountAddress instanceof Address) {
+            getAddressInfoRequest.setAddress(accountAddress.address);
+        } else {
+            getAddressInfoRequest.setAddress(accountAddress.credId);
+        }
         getAddressInfoRequest.setBlockHash(blockHash);
+
 
         const response = await this.sendRequest(
             this.client.getAccountInfo,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { ChannelCredentials, Metadata, ServiceError } from '@grpc/grpc-js';
 import { P2PClient } from '../grpc/concordium_p2p_rpc_grpc_pb';
-import { AccountAddress as Address } from './types/accountAddress';i
+import { AccountAddress as Address } from './types/accountAddress';
 import { CredentialRegistrationId } from './types/CredentialRegistrationId';
 import {
     AccountAddress,
@@ -194,7 +194,6 @@ export default class ConcordiumNodeClient {
             getAddressInfoRequest.setAddress(accountAddress.credId);
         }
         getAddressInfoRequest.setBlockHash(blockHash);
-
 
         const response = await this.sendRequest(
             this.client.getAccountInfo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
     getCredentialForExistingAccountSignDigest,
 };
 export { sha256 };
+export { CredentialRegistrationId } from './types/CredentialRegistrationId';
 export { AccountAddress } from './types/accountAddress';
 export { GtuAmount } from './types/gtuAmount';
 export { TransactionExpiry } from './types/transactionExpiry';

--- a/src/types/CredentialRegistrationId.ts
+++ b/src/types/CredentialRegistrationId.ts
@@ -1,0 +1,30 @@
+import { Buffer } from 'buffer/';
+import { isHex } from '../util';
+
+/**
+ * Representation of an credential registration id, which enforces that it:
+ * - Is a valid Hex string
+ * - Has length exactly 96 (Because 48 bytes)
+ * - Checks the first bit is 1. (Which indicates that the value represents a compressed BLS12-381 curve point)
+ */
+export class CredentialRegistrationId {
+    credId: string;
+
+    constructor(credId: string) {
+        if (address.length !== 96) {
+            throw new Error(
+                'The provided credId ' +
+                    credID +
+                    ' is invalid as its length was not 96'
+            );
+        }
+        if (!isHex(credId)) {
+            throw new Error(
+                'The provided credId ' +
+                    credID +
+                    ' does not represent a hexidecimal value'
+            );
+        }
+        this.credId = credId;
+    }
+}

--- a/src/types/CredentialRegistrationId.ts
+++ b/src/types/CredentialRegistrationId.ts
@@ -1,30 +1,38 @@
-import { Buffer } from 'buffer/';
 import { isHex } from '../util';
 
 /**
- * Representation of an credential registration id, which enforces that it:
+ * Representation of a credential registration id, which enforces that it:
  * - Is a valid Hex string
- * - Has length exactly 96 (Because 48 bytes)
- * - Checks the first bit is 1. (Which indicates that the value represents a compressed BLS12-381 curve point)
+ * - Has length exactly 96, because a credId is 48 bytes.
+ * - Checks the first bit is 1, which indicates that the value represents a compressed BLS12-381 curve point.
  */
 export class CredentialRegistrationId {
     credId: string;
 
     constructor(credId: string) {
-        if (address.length !== 96) {
+        if (credId.length !== 96) {
             throw new Error(
                 'The provided credId ' +
-                    credID +
+                    credId +
                     ' is invalid as its length was not 96'
             );
         }
         if (!isHex(credId)) {
             throw new Error(
                 'The provided credId ' +
-                    credID +
+                    credId +
                     ' does not represent a hexidecimal value'
             );
         }
+        // Check that the first bit is 1
+        if ((parseInt(credId.substring(0, 2), 16) & 0b10000000) === 0) {
+            throw new Error(
+                'The provided credId ' +
+                    credId +
+                    'does not represent a compressed BLS12-381 point'
+            );
+        }
+
         this.credId = credId;
     }
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -11,6 +11,7 @@ import { isValidDate, getNodeClient } from './testHelpers';
 import { bulletProofGenerators } from './resources/bulletproofgenerators';
 import { ipVerifyKey1, ipVerifyKey2 } from './resources/ipVerifyKeys';
 import { PeerElement } from '../grpc/concordium_p2p_rpc_pb';
+import { CredentialRegistrationId } from '../src/types/CredentialRegistrationId';
 
 const client = getNodeClient();
 
@@ -677,6 +678,29 @@ test('retrieves the account info', async () => {
 
         normalAccountCredentialExpects,
     ]);
+});
+
+test('retrieves the same account info for credential of account as account address', async () => {
+    const accountAddress = new AccountAddress(
+        '3sAHwfehRNEnXk28W7A3XB3GzyBiuQkXLNRmDwDGPUe8JsoAcU'
+    );
+    const credId = new CredentialRegistrationId(
+        'a8e810a15eeefcdd425126d6faed3a45fdf211392180d0fb3dc7e9e3382cb0dc6ce8e0d8bc46cfb6cfbb4ea5d8771966'
+    );
+
+    const blockHash =
+        '6b01f2043d5621192480f4223644ef659dd5cda1e54a78fc64ad642587c73def';
+
+    const accountInfo = await client.getAccountInfo(accountAddress, blockHash);
+    const accountInfoCredential = await client.getAccountInfo(
+        credId,
+        blockHash
+    );
+
+    if (!accountInfo || !accountInfoCredential) {
+        throw new Error('Test failed to find account info');
+    }
+    expect(accountInfo).toStrictEqual(accountInfoCredential);
 });
 
 test('retrieves the next account nonce', async () => {


### PR DESCRIPTION
## Purpose

Allow `getAccountInfo` to take a `credId` as argument.

## Changes

Added `CrededentialRegistrationId` class
Allow `getAccountInfo` to take a `CrededentialRegistrationId` as argument instead an `AccountAddress`.
Updated `getAccountInfo` section in README.
Added test for `getAccountInfo` with `CrededentialRegistrationId` argument.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
