### PR TITLE
Add configure baker type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ All serialization and most utility functions are located in this package.
 
 ## [Rust-bindings](./packages/common)
 
-Contains bindings for rust code, which is used by the common package.
-(This should not be used directly, but instead through common)
+Contains bindings for Rust code, which is used by the common package. This package is a utility package that should not be used directly, only through the usage of the common package.
 
 # Build
 
@@ -37,8 +36,53 @@ yarn build
 This will build all the subprojects.
 Note that you must have [wasm-pack](https://rustwasm.github.io/wasm-pack/) installed to build the project.
 
-## Publishing a release
-Currently publishing is done individually for each package. 
+## Making a new release
+The following describes the requirements for creating  a new release for each of the packages contained in this repository.
+### common
+- Bump the version in [package.json](./packages/common/package.json).
+- Update the [CHANGELOG](./packages/common/CHANGELOG.md) describing the changes made.
+- Update the dependency to common in the [web](./packages/web/package.json) and [nodejs](./packages/nodejs/package.json) packages.
+- Update the CHANGELOG in the [web](./packages/web/CHANGELOG.md) and [nodejs](./packages/nodejs/CHANGELOG.md) packages.
+  - Add a change entry: Bumped @concordium/common-sdk to x.y.z.
+- Commit and tag the release.
+  - Tag should be `common/x.y.z`.
+- Build the release.
+  - From the root of the repository run: `yarn build`. This ensures that dependencies are built correctly.
+- Publish the release to NPM.
+  - From the common package directory (packages/common) run ```yarn npm publish```
+
+### nodejs
+- Bump the version in [package.json](./packages/nodejs/package.json).
+- Update the [CHANGELOG](./packages/nodejs/CHANGELOG.md) describing the changes made.
+- Commit and tag the release.
+  - Tag should be `nodejs/x.y.z`.
+- Build the release.
+  - From the root of the repository run: `yarn build`. This ensures that dependencies are built correctly.
+- Publish the release to NPM.
+  - From the nodejs package directory (packages/nodejs) run ```yarn npm publish```
+
+### web
+- Bump the version in [package.json](./packages/web/package.json).
+- Update the [CHANGELOG](./packages/web/CHANGELOG.md) describing the changes made.
+- Commit and tag the release.
+  - Tag should be `web/x.y.z`.
+- Build the release.
+  - From the root of the repository run: `yarn build`. This ensures that dependencies are built correctly.
+- Publish the release to NPM.
+  - From the web package directory (packages/web) run ```yarn npm publish```
+
+### rust-bindings
+- Bump the version in [package.json](./packages/rust-bindings/package.json).
+- Update the [CHANGELOG](./packages/rust-bindings/CHANGELOG.md) describing the changes made.
+- Update the dependency to rust-bindings in the [common](./packages/common/package.json) package.
+- Update the CHANGELOG in the [common](./packages/common/CHANGELOG.md) package
+  - Add a change entry: Bumped @concordium/rust-bindings to x.y.z.
+- Commit and tag the release.
+  - Tag should be `rust-bindings/x.y.z`.
+- Build the release.
+  - From the root of the repository run: `yarn build`. This ensures that dependencies are built correctly.
+- Publish the release to NPM.
+  - From the rust-bindings package directory (packages/rust-bindings) run ```yarn npm publish```
 
 # Test
 An automatic test suite is part of this project, and it is run by executing:

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ The following describes the requirements for creating  a new release for each of
 ### rust-bindings
 - Bump the version in [package.json](./packages/rust-bindings/package.json).
 - Update the [CHANGELOG](./packages/rust-bindings/CHANGELOG.md) describing the changes made.
-- Update the dependency to rust-bindings in the [common](./packages/common/package.json) package.
-- Update the CHANGELOG in the [common](./packages/common/CHANGELOG.md) package
+- Update the dependency to rust-bindings in the [common](./packages/common/package.json) and [web](./packages/web/package.json) packages.
+- Update the CHANGELOG in the [common](./packages/common/CHANGELOG.md) and [web](./packages/web/CHANGELOG.md) packages.
   - Add a change entry: Bumped @concordium/rust-bindings to x.y.z.
 - Commit and tag the release.
   - Tag should be `rust-bindings/x.y.z`.

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.0 2022-8-8
+
+- Added `ConfigureBaker` to `AccountTransactionType` enum.
+
 ## 2.3.2 2022-7-26
 
 ### Fixed

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "2.3.2",
+    "version": "2.4.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1153,6 +1153,7 @@ export enum AccountTransactionType {
     SimpleTransferWithMemo = 22,
     EncryptedTransferWithMemo = 23,
     TransferWithScheduleWithMemo = 24,
+    ConfigureBaker = 25,
     ConfigureDelegation = 26,
 }
 

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Bumped @concordium/common-sdk to 2.4.0.
+
 ## 3.0.2 2022-7-26
 
 ### Fixed
@@ -35,7 +41,7 @@
 - Support deserializing new schema types: ULeb128, ILeb128, ByteArray and ByteList.
 - Support deserializing schemas with versioning information.
 
-### Changes
+### Changed
 
 - The function for deserializing a module schema `deserialModuleFromBuffer` now have the schema version as an optional argument. The function will try to extract the version from the buffer. When a version is provided it falls back to this, otherwise it throws an error.
 

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -57,7 +57,8 @@ metadata.add("authentication", "rpcadmin");
 const insecureCredentials = credentials.createInsecure();
 const client = new ConcordiumNodeClient(
     "127.0.0.1",    // ip address
-    10000,          // portge is the shared library for the nodejs and web SDK's.
+    10000,          // port
+    insecureCredentials,
     metadata,
     15000           // timeout in ms
 );

--- a/packages/nodejs/README.md
+++ b/packages/nodejs/README.md
@@ -57,8 +57,7 @@ metadata.add("authentication", "rpcadmin");
 const insecureCredentials = credentials.createInsecure();
 const client = new ConcordiumNodeClient(
     "127.0.0.1",    // ip address
-    10000,          // port
-    insecureCredentials,
+    10000,          // portge is the shared library for the nodejs and web SDK's.
     metadata,
     15000           // timeout in ms
 );

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -55,7 +55,7 @@
         "build": "([ ! -e \"grpc\" ] && yarn generate) || true && tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "2.3.2",
+        "@concordium/common-sdk": "2.4.0",
         "@grpc/grpc-js": "^1.3.4",
         "buffer": "^6.0.3",
         "google-protobuf": "^3.20.1"

--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## Unreleased

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `deserializeTransaction` function to deserialize transaction created by `serializeAccountTransactionForSubmission` and `serializeCredentialDeploymentTransactionForSubmission`. (Currently SimpleTransfer, SimpleTransferWithMemo and RegisterData are the only supported account transactions kinds)
 
-### Changes
+### Changed
 - Bumped @concordium/common-sdk to 2.4.0.
 
 ## 0.3.0 2022-7-21
@@ -17,7 +17,7 @@
 - Support deserializing new schema types: ULeb128, ILeb128, ByteArray and ByteList.
 - Support deserializing schemas with versioning information.
 
-### Changes
+### Changed
 
 - The function for deserializing a module schema `deserialModuleFromBuffer` now have the schema version as an optional argument. The function will try to extract the version from the buffer. When a version is provided it falls back to this, otherwise it throws an error.
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.4.0 2022-8-8
 
 ### Added
 
 - `deserializeTransaction` function to deserialize transaction created by `serializeAccountTransactionForSubmission` and `serializeCredentialDeploymentTransactionForSubmission`. (Currently SimpleTransfer, SimpleTransferWithMemo and RegisterData are the only supported account transactions kinds)
+
+### Changes
+- Bumped @concordium/common-sdk to 2.4.0.
 
 ## 0.3.0 2022-7-21
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,7 +48,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "2.3.2",
+        "@concordium/common-sdk": "2.4.0",
         "@concordium/rust-bindings": "0.2.0",
         "buffer": "^6.0.3",
         "process": "^0.11.10"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@2.3.2, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@2.4.0, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
@@ -1347,7 +1347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 2.3.2
+    "@concordium/common-sdk": 2.4.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.6.0
     "@types/google-protobuf": ^3.15.3
@@ -1382,7 +1382,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 2.3.2
+    "@concordium/common-sdk": 2.4.0
     "@concordium/rust-bindings": 0.2.0
     "@typescript-eslint/eslint-plugin": ^4.28.1
     "@typescript-eslint/parser": ^4.28.1


### PR DESCRIPTION
## Purpose
Add missing `ConfigureBaker` type to the account transaction type enum. Also documented what is needed to make a release for each of the packages (updating version, updating CHANGELOG's, updating dependencies etc.).

## Changes
- Added `ConfigureBaker` type to transaction type enum.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.