### PR TITLE
Nodejs 3.0.X fixes

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.3.2 2022-7-26
+
+### Fixed
+
+- `deserializeTransaction` no longer throws an error on expired transactions.
+
+## 2.3.1 2022-7-26
+
+### Fixed
+
+- `deserializeTransaction` is now exported from index.
+
 ## 2.3.0 2022-7-25
 
 ### Added

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "2.2.0",
+    "version": "2.3.2",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"
@@ -39,7 +39,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@concordium/rust-bindings": "0.1.1",
+        "@concordium/rust-bindings": "0.2.0",
         "@noble/ed25519": "^1.6.0",
         "bs58check": "^2.1.2",
         "buffer": "^6.0.3",

--- a/packages/common/src/deserialization.ts
+++ b/packages/common/src/deserialization.ts
@@ -89,7 +89,8 @@ function deserializeTransactionHeader(
     // payloadSize
     serializedHeader.read(4).readUInt32BE(0);
     const expiry = TransactionExpiry.fromEpochSeconds(
-        serializedHeader.read(8).readBigUInt64BE(0)
+        serializedHeader.read(8).readBigUInt64BE(0),
+        true
     );
     return {
         sender,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -36,7 +36,10 @@ export {
     buildSignedCredentialForExistingAccount,
 } from './credentialDeploymentTransactions';
 export { isAlias, getAlias } from './alias';
-export { deserializeContractState } from './deserialization';
+export {
+    deserializeContractState,
+    deserializeTransaction,
+} from './deserialization';
 
 export * from './signHelpers';
 export * from './accountHelpers';

--- a/packages/common/src/serialization.ts
+++ b/packages/common/src/serialization.ts
@@ -447,7 +447,7 @@ export function serializeInitContractParameters(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     parameters: any,
     rawSchema: Buffer,
-    schemaVersion: SchemaVersion
+    schemaVersion?: SchemaVersion
 ): Buffer {
     const schemaModule = deserialModuleFromBuffer(rawSchema, schemaVersion);
     if (!schemaModule.value) {
@@ -476,7 +476,7 @@ export function serializeUpdateContractParameters(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     parameters: any,
     rawSchema: Buffer,
-    schemaVersion: SchemaVersion
+    schemaVersion?: SchemaVersion
 ): Buffer {
     const schemaModule = deserialModuleFromBuffer(rawSchema, schemaVersion);
     if (!schemaModule.value) {

--- a/packages/common/src/types/transactionExpiry.ts
+++ b/packages/common/src/types/transactionExpiry.ts
@@ -11,8 +11,8 @@ export class TransactionExpiry {
     /** expiry is measured as seconds since epoch */
     expiryEpochSeconds: bigint;
 
-    constructor(expiry: Date) {
-        if (expiry < new Date()) {
+    constructor(expiry: Date, allowExpired = false) {
+        if (!allowExpired && expiry < new Date()) {
             throw new Error(
                 'A transaction expiry is not allowed to be in the past: ' +
                     expiry
@@ -21,7 +21,13 @@ export class TransactionExpiry {
         this.expiryEpochSeconds = secondsSinceEpoch(expiry);
     }
 
-    static fromEpochSeconds(seconds: bigint): TransactionExpiry {
-        return new TransactionExpiry(new Date(Number(seconds) * 1000));
+    static fromEpochSeconds(
+        seconds: bigint,
+        allowExpired = false
+    ): TransactionExpiry {
+        return new TransactionExpiry(
+            new Date(Number(seconds) * 1000),
+            allowExpired
+        );
     }
 }

--- a/packages/common/test/deserialization.test.ts
+++ b/packages/common/test/deserialization.test.ts
@@ -35,10 +35,11 @@ test('test that deserializeContractState works', () => {
 
 function deserializeAccountTransactionBase(
     type: AccountTransactionType,
-    payload: AccountTransactionPayload
+    payload: AccountTransactionPayload,
+    expiry = new TransactionExpiry(new Date(Date.now() + 1200000))
 ) {
     const header: AccountTransactionHeader = {
-        expiry: new TransactionExpiry(new Date(Date.now() + 1200000)),
+        expiry,
         nonce: 0n,
         sender: new AccountAddress(
             '3VwCfvVskERFAJ3GeJy2mNFrzfChqUymSJJCvoLAP9rtAwMGYt'
@@ -105,5 +106,19 @@ test('test deserialize registerData ', () => {
     deserializeAccountTransactionBase(
         AccountTransactionType.RegisterData,
         payload
+    );
+});
+
+test('Expired transactions can be deserialized', () => {
+    const payload: SimpleTransferPayload = {
+        amount: new GtuAmount(5100000n),
+        toAddress: new AccountAddress(
+            '3VwCfvVskERFAJ3GeJy2mNFrzfChqUymSJJCvoLAP9rtAwMGYt'
+        ),
+    };
+    deserializeAccountTransactionBase(
+        AccountTransactionType.SimpleTransfer,
+        payload,
+        new TransactionExpiry(new Date(2000, 1), true)
     );
 });

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.0.2 2022-7-26
+
+### Fixed
+
+- `deserializeTransaction` no longer throws an error on expired transactions.
+
+## 3.0.1 2022-7-26
+
+### Fixed
+
+- `deserializeTransaction` is now exported from index.
+
 ## 3.0.0 - 2022-7-25
 
 ### Added

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "3.0.0",
+    "version": "3.0.2",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",
@@ -55,7 +55,7 @@
         "build": "([ ! -e \"grpc\" ] && yarn generate) || true && tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "2.2.0",
+        "@concordium/common-sdk": "2.3.2",
         "@grpc/grpc-js": "^1.3.4",
         "buffer": "^6.0.3",
         "google-protobuf": "^3.20.1"

--- a/packages/rust-bindings/package.json
+++ b/packages/rust-bindings/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/rust-bindings",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ### Added
 
 - `deserializeTransaction` function to deserialize transaction created by `serializeAccountTransactionForSubmission` and `serializeCredentialDeploymentTransactionForSubmission`. (Currently SimpleTransfer, SimpleTransferWithMemo and RegisterData are the only supported account transactions kinds)

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,8 +48,8 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "2.2.0",
-        "@concordium/rust-bindings": "0.1.1",
+        "@concordium/common-sdk": "2.3.2",
+        "@concordium/rust-bindings": "0.2.0",
         "buffer": "^6.0.3",
         "process": "^0.11.10"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,11 +1312,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@2.2.0, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@2.3.2, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
-    "@concordium/rust-bindings": 0.1.1
+    "@concordium/rust-bindings": 0.2.0
     "@noble/ed25519": ^1.6.0
     "@types/bs58check": ^2.1.0
     "@types/jest": ^26.0.23
@@ -1347,7 +1347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 2.2.0
+    "@concordium/common-sdk": 2.3.2
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.6.0
     "@types/google-protobuf": ^3.15.3
@@ -1372,7 +1372,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/rust-bindings@0.1.1, @concordium/rust-bindings@workspace:packages/rust-bindings":
+"@concordium/rust-bindings@0.2.0, @concordium/rust-bindings@workspace:packages/rust-bindings":
   version: 0.0.0-use.local
   resolution: "@concordium/rust-bindings@workspace:packages/rust-bindings"
   languageName: unknown
@@ -1382,8 +1382,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 2.2.0
-    "@concordium/rust-bindings": 0.1.1
+    "@concordium/common-sdk": 2.3.2
+    "@concordium/rust-bindings": 0.2.0
     "@typescript-eslint/eslint-plugin": ^4.28.1
     "@typescript-eslint/parser": ^4.28.1
     babel-jest: ^27.0.6


### PR DESCRIPTION
## Purpose

Merge fixes from 3.0.0 to 3.0.2 of Nodejs into main.

## Changes
- `deserializeTransaction` no longer throws an error on expired transactions.
- `deserializeTransaction` is now exported from index.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
