### PR TITLE
Remove reliance on instanceof in getAccountInfo

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Additional arguments to the JSON-RPC HttpProvider, to enable is to receive and forward cookies.
 
+### Fixed
+
+- getAccountInfo no longer relies on instanceof to determine the type of input.
+
 ## 5.0.0 2022-9-29
 
 ### Added

--- a/packages/common/src/JsonRpcClient.ts
+++ b/packages/common/src/JsonRpcClient.ts
@@ -236,7 +236,7 @@ export class JsonRpcClient {
      * @returns the account info for the provided account address, undefined is the account does not exist
      */
     async getAccountInfo(
-        accountAddress: AccountAddress | CredentialRegistrationId,
+        accountAddress: string | AccountAddress | CredentialRegistrationId,
         blockHash?: string
     ): Promise<AccountInfo | undefined> {
         if (!blockHash) {
@@ -246,10 +246,16 @@ export class JsonRpcClient {
             throw new Error('The input was not a valid hash: ' + blockHash);
         }
 
-        const address =
-            accountAddress instanceof AccountAddress
-                ? accountAddress.address
-                : accountAddress.credId;
+        let address: string;
+        if (typeof accountAddress === 'string') {
+            address = accountAddress;
+        } else if ('address' in accountAddress) {
+            address = accountAddress.address;
+        } else if ('credId' in accountAddress) {
+            address = accountAddress.credId;
+        } else {
+            throw new Error('Invalid accountAddress input');
+        }
 
         const response = await this.provider.request('getAccountInfo', {
             blockHash,

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -206,7 +206,7 @@ export default class ConcordiumNodeClient {
      * @returns the account info for the provided account address, undefined is the account does not exist
      */
     async getAccountInfo(
-        accountAddress: Address | CredentialRegistrationId,
+        accountAddress: string | Address | CredentialRegistrationId,
         blockHash: string
     ): Promise<AccountInfo | undefined> {
         if (!isValidHash(blockHash)) {
@@ -214,11 +214,17 @@ export default class ConcordiumNodeClient {
         }
 
         const getAddressInfoRequest = new GetAddressInfoRequest();
-        if (accountAddress instanceof Address) {
+
+        if (typeof accountAddress === 'string') {
+            getAddressInfoRequest.setAddress(accountAddress);
+        } else if ('address' in accountAddress) {
             getAddressInfoRequest.setAddress(accountAddress.address);
-        } else {
+        } else if ('credId' in accountAddress) {
             getAddressInfoRequest.setAddress(accountAddress.credId);
+        } else {
+            throw new Error('Invalid accountAddress input');
         }
+
         getAddressInfoRequest.setBlockHash(blockHash);
 
         const response = await this.sendRequest(


### PR DESCRIPTION
## Purpose

Change `getAccountInfo` so that it doesn't rely on `instanceof`/specific prototype for determining the type of input. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
