### PR TITLE
Web-sdk: Add type to published files

### DIFF
--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.1.2
+
+- Add type file missing from the package
+
+## 0.1.1
+
+-   Fixed issue with wasm from rust bindings
+
+## 0.1.0
+
+-   Initial release

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,11 +1,12 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
     "files": [
-        "lib/concordium.min*"
+        "lib/concordium.min*",
+        "lib/index.d.ts"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Purpose

Types are missing the current release of the web-sdk. This should add them.

## Changes

- Include type file in published package
- Bump web-sdk version
- Add CHANGELOG for web-sdk

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
