### PR TITLE
WIP

### DIFF
--- a/packages/common/src/JsonRpcClient.ts
+++ b/packages/common/src/JsonRpcClient.ts
@@ -19,7 +19,7 @@ import {
 import { AccountAddress } from './types/accountAddress';
 import Provider, { JsonRpcResponse } from './providers/provider';
 import {
-    serializeAccountTransactionForSubmission,
+    serializeSignedAccountTransactionForSubmission,
     serializeSignedCredentialDeploymentDetailsForSubmission,
 } from './serialization';
 import { GtuAmount } from './types/gtuAmount';
@@ -107,7 +107,7 @@ export class JsonRpcClient {
         signatures: AccountTransactionSignature
     ): Promise<boolean> {
         const serializedAccountTransaction: Buffer = Buffer.from(
-            serializeAccountTransactionForSubmission(
+            serializeSignedAccountTransactionForSubmission(
                 accountTransaction,
                 signatures
             )

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,9 +6,10 @@ export {
     getCredentialDeploymentSignDigest,
     getCredentialDeploymentTransactionHash,
     getCredentialForExistingAccountSignDigest,
+    serializeAccountTransaction,
     serializeInitContractParameters,
     serializeUpdateContractParameters,
-    serializeAccountTransactionForSubmission,
+    serializeSignedAccountTransactionForSubmission,
     serializeCredentialDeploymentTransactionForSubmission,
     getSignedCredentialDeploymentTransactionHash,
 } from './serialization';

--- a/packages/common/test/deserialization.test.ts
+++ b/packages/common/test/deserialization.test.ts
@@ -3,7 +3,7 @@ import {
     deserializeTransaction,
 } from '../src/deserialization';
 import { Buffer } from 'buffer/';
-import { serializeAccountTransactionForSubmission } from '../src/serialization';
+import { serializeSignedAccountTransactionForSubmission } from '../src/serialization';
 import {
     AccountAddress,
     AccountTransaction,
@@ -59,7 +59,7 @@ function deserializeAccountTransactionBase(
     };
 
     const deserialized = deserializeTransaction(
-        serializeAccountTransactionForSubmission(transaction, signatures)
+        serializeSignedAccountTransactionForSubmission(transaction, signatures)
     );
 
     if (deserialized.kind !== BlockItemKind.AccountTransactionKind) {

--- a/packages/common/test/serialization.test.ts
+++ b/packages/common/test/serialization.test.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'buffer/';
 import { AccountAddress } from '../src/types/accountAddress';
 import { GtuAmount } from '../src/types/gtuAmount';
 import {
-    serializeAccountTransactionForSubmission,
+    serializeSignedAccountTransactionForSubmission,
     serializeAccountTransactionSignature,
     serializeUpdateContractParameters,
 } from '../src/serialization';
@@ -47,7 +47,7 @@ test('fail account transaction serialization if no signatures', () => {
     };
 
     expect(() =>
-        serializeAccountTransactionForSubmission(
+        serializeSignedAccountTransactionForSubmission(
             simpleTransferAccountTransaction,
             {}
         )


### PR DESCRIPTION
## Purpose

When using Wallet Connect, dApps need to be able to send an encoded transaction without signature to the wallet such that it can sign it. The ideal solution would be to send it as plain stringified JSON, but sending it encoded fits better with existing code.

## Changes

Extract a function from existing serialization code to only serialize the header, type, and payload parts of the transaction.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.