### PR TITLE
Delegation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "0.8.0-alpha.1",
+    "version": "0.8.0-alpha.2",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",

--- a/src/blockSummaryHelpers.ts
+++ b/src/blockSummaryHelpers.ts
@@ -31,4 +31,4 @@ export const isUpdatesV1 = (u: Updates): u is UpdatesV1 =>
     isUpdateQueuesV1(u.updateQueues);
 
 export const isBlockSummaryV1 = (bs: BlockSummary): bs is BlockSummaryV1 =>
-    (bs as BlockSummaryV1).protocolVersion !== undefined;
+    bs.protocolVersion !== undefined && bs.protocolVersion > 3n;

--- a/src/rewardStatusHelpers.ts
+++ b/src/rewardStatusHelpers.ts
@@ -1,4 +1,4 @@
 import { RewardStatus, RewardStatusV1 } from './types';
 
 export const isRewardStatusV1 = (rs: RewardStatus): rs is RewardStatusV1 =>
-    (rs as RewardStatusV1).protocolVersion !== undefined;
+    rs.protocolVersion !== undefined && rs.protocolVersion > 3n;

--- a/src/types.ts
+++ b/src/types.ts
@@ -402,9 +402,9 @@ interface AuthorizationsCommon {
     protocol: Authorization;
     paramGASRewards: Authorization;
     /**
-     * From protocol version 4 and later, this controls the authorization of the poolParameters update.
+     * For protocol version 3 and earlier, this controls the authorization of the bakerStakeThreshold update.
      */
-    bakerStakeThreshold: Authorization;
+    poolParameters: Authorization;
     electionDifficulty: Authorization;
     addAnonymityRevoker: Authorization;
     addIdentityProvider: Authorization;

--- a/src/types.ts
+++ b/src/types.ts
@@ -531,6 +531,7 @@ export interface UpdatesV1 extends UpdatesCommon {
 export type Updates = UpdatesV0 | UpdatesV1;
 
 interface BlockSummaryCommon {
+    protocolVersion?: bigint;
     finalizationData: FinalizationData;
     transactionSummaries: TransactionSummary[];
 }
@@ -553,6 +554,7 @@ export interface BlockSummaryV1 extends BlockSummaryCommon {
 export type BlockSummary = BlockSummaryV0 | BlockSummaryV1;
 
 interface RewardStatusCommon {
+    protocolVersion?: bigint;
     totalAmount: Amount;
     totalEncryptedAmount: Amount;
     bakingRewardAccount: Amount;


### PR DESCRIPTION
## Purpose

Hopefully last fixes for the delegation update.

## Changes

- Add protocol version for blockSummary and RewardStatus V0, because it is present on an updated node.
- Update type guard for blockSummary and RewardStatus to not use the presence of protocol version to determine version.
- Rename bakerStakeThreshold to poolParameters in Authorizations.
- Bump prelease version

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
