### PR TITLE
avoid panicking in DeserializeState

### DIFF
--- a/rust-src/aux_functions.rs
+++ b/rust-src/aux_functions.rs
@@ -193,6 +193,9 @@ pub fn deserialize_state_aux(
     let mut state_cursor = Cursor::new(hex::decode(state_bytes)?);
     let contract_schema = module_schema.contracts.get(contract_name).ok_or(anyhow!("Unable to get contract schema: not included in module schema"))?;
     let state_schema = contract_schema.state.as_ref().ok_or(anyhow!("Unable to get state schema: not included in contract schema"))?;
-    Ok(state_schema.to_json(&mut state_cursor).expect("Unable to parse state to json").to_string())
+    match state_schema.to_json(&mut state_cursor) {
+        Ok(schema) => Ok(schema.to_string()),
+        Err(_) => return Err(anyhow!("unable to parse state to json"))
+    }
 }
 

--- a/rust-src/aux_functions.rs
+++ b/rust-src/aux_functions.rs
@@ -195,7 +195,7 @@ pub fn deserialize_state_aux(
     let state_schema = contract_schema.state.as_ref().ok_or(anyhow!("Unable to get state schema: not included in contract schema"))?;
     match state_schema.to_json(&mut state_cursor) {
         Ok(schema) => Ok(schema.to_string()),
-        Err(_) => return Err(anyhow!("unable to parse state to json"))
+        Err(_) => return Err(anyhow!("Unable to parse state to json"))
     }
 }
 


### PR DESCRIPTION
## Purpose

When wasm modules panics, the error message is not provided in the calling JS code.
So I changed `deserializeState` to not panic, if it is unable to parse the state with the given schema.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
