### PR TITLE
Make getModuleBuffer return buffer/

### DIFF
--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2 2022-6-27
+
+### Fixed
+
+- `getModuleBuffer` returns correct type of `Buffer`.
+
 ## 2.0.1 2022-6-27
 
 ### Added

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { Buffer } from 'buffer/';
 import { BoolResponse, JsonResponse } from '../grpc/concordium_p2p_rpc_pb';
 
 export function intListToStringList(jsonStruct: string): string {


### PR DESCRIPTION
## Purpose

Make getModuleBuffer return correct type of Buffer.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
