### PR TITLE
Bump node sdk version to 6.0.0

### DIFF
--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## 5.0.0 2022-11-15
+## 6.0.0 2022-11-15
 
 ### Breaking Changes
 
-- Bumped @concordium/common-sdk to 6.0.0. (Which changes the function signature of ConcordiumHdWallet and sign helpers functions. Also changes transaction type names and field names to be aligned with other implementations)
+- Bumped @concordium/common-sdk to 6.0.0. (Which changes transaction type names and field names to be aligned with other implementations)
+
+## 5.0.0 2022-11-8
+Breaking Changes
+
+- Bumped @concordium/common-sdk to 5.2.0. (Which changes the function signature of ConcordiumHdWallet and sign helpers functions)
 
 ## 4.0.0 2022-8-26
 

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Purpose

Turns out node-js SDK version 5 has been released, so bumping it.

## Changes

Bumped.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
