### PR TITLE
Use proper format for signMessage

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.0
+
+### Breaking changes
+
+- Updated the signature of helper functions for accounts to sign messages. (and changed the prepend)
+
 ## 4.0.0 2022-8-26
 
 ### Breaking changes

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -536,12 +536,13 @@ const signatures: AccountTransactionSignature = {
 To have an account sign an arbritrary message, one can use the `signMessage` function: 
 
 ```js
+const account = new AccountAddress("4ZJBYQbVp3zVZyjCXfZAAYBVkJMyVj8UKUNj9ox5YqTCBdBq2M");
 const message = "testMessage";
 const signer: AccountSigner = ...;
-const signature = signMessage(message, signer);
+const signature = signMessage(account, message, signer);
 ```
 
-Note that the signMessage preprends a short string, to ensure that the message cannot be a account transaction. To easily verify the signature, one can use the `verifyMessageSignature` function:
+What is actually signed is the sha256 hash of the account address, eight zero bytes and the actual message. This ensures that the message cannot be an account transaction. To easily verify the signature, one can use the `verifyMessageSignature` function:
 
 ```js
 const message = "testMessage";

--- a/packages/common/test/signHelpers.test.ts
+++ b/packages/common/test/signHelpers.test.ts
@@ -5,6 +5,25 @@ import {
 } from '../src/signHelpers';
 import { AccountAddress, AccountInfo } from '../src';
 
+const TEST_CREDENTIALS = {
+    0: {
+        value: {
+            contents: {
+                credentialPublicKeys: {
+                    keys: {
+                        0: {
+                            verifyKey:
+                                'fef5414fc757cd4694bf0c7ea436f015cb7f87a80d08e1d1085b9cc91f13f376',
+                            schemeId: 'Ed25519',
+                        },
+                    },
+                    threshold: 1,
+                },
+            },
+        },
+    },
+};
+
 test('test signMessage', async () => {
     const account = new AccountAddress(
         '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5'
@@ -22,7 +41,7 @@ test('test signMessage', async () => {
     );
 });
 
-test('test verifyMessageSignature', async () => {
+test('verifyMessageSignature returns true on the correct address/signature', async () => {
     const message = 'test';
     const signature = await verifyMessageSignature(
         message,
@@ -35,25 +54,46 @@ test('test verifyMessageSignature', async () => {
             accountAddress:
                 '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5',
             accountThreshold: 1,
-            accountCredentials: {
-                0: {
-                    value: {
-                        contents: {
-                            credentialPublicKeys: {
-                                keys: {
-                                    0: {
-                                        verifyKey:
-                                            'fef5414fc757cd4694bf0c7ea436f015cb7f87a80d08e1d1085b9cc91f13f376',
-                                        schemeId: 'Ed25519',
-                                    },
-                                },
-                                threshold: 1,
-                            },
-                        },
-                    },
-                },
-            },
+            accountCredentials: TEST_CREDENTIALS,
         } as unknown as AccountInfo
     );
     expect(signature).toBeTruthy();
+});
+
+test('verifyMessageSignature returns false on the incorrect address', async () => {
+    const message = 'test';
+    const signature = await verifyMessageSignature(
+        message,
+        {
+            0: {
+                0: '445197d79ca90d8cc8440328dac9f307932ade0c03cc7aa575b59b746e26e5f1bca13ade5ff7a56e918ba5a32450fdf52b034cd2580929b21213263e81f7f809',
+            },
+        },
+        {
+            accountAddress:
+                '3dbRxtzhb8MotFBgH5DcdFJy7t4we4N8Ep6Mxdha8XvLhq7YmZ',
+            accountThreshold: 1,
+            accountCredentials: TEST_CREDENTIALS,
+        } as unknown as AccountInfo
+    );
+    expect(signature).toBeFalsy();
+});
+
+test('verifyMessageSignature returns false on the incorrect signature', async () => {
+    const message = 'test';
+    const signature = await verifyMessageSignature(
+        message,
+        {
+            0: {
+                0: 'b54e4c5f894deb951621b9c13e8f96a4176626265e7bcf5ec197e8ee74ef8464cd32cff4085b0d741fae7cba97fc559ff66adc7c0cdb305d89c5a5d7e657f407',
+            },
+        },
+        {
+            accountAddress:
+                '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5',
+            accountThreshold: 1,
+            accountCredentials: TEST_CREDENTIALS,
+        } as unknown as AccountInfo
+    );
+    expect(signature).toBeFalsy();
 });

--- a/packages/common/test/signHelpers.test.ts
+++ b/packages/common/test/signHelpers.test.ts
@@ -3,18 +3,22 @@ import {
     buildBasicAccountSigner,
     verifyMessageSignature,
 } from '../src/signHelpers';
-import { AccountInfo } from '../src';
+import { AccountAddress, AccountInfo } from '../src';
 
 test('test signMessage', async () => {
+    const account = new AccountAddress(
+        '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5'
+    );
     const message = 'test';
     const signature = await signMessage(
+        account,
         message,
         buildBasicAccountSigner(
             'e1cf504954663e49f4fe884c7c35415b09632cccd82d3d2a62ab2825e67d785d'
         )
     );
     expect(signature[0][0]).toBe(
-        '5420cc5a6c956e8a9b47a834d8aaee1176349435f8d172f0255db28a96040eed553d18cd98e2c873bf37a0c1794d382397f68a230485efab1ef16f678008080a'
+        '445197d79ca90d8cc8440328dac9f307932ade0c03cc7aa575b59b746e26e5f1bca13ade5ff7a56e918ba5a32450fdf52b034cd2580929b21213263e81f7f809'
     );
 });
 
@@ -24,10 +28,12 @@ test('test verifyMessageSignature', async () => {
         message,
         {
             0: {
-                0: '5420cc5a6c956e8a9b47a834d8aaee1176349435f8d172f0255db28a96040eed553d18cd98e2c873bf37a0c1794d382397f68a230485efab1ef16f678008080a',
+                0: '445197d79ca90d8cc8440328dac9f307932ade0c03cc7aa575b59b746e26e5f1bca13ade5ff7a56e918ba5a32450fdf52b034cd2580929b21213263e81f7f809',
             },
         },
         {
+            accountAddress:
+                '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5',
             accountThreshold: 1,
             accountCredentials: {
                 0: {


### PR DESCRIPTION
## Purpose

Replace temporary prepend in signMessage with a proper format.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
