### PR TITLE
Add InvokeContract to JsonRpc

### DIFF
--- a/packages/common/src/JsonRpcClient.ts
+++ b/packages/common/src/JsonRpcClient.ts
@@ -4,6 +4,7 @@ import {
     AccountTransactionSignature,
     ConsensusStatus,
     ContractAddress,
+    ContractContext,
     InstanceInfo,
     NextAccountNonce,
     TransactionStatus,
@@ -11,7 +12,7 @@ import {
 } from './types';
 import { AccountAddress } from './types/accountAddress';
 import Provider, { JsonRpcResponse } from './providers/provider';
-import { serializeAccountTransactionForSubmission } from './serialization';
+import { serializeAccountTransactionForSubmission, serializeInvokeContractForSubmission } from './serialization';
 import { GtuAmount } from './types/gtuAmount';
 import { ModuleReference } from './types/moduleReference';
 import { buildJsonResponseReviver, intToStringTransformer } from './util';
@@ -87,6 +88,19 @@ export class JsonRpcClient {
         );
         const res = await this.provider.request('sendAccountTransaction', {
             transaction: serializedAccountTransaction.toString('base64'),
+        });
+        return JSON.parse(res).result || false;
+    }
+
+    async invokeContract(
+        blockHash: string,
+        contractContext: ContractContext,
+    ): Promise<boolean> {
+        const serializedInvokeContext = serializeInvokeContractForSubmission(contractContext);
+
+        const res = await this.provider.request('invokeContract', {
+            blockHash: blockHash,
+            context: serializedInvokeContext,
         });
         return JSON.parse(res).result || false;
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,6 +8,7 @@ import {
     serializeUpdateContractParameters,
     serializeAccountTransactionForSubmission,
     serializeCredentialDeploymentTransactionForSubmission,
+    serializeInvokeContractForSubmission,
 } from './serialization';
 import { sha256 } from './hash';
 export * from './types';
@@ -21,6 +22,7 @@ export {
     serializeUpdateContractParameters,
     serializeAccountTransactionForSubmission,
     serializeCredentialDeploymentTransactionForSubmission,
+    serializeInvokeContractForSubmission,
 };
 export { sha256 };
 export { CredentialRegistrationId } from './types/CredentialRegistrationId';

--- a/packages/common/src/providers/provider.ts
+++ b/packages/common/src/providers/provider.ts
@@ -1,3 +1,5 @@
+import { ContractContext, InvokeContractContext } from "../types";
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 interface JsonRpcResponseBase {
     jsonrpc: '2.0';
@@ -32,6 +34,7 @@ export type JsonRpcRequest = (
               { blockHash: string; index: bigint; subindex: bigint }
           ]
         | ['sendAccountTransaction', { transaction: string }]
+        | ['invokeContract', { blockHash: string, context: InvokeContractContext }]
 ) => Promise<string>;
 
 export default interface Provider {

--- a/packages/common/src/serialization.ts
+++ b/packages/common/src/serialization.ts
@@ -25,6 +25,10 @@ import {
     UnsignedCredentialDeploymentInformation,
     CredentialDeploymentInfo,
     SchemaVersion,
+    ContractContext,
+    InvokeContractContext,
+    ContractAddress,
+    Invoker,
 } from './types';
 import { calculateEnergyCost } from './energyCost';
 import { countSignatures } from './util';
@@ -221,6 +225,33 @@ export function serializeAccountTransactionForSubmission(
 
     const serializedVersion = encodeWord8(0);
     return Buffer.concat([serializedVersion, serializedAccountTransaction]);
+}
+
+/**
+ * @param context context object as ContractContext
+ * @returns object with Invoker field modified.
+ */
+export function serializeInvokeContractForSubmission(context: ContractContext): InvokeContractContext {
+    let invoker: Invoker;
+
+    if ((context.invoker as AccountAddress).address) {
+        invoker = { type: 'AddressAccount', address: (context.invoker as AccountAddress).address };
+    } else {
+        invoker = { type: 'AddressContract', address: context.invoker as ContractAddress };
+    }
+
+    let parameter = context.parameter?.toString('hex');
+
+    let responseContext = {
+        invoker: invoker,
+        contract: context.contract,
+        amount: context.amount,
+        method: context.method,
+        parameter: parameter,
+        energy: context.energy
+    } as InvokeContractContext;
+
+    return responseContext;
 }
 
 /**

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1408,6 +1408,26 @@ export interface ContractContext {
     energy?: bigint;
 }
 
+export type Invoker =
+    | {
+        type: 'AddressContract';
+        address: ContractAddress;
+    }
+    | {
+        type: 'AddressAccount';
+        address: string;
+    }
+    | null;
+
+export interface InvokeContractContext {
+    invoker?: Invoker;
+    contract: ContractAddress;
+    amount?: bigint | number;
+    method: string;
+    parameter?: string;
+    energy?: bigint;
+}
+
 export interface InvokeContractSuccessResult
     extends Pick<SuccessfulEventResult, 'events'> {
     tag: 'success';


### PR DESCRIPTION
## Purpose

The common-sdk is missing invokeContract method.

## Changes

I've added invokeContract method to the RPC client.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
