### PR TITLE
GRPCv2-PR2: Implement specified functions needed by the browser/desktop wallet 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,7 @@
             }
         }
     ],
-    "ignorePatterns": ["**/pkg/**/", "**/lib/**/", "deps/**/*", "**/nodejs/grpc/*", "**/nodejs/src/grpc/*"],
+    "ignorePatterns": ["**/pkg/**/", "**/lib/**/", "deps/**/*", "**/nodejs/grpc/*"],
     "settings": {
         "import/ignore": [
             "bs58check"

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.3.0
+
+### Added
+
+- Serialization:
+    - `serializeAccountTransactionPayload()`
+    - `serializeCredentialDeploymentPayload()`
+
 ## 6.2.0 2023-01-04
 
 ### Added

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,6 +12,8 @@ export {
     serializeCredentialDeploymentTransactionForSubmission,
     getSignedCredentialDeploymentTransactionHash,
     serializeTypeValue,
+    serializeAccountTransactionPayload,
+    serializeCredentialDeploymentPayload,
 } from './serialization';
 export { sha256 };
 export { CredentialRegistrationId } from './types/CredentialRegistrationId';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -55,6 +55,7 @@ export * from './identity';
 export * from './types/rejectReason';
 export * from './types/chainUpdate';
 export * from './types/transactionEvent';
+export * from './types/blockItemSummary';
 
 export { getAccountTransactionHandler } from './accountTransactions';
 export { calculateEnergyCost } from './energyCost';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -50,6 +50,9 @@ export { isHex } from './util';
 export { HttpProvider } from './providers/httpProvider';
 export { JsonRpcClient } from './JsonRpcClient';
 export * from './identity';
+export * from './types/rejectReason';
+export * from './types/chainUpdate';
+export * from './types/transactionEvent';
 
 export { getAccountTransactionHandler } from './accountTransactions';
 export { calculateEnergyCost } from './energyCost';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -14,6 +14,7 @@ export {
     serializeTypeValue,
     serializeAccountTransactionPayload,
     serializeCredentialDeploymentPayload,
+    serializeTypeValue,
 } from './serialization';
 export { sha256 };
 export { CredentialRegistrationId } from './types/CredentialRegistrationId';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -14,7 +14,6 @@ export {
     serializeTypeValue,
     serializeAccountTransactionPayload,
     serializeCredentialDeploymentPayload,
-    serializeTypeValue,
 } from './serialization';
 export { sha256 };
 export { CredentialRegistrationId } from './types/CredentialRegistrationId';

--- a/packages/common/src/serialization.ts
+++ b/packages/common/src/serialization.ts
@@ -25,6 +25,7 @@ import {
     SchemaVersion,
     CredentialDeploymentDetails,
     SignedCredentialDeploymentDetails,
+    CredentialDeploymentTransaction,
 } from './types';
 import { calculateEnergyCost } from './energyCost';
 import { countSignatures } from './util';
@@ -141,6 +142,28 @@ export function serializeAccountTransaction(
         serializedType,
         serializedPayload,
     ]);
+}
+
+/**
+ * Serializes a transaction payload.
+ * @param accountTransaction the transaction which payload is to be serialized
+ * @returns the account transaction payload serialized as a buffer.
+ */
+export function serializeAccountTransactionPayload(
+    accountTransaction: AccountTransaction
+): Buffer {
+    const serializedType = serializeAccountTransactionType(
+        accountTransaction.type
+    );
+
+    const accountTransactionHandler = getAccountTransactionHandler(
+        accountTransaction.type
+    );
+    const serializedPayload = accountTransactionHandler.serialize(
+        accountTransaction.payload
+    );
+
+    return Buffer.concat([serializedType, serializedPayload]);
 }
 
 /**
@@ -552,4 +575,15 @@ export function getSignedCredentialDeploymentTransactionHash(
     const serializedDetails =
         serializeSignedCredentialDeploymentDetails(credentialDetails);
     return sha256([serializedDetails]).toString('hex');
+}
+
+export function serializeCredentialDeploymentPayload(
+    signatures: string[],
+    credentialDeploymentTransaction: CredentialDeploymentTransaction
+): Buffer {
+    const payloadByteArray = wasm.serializeCredentialDeploymentPayload(
+        signatures,
+        JSON.stringify(credentialDeploymentTransaction.unsignedCdi)
+    );
+    return Buffer.from(payloadByteArray);
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -5,6 +5,12 @@ import { DataBlob } from './types/DataBlob';
 import { TransactionExpiry } from './types/transactionExpiry';
 import { Buffer } from 'buffer/';
 import { ModuleReference } from './types/moduleReference';
+import { RejectReason } from './types/rejectReason';
+import {
+    MemoEvent,
+    TransactionEvent,
+    TransferredEvent,
+} from './types/transactionEvent';
 
 export type HexString = string;
 
@@ -84,284 +90,15 @@ export interface AddressAccount {
     address: string;
 }
 
-export type AccountIdentifierInput =
-    | AccountAddress
-    | CredentialRegistrationId
-    | bigint;
-
-export interface TransactionEvent {
-    tag:
-        | 'ModuleDeployed'
-        | 'ContractInitialized'
-        | 'AccountCreated'
-        | 'CredentialDeployed'
-        | 'BakerAdded'
-        | 'BakerRemoved'
-        | 'BakerStakeIncreased'
-        | 'BakerStakeDecreased'
-        | 'BakerSetRestakeEarnings'
-        | 'BakerKeysUpdated'
-        | 'CredentialKeysUpdated'
-        | 'NewEncryptedAmount'
-        | 'EncryptedAmountsRemoved'
-        | 'AmountAddedByDecryption'
-        | 'EncryptedSelfAmountAdded'
-        | 'UpdateEnqueued'
-        | 'TransferredWithSchedule'
-        | 'CredentialsUpdated'
-        | 'DataRegistered'
-        | 'BakerSetOpenStatus'
-        | 'BakerSetMetadataURL'
-        | 'BakerSetTransactionFeeCommission'
-        | 'BakerSetBakingRewardCommission'
-        | 'BakerSetFinalizationRewardCommission'
-        | 'DelegationStakeIncreased'
-        | 'DelegationStakeDecreased'
-        | 'DelegationSetRestakeEarnings'
-        | 'DelegationSetDelegationTarget'
-        | 'DelegationAdded'
-        | 'DelegationRemoved';
-}
-
 export interface ContractAddress {
     index: bigint;
     subindex: bigint;
 }
 
-export interface InterruptedEvent {
-    tag: 'Interrupted';
-    address: ContractAddress;
-    events: string[];
-}
-
-export interface ResumedEvent {
-    tag: 'Resumed';
-    address: ContractAddress;
-    success: boolean;
-}
-
-export interface UpdatedEvent {
-    tag: 'Updated';
-    address: ContractAddress;
-    instigator: AddressAccount;
-    amount: bigint;
-    message: string;
-    receiveName: string;
-    events: [string];
-}
-
-export interface TransferredEvent {
-    tag: 'Transferred';
-    amount: bigint;
-    to: AddressAccount;
-    from: AddressAccount;
-}
-
-export interface TransferredWithScheduleEvent {
-    tag: 'TransferredWithSchedule';
-    to: AddressAccount;
-    from: AddressAccount;
-    amount: ReleaseSchedule[];
-}
-
-export interface MemoEvent {
-    tag: 'TransferMemo';
-    memo: string;
-}
-
-/**
- * An enum containing all the possible reject reasons that can be
- * received from a node as a response to a transaction submission.
- *
- * This should be kept in sync with the list of reject reasons
- * found here: https://github.com/Concordium/concordium-base/blob/main/haskell-src/Concordium/Types/Execution.hs
- */
-export enum RejectReasonTag {
-    ModuleNotWF = 'ModuleNotWF',
-    ModuleHashAlreadyExists = 'ModuleHashAlreadyExists',
-    InvalidAccountReference = 'InvalidAccountReference',
-    InvalidInitMethod = 'InvalidInitMethod',
-    InvalidReceiveMethod = 'InvalidReceiveMethod',
-    InvalidModuleReference = 'InvalidModuleReference',
-    InvalidContractAddress = 'InvalidContractAddress',
-    RuntimeFailure = 'RuntimeFailure',
-    AmountTooLarge = 'AmountTooLarge',
-    SerializationFailure = 'SerializationFailure',
-    OutOfEnergy = 'OutOfEnergy',
-    RejectedInit = 'RejectedInit',
-    RejectedReceive = 'RejectedReceive',
-    NonExistentRewardAccount = 'NonExistentRewardAccount',
-    InvalidProof = 'InvalidProof',
-    AlreadyABaker = 'AlreadyABaker',
-    NotABaker = 'NotABaker',
-    InsufficientBalanceForBakerStake = 'InsufficientBalanceForBakerStake',
-    StakeUnderMinimumThresholdForBaking = 'StakeUnderMinimumThresholdForBaking',
-    BakerInCooldown = 'BakerInCooldown',
-    DuplicateAggregationKey = 'DuplicateAggregationKey',
-    NonExistentCredentialID = 'NonExistentCredentialID',
-    KeyIndexAlreadyInUse = 'KeyIndexAlreadyInUse',
-    InvalidAccountThreshold = 'InvalidAccountThreshold',
-    InvalidCredentialKeySignThreshold = 'InvalidCredentialKeySignThreshold',
-    InvalidEncryptedAmountTransferProof = 'InvalidEncryptedAmountTransferProof',
-    InvalidTransferToPublicProof = 'InvalidTransferToPublicProof',
-    EncryptedAmountSelfTransfer = 'EncryptedAmountSelfTransfer',
-    InvalidIndexOnEncryptedTransfer = 'InvalidIndexOnEncryptedTransfer',
-    ZeroScheduledAmount = 'ZeroScheduledAmount',
-    NonIncreasingSchedule = 'NonIncreasingSchedule',
-    FirstScheduledReleaseExpired = 'FirstScheduledReleaseExpired',
-    ScheduledSelfTransfer = 'ScheduledSelfTransfer',
-    InvalidCredentials = 'InvalidCredentials',
-    DuplicateCredIDs = 'DuplicateCredIDs',
-    NonExistentCredIDs = 'NonExistentCredIDs',
-    RemoveFirstCredential = 'RemoveFirstCredential',
-    CredentialHolderDidNotSign = 'CredentialHolderDidNotSign',
-    NotAllowedMultipleCredentials = 'NotAllowedMultipleCredentials',
-    NotAllowedToReceiveEncrypted = 'NotAllowedToReceiveEncrypted',
-    NotAllowedToHandleEncrypted = 'NotAllowedToHandleEncrypted',
-    MissingBakerAddParameters = 'MissingBakerAddParameters',
-    FinalizationRewardCommissionNotInRange = 'FinalizationRewardCommissionNotInRange',
-    BakingRewardCommissionNotInRange = 'BakingRewardCommissionNotInRange',
-    TransactionFeeCommissionNotInRange = 'TransactionFeeCommissionNotInRange',
-    AlreadyADelegator = 'AlreadyADelegator',
-    InsufficientBalanceForDelegationStake = 'InsufficientBalanceForDelegationStake',
-    MissingDelegationAddParameters = 'MissingDelegationAddParameters',
-    InsufficientDelegationStake = 'InsufficientDelegationStake',
-    DelegatorInCooldown = 'DelegatorInCooldown',
-    NotADelegator = 'NotADelegator',
-    DelegationTargetNotABaker = 'DelegationTargetNotABaker',
-    StakeOverMaximumThresholdForPool = 'StakeOverMaximumThresholdForPool',
-    PoolWouldBecomeOverDelegated = 'PoolWouldBecomeOverDelegated',
-    PoolClosed = 'PoolClosed',
-}
-
-export interface RejectedReceive {
-    tag: RejectReasonTag.RejectedReceive;
-    contractAddress: ContractAddress;
-    receiveName: string;
-    rejectReason: number;
-    parameter: string;
-}
-
-export interface RejectedInit {
-    tag: RejectReasonTag.RejectedInit;
-    rejectReason: number;
-}
-
-export type SimpleRejectReasonTag =
-    | RejectReasonTag.ModuleNotWF
-    | RejectReasonTag.RuntimeFailure
-    | RejectReasonTag.SerializationFailure
-    | RejectReasonTag.OutOfEnergy
-    | RejectReasonTag.InvalidProof
-    | RejectReasonTag.InsufficientBalanceForBakerStake
-    | RejectReasonTag.StakeUnderMinimumThresholdForBaking
-    | RejectReasonTag.BakerInCooldown
-    | RejectReasonTag.NonExistentCredentialID
-    | RejectReasonTag.KeyIndexAlreadyInUse
-    | RejectReasonTag.InvalidAccountThreshold
-    | RejectReasonTag.InvalidCredentialKeySignThreshold
-    | RejectReasonTag.InvalidEncryptedAmountTransferProof
-    | RejectReasonTag.InvalidTransferToPublicProof
-    | RejectReasonTag.InvalidIndexOnEncryptedTransfer
-    | RejectReasonTag.ZeroScheduledAmount
-    | RejectReasonTag.NonIncreasingSchedule
-    | RejectReasonTag.FirstScheduledReleaseExpired
-    | RejectReasonTag.InvalidCredentials
-    | RejectReasonTag.RemoveFirstCredential
-    | RejectReasonTag.CredentialHolderDidNotSign
-    | RejectReasonTag.NotAllowedMultipleCredentials
-    | RejectReasonTag.NotAllowedToReceiveEncrypted
-    | RejectReasonTag.NotAllowedToHandleEncrypted
-    | RejectReasonTag.MissingBakerAddParameters
-    | RejectReasonTag.FinalizationRewardCommissionNotInRange
-    | RejectReasonTag.BakingRewardCommissionNotInRange
-    | RejectReasonTag.TransactionFeeCommissionNotInRange
-    | RejectReasonTag.AlreadyADelegator
-    | RejectReasonTag.InsufficientBalanceForDelegationStake
-    | RejectReasonTag.MissingDelegationAddParameters
-    | RejectReasonTag.InsufficientDelegationStake
-    | RejectReasonTag.DelegatorInCooldown
-    | RejectReasonTag.StakeOverMaximumThresholdForPool
-    | RejectReasonTag.PoolWouldBecomeOverDelegated
-    | RejectReasonTag.PoolClosed;
-
-export type ModuleRefRejectReasonTag =
-    | RejectReasonTag.ModuleHashAlreadyExists
-    | RejectReasonTag.InvalidModuleReference;
-
-export type AccountAddressRejectReasonTag =
-    | RejectReasonTag.InvalidAccountReference
-    | RejectReasonTag.NotADelegator
-    | RejectReasonTag.NonExistentRewardAccount
-    | RejectReasonTag.NotABaker
-    | RejectReasonTag.ScheduledSelfTransfer
-    | RejectReasonTag.EncryptedAmountSelfTransfer
-;
-
-export type StringRejectReasonTag = ModuleRefRejectReasonTag | AccountAddressRejectReasonTag | RejectReasonTag.NonExistentCredentialID | RejectReasonTag.DuplicateAggregationKey;
-
-export interface StringRejectReason {
-    tag: StringRejectReasonTag;
-    contents: string;
-}
-export type NumberRejectReasonTag = RejectReasonTag.AlreadyABaker | RejectReasonTag.DelegationTargetNotABaker;
-
-export interface NumberRejectReason {
-    tag: NumberRejectReasonTag;
-    contents: number;
-}
-
-export interface SimpleRejectReason {
-    tag: SimpleRejectReasonTag;
-}
-
-export interface InvalidReceiveMethod {
-    tag: RejectReasonTag.InvalidReceiveMethod;
-    contents: {
-        moduleRef: string;
-        receiveName: string;
-    };
-}
-
-export interface InvalidInitMethod {
-    tag: RejectReasonTag.InvalidInitMethod;
-    contents: {
-        moduleRef: string;
-        initName: string;
-    };
-}
-
-export interface AmountTooLarge {
-    tag: RejectReasonTag.AmountTooLarge;
-    contents: {
-        address: string;
-        amount: string;
-    };
-}
-
-export interface InvalidContractAddress {
-    tag: RejectReasonTag.InvalidContractAddress,
-    contents: ContractAddress
-}
-
-export type CredIdsRejectReasonTag = RejectReasonTag.DuplicateCredIDs | RejectReasonTag.NonExistentCredIDs;
-
-export interface CredIdsRejectReason {
-    tag: CredIdsRejectReasonTag;
-    contents: string[]
-}
-
-export type RejectReason =
-    | SimpleRejectReason
-    | RejectedReceive
-    | RejectedInit
-    | StringRejectReason
-    | NumberRejectReason
-    | InvalidReceiveMethod
-    | InvalidInitMethod
-    | AmountTooLarge
-    | InvalidContractAddress
-    | CredIdsRejectReason;
+export type AccountIdentifierInput =
+    | AccountAddress
+    | CredentialRegistrationId
+    | bigint;
 
 interface RejectedEventResult {
     outcome: 'reject';
@@ -370,15 +107,7 @@ interface RejectedEventResult {
 
 interface SuccessfulEventResult {
     outcome: 'success';
-    events: (
-        | TransactionEvent
-        | TransferredEvent
-        | UpdatedEvent
-        | ResumedEvent
-        | InterruptedEvent
-        | MemoEvent
-        | TransferredWithScheduleEvent
-    )[];
+    events: TransactionEvent[];
 }
 
 export type EventResult =

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -124,11 +124,15 @@ export type EventResult =
     | TransferWithMemoEventResult
     | RejectedEventResult;
 
+export enum TransactionSummaryType {
+    AccountTransaction = 'accountTransaction',
+    CredentialDeploymentTransaction = 'credentialDeploymentTransaction',
+    AccountCreation = 'accountCreation',
+    UpdateTransaction = 'UpdateTransaction',
+}
+
 interface BaseTransactionSummaryType {
-    type:
-        | 'accountTransaction'
-        | 'credentialDeploymentTransaction'
-        | 'updateTransaction';
+    type: TransactionSummaryType;
 }
 
 export interface TransferWithMemoSummaryType

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -13,6 +13,7 @@ import {
 } from './types/transactionEvent';
 
 export type HexString = string;
+export type Base58String = string;
 
 /**
  * Returns a union of all keys of type T with values matching type V.
@@ -87,7 +88,7 @@ export enum TransactionStatusEnum {
 
 export interface AddressAccount {
     type: 'AddressAccount';
-    address: string;
+    address: Base58String;
 }
 
 export interface ContractAddress {
@@ -99,6 +100,13 @@ export type AccountIdentifierInput =
     | AccountAddress
     | CredentialRegistrationId
     | bigint;
+
+export type Address =
+    | {
+          type: 'AddressContract';
+          address: ContractAddress;
+      }
+    | AddressAccount;
 
 interface RejectedEventResult {
     outcome: 'reject';
@@ -817,7 +825,7 @@ type PoolStatusWrapper<T extends keyof typeof PoolStatusType, S> = S & {
 
 export interface BakerPoolStatusDetails {
     bakerId: BakerId;
-    bakerAddress: string;
+    bakerAddress: Base58String;
     bakerEquityCapital: Amount;
     delegatedCapital: Amount;
     delegatedCapitalCap: Amount;
@@ -893,7 +901,7 @@ export type AccountCredential = Versioned<
 >;
 
 interface AccountInfoCommon {
-    accountAddress: string;
+    accountAddress: Base58String;
     accountNonce: bigint;
     accountAmount: bigint;
     accountIndex: bigint;
@@ -1256,7 +1264,7 @@ export type Invoker =
       }
     | {
           type: 'AddressAccount';
-          address: string;
+          address: Base58String;
       }
     | null;
 
@@ -1377,6 +1385,11 @@ export interface IdentityInput {
     prfKey: string;
     idCredSecret: string;
     randomness: string;
+}
+
+export enum ContractVersion {
+    V0 = 0,
+    V1 = 1,
 }
 
 export enum SchemaVersion {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -128,7 +128,7 @@ export enum TransactionSummaryType {
     AccountTransaction = 'accountTransaction',
     CredentialDeploymentTransaction = 'credentialDeploymentTransaction',
     AccountCreation = 'accountCreation',
-    UpdateTransaction = 'UpdateTransaction',
+    UpdateTransaction = 'updateTransaction',
 }
 
 interface BaseTransactionSummaryType {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -285,27 +285,83 @@ export type SimpleRejectReasonTag =
     | RejectReasonTag.PoolWouldBecomeOverDelegated
     | RejectReasonTag.PoolClosed;
 
+export type ModuleRefRejectReasonTag =
+    | RejectReasonTag.ModuleHashAlreadyExists
+    | RejectReasonTag.InvalidModuleReference;
+
+export type AccountAddressRejectReasonTag =
+    | RejectReasonTag.InvalidAccountReference
+    | RejectReasonTag.NotADelegator
+    | RejectReasonTag.NonExistentRewardAccount
+    | RejectReasonTag.NotABaker
+    | RejectReasonTag.ScheduledSelfTransfer
+    | RejectReasonTag.EncryptedAmountSelfTransfer
+;
+
+export type StringRejectReasonTag = ModuleRefRejectReasonTag | AccountAddressRejectReasonTag | RejectReasonTag.NonExistentCredentialID | RejectReasonTag.DuplicateAggregationKey;
+
+export interface StringRejectReason {
+    tag: StringRejectReasonTag;
+    contents: string;
+}
+export type NumberRejectReasonTag = RejectReasonTag.AlreadyABaker | RejectReasonTag.DelegationTargetNotABaker;
+
+export interface NumberRejectReason {
+    tag: NumberRejectReasonTag;
+    contents: number;
+}
+
 export interface SimpleRejectReason {
     tag: SimpleRejectReasonTag;
 }
 
-// TODO split this into types with contents properly typed/parsed;
-export interface RejectReasonWithContents {
-    tag: Exclude<
-        RejectReasonTag,
-        | RejectReasonTag.RejectedReceive
-        | RejectReasonTag.RejectedInit
-        | SimpleRejectReasonTag
-    >;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    contents: any;
+export interface InvalidReceiveMethod {
+    tag: RejectReasonTag.InvalidReceiveMethod;
+    contents: {
+        moduleRef: string;
+        receiveName: string;
+    };
+}
+
+export interface InvalidInitMethod {
+    tag: RejectReasonTag.InvalidInitMethod;
+    contents: {
+        moduleRef: string;
+        initName: string;
+    };
+}
+
+export interface AmountTooLarge {
+    tag: RejectReasonTag.AmountTooLarge;
+    contents: {
+        address: string;
+        amount: string;
+    };
+}
+
+export interface InvalidContractAddress {
+    tag: RejectReasonTag.InvalidContractAddress,
+    contents: ContractAddress
+}
+
+export type CredIdsRejectReasonTag = RejectReasonTag.DuplicateCredIDs | RejectReasonTag.NonExistentCredIDs;
+
+export interface CredIdsRejectReason {
+    tag: CredIdsRejectReasonTag;
+    contents: string[]
 }
 
 export type RejectReason =
-    | RejectReasonWithContents
     | SimpleRejectReason
     | RejectedReceive
-    | RejectedInit;
+    | RejectedInit
+    | StringRejectReason
+    | NumberRejectReason
+    | InvalidReceiveMethod
+    | InvalidInitMethod
+    | AmountTooLarge
+    | InvalidContractAddress
+    | CredIdsRejectReason;
 
 interface RejectedEventResult {
     outcome: 'reject';

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -14,6 +14,7 @@ import {
 
 export type HexString = string;
 export type Base58String = string;
+export type DigitString = string;
 
 /**
  * Returns a union of all keys of type T with values matching type V.
@@ -866,6 +867,12 @@ export interface DelegationTargetBaker {
     delegateType: DelegationTargetType.Baker;
     bakerId: BakerId;
 }
+export type EventDelegationTarget =
+    | {
+          delegateType: DelegationTargetType.Baker;
+          bakerId: number;
+      }
+    | DelegationTargetPassiveDelegation;
 
 export type DelegationTarget =
     | DelegationTargetPassiveDelegation
@@ -1258,8 +1265,8 @@ export type Invoker =
     | {
           type: 'AddressContract';
           address: {
-              index: string;
-              subindex: string;
+              index: DigitString;
+              subindex: DigitString;
           };
       }
     | {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -7,6 +7,7 @@ import { Buffer } from 'buffer/';
 import { ModuleReference } from './types/moduleReference';
 import { RejectReason } from './types/rejectReason';
 import {
+    ContractTraceEvent,
     MemoEvent,
     TransactionEvent,
     TransferredEvent,
@@ -1307,10 +1308,10 @@ export function buildInvoker(
     }
 }
 
-export interface InvokeContractSuccessResult
-    extends Pick<SuccessfulEventResult, 'events'> {
+export interface InvokeContractSuccessResult {
     tag: 'success';
     usedEnergy: bigint;
+    events: ContractTraceEvent[];
     returnValue?: string;
 }
 

--- a/packages/common/src/types/blockItemSummary.ts
+++ b/packages/common/src/types/blockItemSummary.ts
@@ -68,148 +68,140 @@ export enum TransactionKindString {
     StakingReward = 'paydayAccountReward',
 }
 
-export interface TransferSummary extends BaseAccountTransactionSummary {
+export interface TransferSummary {
     transactionType: TransactionKindString.Transfer;
-    events: [TransferredEvent];
+    event: TransferredEvent;
 }
 
-export interface TransferWithMemoSummary extends BaseAccountTransactionSummary {
+export interface TransferWithMemoSummary {
     transactionType: TransactionKindString.TransferWithMemo;
     events: [TransferredEvent, MemoEvent];
 }
 
-export interface TransferWithScheduleSummary
-    extends BaseAccountTransactionSummary {
+export interface TransferWithScheduleSummary {
     transactionType: TransactionKindString.TransferWithSchedule;
-    events: [TransferredWithScheduleEvent];
+    event: TransferredWithScheduleEvent;
 }
 
-export interface TransferWithScheduleAndMemoSummary
-    extends BaseAccountTransactionSummary {
+export interface TransferWithScheduleAndMemoSummary {
     transactionType: TransactionKindString.TransferWithScheduleAndMemo;
     events: [TransferredWithScheduleEvent, MemoEvent];
 }
 
-export interface EncryptedAmountTransferSummary
-    extends BaseAccountTransactionSummary {
+export interface EncryptedAmountTransferSummary {
     transactionType: TransactionKindString.EncryptedAmountTransfer;
     events: [EncryptedAmountsRemovedEvent, NewEncryptedAmountEvent];
 }
 
-export interface EncryptedAmountTransferWithMemoSummary
-    extends BaseAccountTransactionSummary {
+export interface EncryptedAmountTransferWithMemoSummary {
     transactionType: TransactionKindString.EncryptedAmountTransferWithMemo;
     events: [EncryptedAmountsRemovedEvent, NewEncryptedAmountEvent, MemoEvent];
 }
 
-export interface ModueDeployedSummary extends BaseAccountTransactionSummary {
+export interface ModueDeployedSummary {
     transactionType: TransactionKindString.DeployModule;
-    events: [ModuleDeployedEvent];
+    event: ModuleDeployedEvent;
 }
 
-export interface InitContractSummary extends BaseAccountTransactionSummary {
+export interface InitContractSummary {
     transactionType: TransactionKindString.InitContract;
-    events: [ContractInitializedEvent];
+    event: ContractInitializedEvent;
 }
 
-export interface UpdateContractSummary extends BaseAccountTransactionSummary {
+export interface UpdateContractSummary {
     transactionType: TransactionKindString.Update;
     events: ContractTraceEvent[];
 }
 
-export interface DataRegisteredSummary extends BaseAccountTransactionSummary {
+export interface DataRegisteredSummary {
     transactionType: TransactionKindString.RegisterData;
-    events: [DataRegisteredEvent];
+    event: DataRegisteredEvent;
 }
 
-export interface TransferToPublicSummary extends BaseAccountTransactionSummary {
+export interface TransferToPublicSummary {
     transactionType: TransactionKindString.TransferToPublic;
     events: [EncryptedAmountsRemovedEvent, AmountAddedByDecryptionEvent];
 }
 
-export interface TransferToEncryptedSummary
-    extends BaseAccountTransactionSummary {
+export interface TransferToEncryptedSummary {
     transactionType: TransactionKindString.TransferToEncrypted;
-    events: [EncryptedSelfAmountAddedEvent];
+    event: EncryptedSelfAmountAddedEvent;
 }
 
-export interface AddBakerSummary extends BaseAccountTransactionSummary {
+export interface AddBakerSummary {
     transactionType: TransactionKindString.AddBaker;
-    events: [BakerAddedEvent];
+    event: BakerAddedEvent;
 }
 
-export interface RemoveBakerSummary extends BaseAccountTransactionSummary {
+export interface RemoveBakerSummary {
     transactionType: TransactionKindString.RemoveBaker;
-    events: [BakerRemovedEvent];
+    event: BakerRemovedEvent;
 }
 
-export interface UpdateBakerKeysSummary extends BaseAccountTransactionSummary {
+export interface UpdateBakerKeysSummary {
     transactionType: TransactionKindString.UpdateBakerKeys;
-    events: [BakerKeysUpdatedEvent];
+    event: BakerKeysUpdatedEvent;
 }
 
-export interface UpdateBakerStakeSummary extends BaseAccountTransactionSummary {
+export interface UpdateBakerStakeSummary {
     transactionType: TransactionKindString.UpdateBakerStake;
-    events: [BakerStakeChangedEvent];
+    event: BakerStakeChangedEvent;
 }
 
-export interface UpdateBakerRestakeEarningsSummary
-    extends BaseAccountTransactionSummary {
+export interface UpdateBakerRestakeEarningsSummary {
     transactionType: TransactionKindString.UpdateBakerRestakeEarnings;
-    events: [BakerSetRestakeEarningsEvent];
+    event: BakerSetRestakeEarningsEvent;
 }
 
-export interface ConfigureBakerSummary extends BaseAccountTransactionSummary {
+export interface ConfigureBakerSummary {
     transactionType: TransactionKindString.ConfigureBaker;
     events: BakerEvent[];
 }
 
-export interface ConfigureDelegationSummary
-    extends BaseAccountTransactionSummary {
+export interface ConfigureDelegationSummary {
     transactionType: TransactionKindString.ConfigureDelegation;
     events: DelegationEvent[];
 }
 
-export interface UpdateCredentialKeysSummary
-    extends BaseAccountTransactionSummary {
+export interface UpdateCredentialKeysSummary {
     transactionType: TransactionKindString.UpdateCredentialKeys;
-    events: [CredentialKeysUpdatedEvent];
+    event: CredentialKeysUpdatedEvent;
 }
 
-export interface UpdateCredentialsSummary
-    extends BaseAccountTransactionSummary {
+export interface UpdateCredentialsSummary {
     transactionType: TransactionKindString.UpdateCredentials;
-    events: [CredentialsUpdatedEvent];
+    event: CredentialsUpdatedEvent;
 }
-export interface FailedTransactionSummary
-    extends BaseAccountTransactionSummary {
+export interface FailedTransactionSummary {
     failedTransactionType: TransactionKindString;
     rejectReason: RejectReason;
 }
 
-export type AccountTransactionSummary =
-    | TransferSummary
-    | TransferWithMemoSummary
-    | TransferWithScheduleSummary
-    | TransferWithScheduleAndMemoSummary
-    | EncryptedAmountTransferSummary
-    | EncryptedAmountTransferWithMemoSummary
-    | DataRegisteredSummary
-    | TransferToPublicSummary
-    | TransferToEncryptedSummary
-    | ModueDeployedSummary
-    | InitContractSummary
-    | UpdateContractSummary
-    | FailedTransactionSummary
-    | AddBakerSummary
-    | RemoveBakerSummary
-    | UpdateBakerKeysSummary
-    | UpdateBakerStakeSummary
-    | UpdateBakerRestakeEarningsSummary
-    | ConfigureBakerSummary
-    | ConfigureDelegationSummary
-    | UpdateCredentialKeysSummary
-    | UpdateCredentialsSummary;
+export type AccountTransactionSummary = BaseAccountTransactionSummary &
+    (
+        | TransferSummary
+        | TransferWithMemoSummary
+        | TransferWithScheduleSummary
+        | TransferWithScheduleAndMemoSummary
+        | EncryptedAmountTransferSummary
+        | EncryptedAmountTransferWithMemoSummary
+        | DataRegisteredSummary
+        | TransferToPublicSummary
+        | TransferToEncryptedSummary
+        | ModueDeployedSummary
+        | InitContractSummary
+        | UpdateContractSummary
+        | FailedTransactionSummary
+        | AddBakerSummary
+        | RemoveBakerSummary
+        | UpdateBakerKeysSummary
+        | UpdateBakerStakeSummary
+        | UpdateBakerRestakeEarningsSummary
+        | ConfigureBakerSummary
+        | ConfigureDelegationSummary
+        | UpdateCredentialKeysSummary
+        | UpdateCredentialsSummary
+    );
 
 export interface AccountCreationSummary {
     type: TransactionSummaryType.AccountCreation;

--- a/packages/common/src/types/blockItemSummary.ts
+++ b/packages/common/src/types/blockItemSummary.ts
@@ -1,0 +1,254 @@
+import {
+    AmountAddedByDecryptionEvent,
+    BakerAddedEvent,
+    BakerEvent,
+    BakerKeysUpdatedEvent,
+    BakerRemovedEvent,
+    BakerSetRestakeEarningsEvent,
+    BakerStakeChangedEvent,
+    ContractInitializedEvent,
+    ContractTraceEvent,
+    CredentialKeysUpdatedEvent,
+    CredentialsUpdatedEvent,
+    DataRegisteredEvent,
+    DelegationEvent,
+    EncryptedAmountsRemovedEvent,
+    EncryptedSelfAmountAddedEvent,
+    MemoEvent,
+    ModuleDeployedEvent,
+    NewEncryptedAmountEvent,
+    TransferredEvent,
+    TransferredWithScheduleEvent,
+} from './transactionEvent';
+import { UpdateInstructionPayload } from './chainUpdate';
+import {
+    HexString,
+    TransactionSummaryType,
+    TransactionStatusEnum,
+} from '../types';
+import { RejectReason } from './rejectReason';
+
+export interface BaseBlockItemSummary {
+    index: bigint;
+    energyCost: bigint;
+    hash: HexString;
+}
+
+export interface BaseAccountTransactionSummary extends BaseBlockItemSummary {
+    type: TransactionSummaryType.AccountTransaction;
+    cost: bigint;
+    sender: string;
+}
+
+export enum TransactionKindString {
+    DeployModule = 'deployModule',
+    InitContract = 'initContract',
+    Update = 'update',
+    Transfer = 'transfer',
+    AddBaker = 'addBaker',
+    RemoveBaker = 'removeBaker',
+    UpdateBakerStake = 'updateBakerStake',
+    UpdateBakerRestakeEarnings = 'updateBakerRestakeEarnings',
+    UpdateBakerKeys = 'updateBakerKeys',
+    UpdateCredentialKeys = 'updateCredentialKeys',
+    BakingReward = 'bakingReward',
+    BlockReward = 'blockReward',
+    FinalizationReward = 'finalizationReward',
+    EncryptedAmountTransfer = 'encryptedAmountTransfer',
+    TransferToEncrypted = 'transferToEncrypted',
+    TransferToPublic = 'transferToPublic',
+    TransferWithSchedule = 'transferWithSchedule',
+    UpdateCredentials = 'updateCredentials',
+    RegisterData = 'registerData',
+    TransferWithMemo = 'transferWithMemo',
+    EncryptedAmountTransferWithMemo = 'encryptedAmountTransferWithMemo',
+    TransferWithScheduleAndMemo = 'transferWithScheduleAndMemo',
+    ConfigureBaker = 'configureBaker',
+    ConfigureDelegation = 'configureDelegation',
+    StakingReward = 'paydayAccountReward',
+}
+
+export interface TransferSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.Transfer;
+    events: [TransferredEvent];
+}
+
+export interface TransferWithMemoSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.TransferWithMemo;
+    events: [TransferredEvent, MemoEvent];
+}
+
+export interface TransferWithScheduleSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.TransferWithSchedule;
+    events: [TransferredWithScheduleEvent];
+}
+
+export interface TransferWithScheduleAndMemoSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.TransferWithScheduleAndMemo;
+    events: [TransferredWithScheduleEvent, MemoEvent];
+}
+
+export interface EncryptedAmountTransferSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.EncryptedAmountTransfer;
+    events: [EncryptedAmountsRemovedEvent, NewEncryptedAmountEvent];
+}
+
+export interface EncryptedAmountTransferWithMemoSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.EncryptedAmountTransferWithMemo;
+    events: [EncryptedAmountsRemovedEvent, NewEncryptedAmountEvent, MemoEvent];
+}
+
+export interface ModueDeployedSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.DeployModule;
+    events: [ModuleDeployedEvent];
+}
+
+export interface InitContractSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.InitContract;
+    events: [ContractInitializedEvent];
+}
+
+export interface UpdateContractSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.Update;
+    events: ContractTraceEvent[];
+}
+
+export interface DataRegisteredSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.RegisterData;
+    events: [DataRegisteredEvent];
+}
+
+export interface TransferToPublicSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.TransferToPublic;
+    events: [EncryptedAmountsRemovedEvent, AmountAddedByDecryptionEvent];
+}
+
+export interface TransferToEncryptedSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.TransferToEncrypted;
+    events: [EncryptedSelfAmountAddedEvent];
+}
+
+export interface AddBakerSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.AddBaker;
+    events: [BakerAddedEvent];
+}
+
+export interface RemoveBakerSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.RemoveBaker;
+    events: [BakerRemovedEvent];
+}
+
+export interface UpdateBakerKeysSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.UpdateBakerKeys;
+    events: [BakerKeysUpdatedEvent];
+}
+
+export interface UpdateBakerStakeSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.UpdateBakerStake;
+    events: [BakerStakeChangedEvent];
+}
+
+export interface UpdateBakerRestakeEarningsSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.UpdateBakerRestakeEarnings;
+    events: [BakerSetRestakeEarningsEvent];
+}
+
+export interface ConfigureBakerSummary extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.ConfigureBaker;
+    events: BakerEvent[];
+}
+
+export interface ConfigureDelegationSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.ConfigureDelegation;
+    events: DelegationEvent[];
+}
+
+export interface UpdateCredentialKeysSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.UpdateCredentialKeys;
+    events: [CredentialKeysUpdatedEvent];
+}
+
+export interface UpdateCredentialsSummary
+    extends BaseAccountTransactionSummary {
+    transactionType: TransactionKindString.UpdateCredentials;
+    events: [CredentialsUpdatedEvent];
+}
+export interface FailedTransactionSummary
+    extends BaseAccountTransactionSummary {
+    failedTransactionType: TransactionKindString;
+    rejectReason: RejectReason;
+}
+
+export type AccountTransactionSummary =
+    | TransferSummary
+    | TransferWithMemoSummary
+    | TransferWithScheduleSummary
+    | TransferWithScheduleAndMemoSummary
+    | EncryptedAmountTransferSummary
+    | EncryptedAmountTransferWithMemoSummary
+    | DataRegisteredSummary
+    | TransferToPublicSummary
+    | TransferToEncryptedSummary
+    | ModueDeployedSummary
+    | InitContractSummary
+    | UpdateContractSummary
+    | FailedTransactionSummary
+    | AddBakerSummary
+    | RemoveBakerSummary
+    | UpdateBakerKeysSummary
+    | UpdateBakerStakeSummary
+    | UpdateBakerRestakeEarningsSummary
+    | ConfigureBakerSummary
+    | ConfigureDelegationSummary
+    | UpdateCredentialKeysSummary
+    | UpdateCredentialsSummary;
+
+export interface AccountCreationSummary {
+    type: TransactionSummaryType.AccountCreation;
+    credentialType: 'initial' | 'normal';
+    address: string;
+    regId: string;
+}
+
+export interface UpdateSummary extends BaseBlockItemSummary {
+    type: TransactionSummaryType.UpdateTransaction;
+    effectiveTime: bigint;
+    payload: UpdateInstructionPayload;
+}
+
+export type BlockItemSummary =
+    | AccountTransactionSummary
+    | AccountCreationSummary
+    | UpdateSummary;
+
+export interface BlockItemSummaryInBlock {
+    blockHash: string;
+    summary: BlockItemSummary;
+}
+
+export interface PendingBlockItem {
+    status: TransactionStatusEnum.Received;
+}
+
+export interface CommittedBlockItem {
+    status: TransactionStatusEnum.Committed;
+    outcomes: BlockItemSummaryInBlock[];
+}
+
+export interface FinalizedBlockItem {
+    status: TransactionStatusEnum.Finalized;
+    outcome: BlockItemSummaryInBlock;
+}
+
+export type BlockItemStatus =
+    | CommittedBlockItem
+    | FinalizedBlockItem
+    | PendingBlockItem;

--- a/packages/common/src/types/blockItemSummary.ts
+++ b/packages/common/src/types/blockItemSummary.ts
@@ -70,12 +70,13 @@ export enum TransactionKindString {
 
 export interface TransferSummary {
     transactionType: TransactionKindString.Transfer;
-    event: TransferredEvent;
+    transfer: TransferredEvent;
 }
 
 export interface TransferWithMemoSummary {
     transactionType: TransactionKindString.TransferWithMemo;
-    events: [TransferredEvent, MemoEvent];
+    transfer: TransferredEvent;
+    memo: MemoEvent;
 }
 
 export interface TransferWithScheduleSummary {
@@ -85,27 +86,31 @@ export interface TransferWithScheduleSummary {
 
 export interface TransferWithScheduleAndMemoSummary {
     transactionType: TransactionKindString.TransferWithScheduleAndMemo;
-    events: [TransferredWithScheduleEvent, MemoEvent];
+    transfer: TransferredWithScheduleEvent;
+    memo: MemoEvent;
 }
 
 export interface EncryptedAmountTransferSummary {
     transactionType: TransactionKindString.EncryptedAmountTransfer;
-    events: [EncryptedAmountsRemovedEvent, NewEncryptedAmountEvent];
+    removed: EncryptedAmountsRemovedEvent;
+    added: NewEncryptedAmountEvent;
 }
 
 export interface EncryptedAmountTransferWithMemoSummary {
     transactionType: TransactionKindString.EncryptedAmountTransferWithMemo;
-    events: [EncryptedAmountsRemovedEvent, NewEncryptedAmountEvent, MemoEvent];
+    removed: EncryptedAmountsRemovedEvent;
+    added: NewEncryptedAmountEvent;
+    memo: MemoEvent;
 }
 
-export interface ModueDeployedSummary {
+export interface ModuleDeployedSummary {
     transactionType: TransactionKindString.DeployModule;
-    event: ModuleDeployedEvent;
+    moduleDeployed: ModuleDeployedEvent;
 }
 
 export interface InitContractSummary {
     transactionType: TransactionKindString.InitContract;
-    event: ContractInitializedEvent;
+    contractInitialized: ContractInitializedEvent;
 }
 
 export interface UpdateContractSummary {
@@ -115,42 +120,43 @@ export interface UpdateContractSummary {
 
 export interface DataRegisteredSummary {
     transactionType: TransactionKindString.RegisterData;
-    event: DataRegisteredEvent;
+    dataRegistered: DataRegisteredEvent;
 }
 
 export interface TransferToPublicSummary {
     transactionType: TransactionKindString.TransferToPublic;
-    events: [EncryptedAmountsRemovedEvent, AmountAddedByDecryptionEvent];
+    removed: EncryptedAmountsRemovedEvent;
+    added: AmountAddedByDecryptionEvent;
 }
 
 export interface TransferToEncryptedSummary {
     transactionType: TransactionKindString.TransferToEncrypted;
-    event: EncryptedSelfAmountAddedEvent;
+    added: EncryptedSelfAmountAddedEvent;
 }
 
 export interface AddBakerSummary {
     transactionType: TransactionKindString.AddBaker;
-    event: BakerAddedEvent;
+    bakerAdded: BakerAddedEvent;
 }
 
 export interface RemoveBakerSummary {
     transactionType: TransactionKindString.RemoveBaker;
-    event: BakerRemovedEvent;
+    bakerRemoved: BakerRemovedEvent;
 }
 
 export interface UpdateBakerKeysSummary {
     transactionType: TransactionKindString.UpdateBakerKeys;
-    event: BakerKeysUpdatedEvent;
+    bakerKeysUpdated: BakerKeysUpdatedEvent;
 }
 
 export interface UpdateBakerStakeSummary {
     transactionType: TransactionKindString.UpdateBakerStake;
-    event: BakerStakeChangedEvent;
+    bakerStakeChanged: BakerStakeChangedEvent;
 }
 
 export interface UpdateBakerRestakeEarningsSummary {
     transactionType: TransactionKindString.UpdateBakerRestakeEarnings;
-    event: BakerSetRestakeEarningsEvent;
+    bakerRestakeEarningsUpdated: BakerSetRestakeEarningsEvent;
 }
 
 export interface ConfigureBakerSummary {
@@ -165,12 +171,12 @@ export interface ConfigureDelegationSummary {
 
 export interface UpdateCredentialKeysSummary {
     transactionType: TransactionKindString.UpdateCredentialKeys;
-    event: CredentialKeysUpdatedEvent;
+    keysUpdated: CredentialKeysUpdatedEvent;
 }
 
 export interface UpdateCredentialsSummary {
     transactionType: TransactionKindString.UpdateCredentials;
-    event: CredentialsUpdatedEvent;
+    credentialsUpdated: CredentialsUpdatedEvent;
 }
 export interface FailedTransactionSummary {
     failedTransactionType: TransactionKindString;
@@ -188,7 +194,7 @@ export type AccountTransactionSummary = BaseAccountTransactionSummary &
         | DataRegisteredSummary
         | TransferToPublicSummary
         | TransferToEncryptedSummary
-        | ModueDeployedSummary
+        | ModuleDeployedSummary
         | InitContractSummary
         | UpdateContractSummary
         | FailedTransactionSummary

--- a/packages/common/src/types/chainUpdate.ts
+++ b/packages/common/src/types/chainUpdate.ts
@@ -1,3 +1,4 @@
+import { AuthorizationsV0, AuthorizationsV1 } from '..';
 import type {
     IpInfo,
     ArInfo,
@@ -10,22 +11,126 @@ import type {
     CommissionRates,
 } from '../types';
 
+export interface MintDistributionUpdate {
+    updateType: UpdateType.MintDistribution;
+    update: MintDistribution;
+}
+
+export interface FoundationAccountUpdate {
+    updateType: UpdateType.FoundationAccount;
+    update: FoundationAccount;
+}
+
+export interface ElectionDifficultyUpdate {
+    updateType: UpdateType.ElectionDifficulty;
+    update: ElectionDifficulty;
+}
+
+export interface EuroPerEnergyUpdate {
+    updateType: UpdateType.EuroPerEnergy;
+    update: ExchangeRate;
+}
+
+export interface MicroGtuPerEuroUpdate {
+    updateType: UpdateType.MicroGtuPerEuro;
+    update: ExchangeRate;
+}
+
+export interface TransactionFeeDistributionUpdate {
+    updateType: UpdateType.TransactionFeeDistribution;
+    update: TransactionFeeDistribution;
+}
+
+export interface GasRewardsUpdate {
+    updateType: UpdateType.GasRewards;
+    update: GasRewards;
+}
+
+export interface AddAnonymityRevokerUpdate {
+    updateType: UpdateType.AddAnonymityRevoker;
+    update: AddAnonymityRevoker;
+}
+
+export interface AddIdentityProviderUpdate {
+    updateType: UpdateType.AddIdentityProvider;
+    update: AddIdentityProvider;
+}
+
+export interface CooldownParametersUpdate {
+    updateType: UpdateType.CooldownParameters;
+    update: CooldownParameters;
+}
+
+export interface TimeParametersUpdate {
+    updateType: UpdateType.TimeParameters;
+    update: TimeParameters;
+}
+
+export interface ProtocolUpdate {
+    updateType: UpdateType.Protocol;
+    update: ProtocolUpdateDetails;
+}
+
+export interface PoolParametersUpdate {
+    updateType: UpdateType.PoolParameters;
+    update: PoolParameters;
+}
+
+export interface BakerStakeThresholdUpdate {
+    updateType: UpdateType.BakerStakeThreshold;
+    update: BakerStakeThreshold;
+}
+
+export interface Level1Update {
+    updateType: UpdateType.Level1;
+    update: KeyUpdate;
+}
+
+export interface RootUpdate {
+    updateType: UpdateType.Root;
+    update: KeyUpdate;
+}
+
 export type UpdateInstructionPayload =
-    | ExchangeRate
-    | TransactionFeeDistribution
-    | FoundationAccount
-    | MintDistribution
+    | MicroGtuPerEuroUpdate
+    | EuroPerEnergyUpdate
+    | TransactionFeeDistributionUpdate
+    | FoundationAccountUpdate
+    | MintDistributionUpdate
     | ProtocolUpdate
-    | GasRewards
-    | BakerStakeThreshold
-    | ElectionDifficulty
-    | HigherLevelKeyUpdate
-    | AuthorizationKeysUpdate
-    | AddAnonymityRevoker
-    | AddIdentityProvider
-    | CooldownParameters
-    | PoolParameters
-    | TimeParameters;
+    | GasRewardsUpdate
+    | BakerStakeThresholdUpdate
+    | ElectionDifficultyUpdate
+    | AddAnonymityRevokerUpdate
+    | AddIdentityProviderUpdate
+    | CooldownParametersUpdate
+    | PoolParametersUpdate
+    | TimeParametersUpdate
+    | RootUpdate
+    | Level1Update;
+
+export enum UpdateType {
+    Root = 'root',
+    Level1 = 'level1',
+    Protocol = 'protocol',
+    ElectionDifficulty = 'electionDifficulty',
+    EuroPerEnergy = 'euroPerEnergy',
+    MicroGtuPerEuro = 'microGtuPerEuro',
+    FoundationAccount = 'foundationAccount',
+    MintDistribution = 'mintDistribution',
+    TransactionFeeDistribution = 'transactionFeeDistribution',
+    GasRewards = 'gasRewards',
+    PoolParameters = 'poolParameters',
+    AddAnonymityRevoker = 'addAnonymityRevoker',
+    AddIdentityProvider = 'addIdentityProvider',
+    CooldownParameters = 'cooldownParameters',
+    TimeParameters = 'timeParameters',
+    ProtocolUpdate = 'protocolUpdate',
+    BakerStakeThreshold = 'bakerStakeThreshold',
+    Emergency = 'emergency',
+}
+
+export type KeyUpdate = HigherLevelKeyUpdate | AuthorizationKeysUpdate;
 
 export interface Fraction {
     numerator: bigint;
@@ -39,7 +144,7 @@ export interface FoundationAccount {
     address: string;
 }
 
-export interface ProtocolUpdate {
+export interface ProtocolUpdateDetails {
     message: string;
     specificationUrl: string;
     specificationHash: string;
@@ -94,52 +199,28 @@ export interface KeyWithStatus {
     status: KeyUpdateEntryStatus;
 }
 
-export type HigherLevelKeyUpdateType = 0 | 1;
-/**
- * The higher level key update covers three transaction types:
- *  - Updating root keys with root keys
- *  - Updating level 1 keys with root keys
- *  - Updating level 1 keys with level 1 keys
- */
+export enum HigherLevelKeyUpdateType {
+    RootKeysUpdate = 'rootKeysUpdate',
+    Level1KeysUpdate = 'level1KeysUpdate',
+}
+
 export interface HigherLevelKeyUpdate {
-    // Has to be 0 when updating root keys with root keys,
-    // 1 when updating level 1 keys with root keys, and
-    // 0 when updating level 1 keys with level 1 keys.
-    keyUpdateType: HigherLevelKeyUpdateType;
-    updateKeys: KeyWithStatus[];
+    typeOfUpdate: HigherLevelKeyUpdateType;
+    updateKeys: VerifyKey[];
     threshold: number;
 }
 
-export interface KeyIndexWithStatus {
-    index: number;
-    status: KeyUpdateEntryStatus;
+export enum AuthorizationKeysUpdateType {
+    Level2KeysUpdate = 'level2KeysUpdate',
+    Level2KeysUpdateV1 = 'level2KeysUpdateV1',
 }
 
-export enum AccessStructureEnum {
-    emergency,
-    protocol,
-    electionDifficulty,
-    euroPerEnergy,
-    microGtuPerEuro,
-    foundationAccount,
-    mintDistribution,
-    transactionFeeDistribution,
-    gasRewards,
-    poolParameters,
-    addAnonymityRevoker,
-    addIdentityProvider,
-    cooldownParameters,
-    timeParameters,
-}
-
-export interface AccessStructure {
-    publicKeyIndicies: KeyIndexWithStatus[];
-    threshold: number;
-    type: AccessStructureEnum;
-}
-
-export interface AuthorizationKeysUpdate {
-    keyUpdateType: number;
-    keys: VerifyKey[];
-    accessStructures: AccessStructure[];
-}
+export type AuthorizationKeysUpdate =
+    | {
+          typeOfUpdate: AuthorizationKeysUpdateType.Level2KeysUpdate;
+          updatePayload: AuthorizationsV0;
+      }
+    | {
+          typeOfUpdate: AuthorizationKeysUpdateType.Level2KeysUpdateV1;
+          updatePayload: AuthorizationsV1;
+      };

--- a/packages/common/src/types/chainUpdate.ts
+++ b/packages/common/src/types/chainUpdate.ts
@@ -1,0 +1,145 @@
+import type {
+    IpInfo,
+    ArInfo,
+    VerifyKey,
+    ExchangeRate,
+    TransactionFeeDistribution,
+    MintDistribution,
+    GasRewards,
+    MintRate,
+    CommissionRates,
+} from '../types';
+
+export type UpdateInstructionPayload =
+    | ExchangeRate
+    | TransactionFeeDistribution
+    | FoundationAccount
+    | MintDistribution
+    | ProtocolUpdate
+    | GasRewards
+    | BakerStakeThreshold
+    | ElectionDifficulty
+    | HigherLevelKeyUpdate
+    | AuthorizationKeysUpdate
+    | AddAnonymityRevoker
+    | AddIdentityProvider
+    | CooldownParameters
+    | PoolParameters
+    | TimeParameters;
+
+export interface Fraction {
+    numerator: bigint;
+    denominator: bigint;
+}
+
+export type AddIdentityProvider = IpInfo;
+export type AddAnonymityRevoker = ArInfo;
+
+export interface FoundationAccount {
+    address: string;
+}
+
+export interface ProtocolUpdate {
+    message: string;
+    specificationUrl: string;
+    specificationHash: string;
+    specificationAuxiliaryData?: string;
+}
+
+export interface BakerStakeThreshold {
+    threshold: bigint;
+}
+
+export interface ElectionDifficulty {
+    electionDifficulty: number;
+}
+
+export interface TimeParameters {
+    rewardPeriodLength: bigint;
+    mintRatePerPayday: MintRate;
+}
+
+export interface CooldownParameters {
+    poolOwnerCooldown: bigint;
+    delegatorCooldown: bigint;
+}
+
+export interface CommissionRange {
+    min: number;
+    max: number;
+}
+
+export interface CommissionRanges {
+    finalizationRewardCommission: CommissionRange;
+    bakingRewardCommission: CommissionRange;
+    transactionFeeCommission: CommissionRange;
+}
+
+export interface PoolParameters {
+    passiveCommissions: CommissionRates;
+    commissionBounds: CommissionRanges;
+    minimumEquityCapital: bigint;
+    capitalBound: number;
+    leverageBound: Fraction;
+}
+
+export enum KeyUpdateEntryStatus {
+    Added,
+    Removed,
+    Unchanged,
+}
+
+export interface KeyWithStatus {
+    key: VerifyKey;
+    status: KeyUpdateEntryStatus;
+}
+
+export type HigherLevelKeyUpdateType = 0 | 1;
+/**
+ * The higher level key update covers three transaction types:
+ *  - Updating root keys with root keys
+ *  - Updating level 1 keys with root keys
+ *  - Updating level 1 keys with level 1 keys
+ */
+export interface HigherLevelKeyUpdate {
+    // Has to be 0 when updating root keys with root keys,
+    // 1 when updating level 1 keys with root keys, and
+    // 0 when updating level 1 keys with level 1 keys.
+    keyUpdateType: HigherLevelKeyUpdateType;
+    updateKeys: KeyWithStatus[];
+    threshold: number;
+}
+
+export interface KeyIndexWithStatus {
+    index: number;
+    status: KeyUpdateEntryStatus;
+}
+
+export enum AccessStructureEnum {
+    emergency,
+    protocol,
+    electionDifficulty,
+    euroPerEnergy,
+    microGtuPerEuro,
+    foundationAccount,
+    mintDistribution,
+    transactionFeeDistribution,
+    gasRewards,
+    poolParameters,
+    addAnonymityRevoker,
+    addIdentityProvider,
+    cooldownParameters,
+    timeParameters,
+}
+
+export interface AccessStructure {
+    publicKeyIndicies: KeyIndexWithStatus[];
+    threshold: number;
+    type: AccessStructureEnum;
+}
+
+export interface AuthorizationKeysUpdate {
+    keyUpdateType: number;
+    keys: VerifyKey[];
+    accessStructures: AccessStructure[];
+}

--- a/packages/common/src/types/moduleReference.ts
+++ b/packages/common/src/types/moduleReference.ts
@@ -27,6 +27,10 @@ export class ModuleReference {
         }
     }
 
+    static fromBytes(bytes: Buffer): ModuleReference {
+        return new ModuleReference(bytes.toString('hex'));
+    }
+
     toJSON(): string {
         return packBufferWithWord32Length(
             Buffer.from(this.decodedModuleRef)

--- a/packages/common/src/types/rejectReason.ts
+++ b/packages/common/src/types/rejectReason.ts
@@ -3,8 +3,8 @@ import {
     Base58String,
     DigitString,
     HexString,
-} from '..';
-import type { ContractAddress } from '../types';
+    ContractAddress,
+} from '../types';
 
 /*
  * An enum containing all the possible reject reasons that can be

--- a/packages/common/src/types/rejectReason.ts
+++ b/packages/common/src/types/rejectReason.ts
@@ -1,0 +1,202 @@
+import type { ContractAddress } from '../types';
+
+/*
+ * An enum containing all the possible reject reasons that can be
+ * received from a node as a response to a transaction submission.
+ *
+ * This should be kept in sync with the list of reject reasons
+ * found here: https://github.com/Concordium/concordium-base/blob/main/haskell-src/Concordium/Types/Execution.hs
+ */
+export enum RejectReasonTag {
+    ModuleNotWF = 'ModuleNotWF',
+    ModuleHashAlreadyExists = 'ModuleHashAlreadyExists',
+    InvalidAccountReference = 'InvalidAccountReference',
+    InvalidInitMethod = 'InvalidInitMethod',
+    InvalidReceiveMethod = 'InvalidReceiveMethod',
+    InvalidModuleReference = 'InvalidModuleReference',
+    InvalidContractAddress = 'InvalidContractAddress',
+    RuntimeFailure = 'RuntimeFailure',
+    AmountTooLarge = 'AmountTooLarge',
+    SerializationFailure = 'SerializationFailure',
+    OutOfEnergy = 'OutOfEnergy',
+    RejectedInit = 'RejectedInit',
+    RejectedReceive = 'RejectedReceive',
+    NonExistentRewardAccount = 'NonExistentRewardAccount',
+    InvalidProof = 'InvalidProof',
+    AlreadyABaker = 'AlreadyABaker',
+    NotABaker = 'NotABaker',
+    InsufficientBalanceForBakerStake = 'InsufficientBalanceForBakerStake',
+    StakeUnderMinimumThresholdForBaking = 'StakeUnderMinimumThresholdForBaking',
+    BakerInCooldown = 'BakerInCooldown',
+    DuplicateAggregationKey = 'DuplicateAggregationKey',
+    NonExistentCredentialID = 'NonExistentCredentialID',
+    KeyIndexAlreadyInUse = 'KeyIndexAlreadyInUse',
+    InvalidAccountThreshold = 'InvalidAccountThreshold',
+    InvalidCredentialKeySignThreshold = 'InvalidCredentialKeySignThreshold',
+    InvalidEncryptedAmountTransferProof = 'InvalidEncryptedAmountTransferProof',
+    InvalidTransferToPublicProof = 'InvalidTransferToPublicProof',
+    EncryptedAmountSelfTransfer = 'EncryptedAmountSelfTransfer',
+    InvalidIndexOnEncryptedTransfer = 'InvalidIndexOnEncryptedTransfer',
+    ZeroScheduledAmount = 'ZeroScheduledAmount',
+    NonIncreasingSchedule = 'NonIncreasingSchedule',
+    FirstScheduledReleaseExpired = 'FirstScheduledReleaseExpired',
+    ScheduledSelfTransfer = 'ScheduledSelfTransfer',
+    InvalidCredentials = 'InvalidCredentials',
+    DuplicateCredIDs = 'DuplicateCredIDs',
+    NonExistentCredIDs = 'NonExistentCredIDs',
+    RemoveFirstCredential = 'RemoveFirstCredential',
+    CredentialHolderDidNotSign = 'CredentialHolderDidNotSign',
+    NotAllowedMultipleCredentials = 'NotAllowedMultipleCredentials',
+    NotAllowedToReceiveEncrypted = 'NotAllowedToReceiveEncrypted',
+    NotAllowedToHandleEncrypted = 'NotAllowedToHandleEncrypted',
+    MissingBakerAddParameters = 'MissingBakerAddParameters',
+    FinalizationRewardCommissionNotInRange = 'FinalizationRewardCommissionNotInRange',
+    BakingRewardCommissionNotInRange = 'BakingRewardCommissionNotInRange',
+    TransactionFeeCommissionNotInRange = 'TransactionFeeCommissionNotInRange',
+    AlreadyADelegator = 'AlreadyADelegator',
+    InsufficientBalanceForDelegationStake = 'InsufficientBalanceForDelegationStake',
+    MissingDelegationAddParameters = 'MissingDelegationAddParameters',
+    InsufficientDelegationStake = 'InsufficientDelegationStake',
+    DelegatorInCooldown = 'DelegatorInCooldown',
+    NotADelegator = 'NotADelegator',
+    DelegationTargetNotABaker = 'DelegationTargetNotABaker',
+    StakeOverMaximumThresholdForPool = 'StakeOverMaximumThresholdForPool',
+    PoolWouldBecomeOverDelegated = 'PoolWouldBecomeOverDelegated',
+    PoolClosed = 'PoolClosed',
+}
+
+export interface RejectedReceive {
+    tag: RejectReasonTag.RejectedReceive;
+    contractAddress: ContractAddress;
+    receiveName: string;
+    rejectReason: number;
+    parameter: string;
+}
+
+export interface RejectedInit {
+    tag: RejectReasonTag.RejectedInit;
+    rejectReason: number;
+}
+
+export type SimpleRejectReasonTag =
+    | RejectReasonTag.ModuleNotWF
+    | RejectReasonTag.RuntimeFailure
+    | RejectReasonTag.SerializationFailure
+    | RejectReasonTag.OutOfEnergy
+    | RejectReasonTag.InvalidProof
+    | RejectReasonTag.InsufficientBalanceForBakerStake
+    | RejectReasonTag.StakeUnderMinimumThresholdForBaking
+    | RejectReasonTag.BakerInCooldown
+    | RejectReasonTag.NonExistentCredentialID
+    | RejectReasonTag.KeyIndexAlreadyInUse
+    | RejectReasonTag.InvalidAccountThreshold
+    | RejectReasonTag.InvalidCredentialKeySignThreshold
+    | RejectReasonTag.InvalidEncryptedAmountTransferProof
+    | RejectReasonTag.InvalidTransferToPublicProof
+    | RejectReasonTag.InvalidIndexOnEncryptedTransfer
+    | RejectReasonTag.ZeroScheduledAmount
+    | RejectReasonTag.NonIncreasingSchedule
+    | RejectReasonTag.FirstScheduledReleaseExpired
+    | RejectReasonTag.InvalidCredentials
+    | RejectReasonTag.RemoveFirstCredential
+    | RejectReasonTag.CredentialHolderDidNotSign
+    | RejectReasonTag.NotAllowedMultipleCredentials
+    | RejectReasonTag.NotAllowedToReceiveEncrypted
+    | RejectReasonTag.NotAllowedToHandleEncrypted
+    | RejectReasonTag.MissingBakerAddParameters
+    | RejectReasonTag.FinalizationRewardCommissionNotInRange
+    | RejectReasonTag.BakingRewardCommissionNotInRange
+    | RejectReasonTag.TransactionFeeCommissionNotInRange
+    | RejectReasonTag.AlreadyADelegator
+    | RejectReasonTag.InsufficientBalanceForDelegationStake
+    | RejectReasonTag.MissingDelegationAddParameters
+    | RejectReasonTag.InsufficientDelegationStake
+    | RejectReasonTag.DelegatorInCooldown
+    | RejectReasonTag.StakeOverMaximumThresholdForPool
+    | RejectReasonTag.PoolWouldBecomeOverDelegated
+    | RejectReasonTag.PoolClosed;
+
+export type ModuleRefRejectReasonTag =
+    | RejectReasonTag.ModuleHashAlreadyExists
+    | RejectReasonTag.InvalidModuleReference;
+
+export type AccountAddressRejectReasonTag =
+    | RejectReasonTag.InvalidAccountReference
+    | RejectReasonTag.NotADelegator
+    | RejectReasonTag.NonExistentRewardAccount
+    | RejectReasonTag.NotABaker
+    | RejectReasonTag.ScheduledSelfTransfer
+    | RejectReasonTag.EncryptedAmountSelfTransfer;
+
+export type StringRejectReasonTag =
+    | ModuleRefRejectReasonTag
+    | AccountAddressRejectReasonTag
+    | RejectReasonTag.NonExistentCredentialID
+    | RejectReasonTag.DuplicateAggregationKey;
+
+export interface StringRejectReason {
+    tag: StringRejectReasonTag;
+    contents: string;
+}
+export type NumberRejectReasonTag =
+    | RejectReasonTag.AlreadyABaker
+    | RejectReasonTag.DelegationTargetNotABaker;
+
+export interface NumberRejectReason {
+    tag: NumberRejectReasonTag;
+    contents: number;
+}
+
+export interface SimpleRejectReason {
+    tag: SimpleRejectReasonTag;
+}
+
+export interface InvalidReceiveMethod {
+    tag: RejectReasonTag.InvalidReceiveMethod;
+    contents: {
+        moduleRef: string;
+        receiveName: string;
+    };
+}
+
+export interface InvalidInitMethod {
+    tag: RejectReasonTag.InvalidInitMethod;
+    contents: {
+        moduleRef: string;
+        initName: string;
+    };
+}
+
+export interface AmountTooLarge {
+    tag: RejectReasonTag.AmountTooLarge;
+    contents: {
+        address: string;
+        amount: string;
+    };
+}
+
+export interface InvalidContractAddress {
+    tag: RejectReasonTag.InvalidContractAddress;
+    contents: ContractAddress;
+}
+
+export type CredIdsRejectReasonTag =
+    | RejectReasonTag.DuplicateCredIDs
+    | RejectReasonTag.NonExistentCredIDs;
+
+export interface CredIdsRejectReason {
+    tag: CredIdsRejectReasonTag;
+    contents: string[];
+}
+
+export type RejectReason =
+    | SimpleRejectReason
+    | RejectedReceive
+    | RejectedInit
+    | StringRejectReason
+    | NumberRejectReason
+    | InvalidReceiveMethod
+    | InvalidInitMethod
+    | AmountTooLarge
+    | InvalidContractAddress
+    | CredIdsRejectReason;

--- a/packages/common/src/types/rejectReason.ts
+++ b/packages/common/src/types/rejectReason.ts
@@ -1,4 +1,9 @@
-import { AddressAccount } from '..';
+import {
+    Address,
+    Base58String,
+    DigitString,
+    HexString,
+} from '..';
 import type { ContractAddress } from '../types';
 
 /*
@@ -9,6 +14,7 @@ import type { ContractAddress } from '../types';
  * found here: https://github.com/Concordium/concordium-base/blob/main/haskell-src/Concordium/Types/Execution.hs
  */
 export enum RejectReasonTag {
+    // Module not "well formed", meaning it is not a valid smart contract
     ModuleNotWF = 'ModuleNotWF',
     ModuleHashAlreadyExists = 'ModuleHashAlreadyExists',
     InvalidAccountReference = 'InvalidAccountReference',
@@ -71,7 +77,7 @@ export interface RejectedReceive {
     contractAddress: ContractAddress;
     receiveName: string;
     rejectReason: number;
-    parameter: string;
+    parameter: HexString;
 }
 
 export interface RejectedInit {
@@ -137,7 +143,7 @@ export type StringRejectReasonTag =
 
 export interface StringRejectReason {
     tag: StringRejectReasonTag;
-    contents: string;
+    contents: HexString | Base58String;
 }
 export type NumberRejectReasonTag =
     | RejectReasonTag.AlreadyABaker
@@ -154,17 +160,17 @@ export interface SimpleRejectReason {
 
 export interface InvalidReceiveMethod {
     tag: RejectReasonTag.InvalidReceiveMethod;
-    contents: [string, string]; // [moduleRef, receiveName]
+    contents: [HexString, string]; // [moduleRef, receiveName]
 }
 
 export interface InvalidInitMethod {
     tag: RejectReasonTag.InvalidInitMethod;
-    contents: [string, string]; // [moduleRef, initName]
+    contents: [HexString, string]; // [moduleRef, initName]
 }
 
 export interface AmountTooLarge {
     tag: RejectReasonTag.AmountTooLarge;
-    contents: [AddressAccount, string]; // [address, amount] // TODO change to Address
+    contents: [Address, DigitString]; // [address, amount]
 }
 
 export interface InvalidContractAddress {

--- a/packages/common/src/types/rejectReason.ts
+++ b/packages/common/src/types/rejectReason.ts
@@ -1,3 +1,4 @@
+import { AddressAccount } from '..';
 import type { ContractAddress } from '../types';
 
 /*
@@ -153,26 +154,17 @@ export interface SimpleRejectReason {
 
 export interface InvalidReceiveMethod {
     tag: RejectReasonTag.InvalidReceiveMethod;
-    contents: {
-        moduleRef: string;
-        receiveName: string;
-    };
+    contents: [string, string] // [moduleRef, receiveName]
 }
 
 export interface InvalidInitMethod {
     tag: RejectReasonTag.InvalidInitMethod;
-    contents: {
-        moduleRef: string;
-        initName: string;
-    };
+    contents: [string, string] // [moduleRef, initName]
 }
 
 export interface AmountTooLarge {
     tag: RejectReasonTag.AmountTooLarge;
-    contents: {
-        address: string;
-        amount: string;
-    };
+    contents: [AddressAccount, string]; // [address, amount]
 }
 
 export interface InvalidContractAddress {

--- a/packages/common/src/types/rejectReason.ts
+++ b/packages/common/src/types/rejectReason.ts
@@ -154,17 +154,17 @@ export interface SimpleRejectReason {
 
 export interface InvalidReceiveMethod {
     tag: RejectReasonTag.InvalidReceiveMethod;
-    contents: [string, string] // [moduleRef, receiveName]
+    contents: [string, string]; // [moduleRef, receiveName]
 }
 
 export interface InvalidInitMethod {
     tag: RejectReasonTag.InvalidInitMethod;
-    contents: [string, string] // [moduleRef, initName]
+    contents: [string, string]; // [moduleRef, initName]
 }
 
 export interface AmountTooLarge {
     tag: RejectReasonTag.AmountTooLarge;
-    contents: [AddressAccount, string]; // [address, amount]
+    contents: [AddressAccount, string]; // [address, amount] // TODO change to Address
 }
 
 export interface InvalidContractAddress {

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -1,12 +1,16 @@
 import type {
     OpenStatusText,
     ContractAddress,
-    AddressAccount,
     ReleaseSchedule,
     DelegationTargetType,
     DelegationTargetPassiveDelegation,
+    ContractVersion,
+    Address,
+    Base58String,
+    HexString,
 } from '../types';
 import type { UpdateInstructionPayload } from './chainUpdate';
+import { ModuleReference } from './moduleReference';
 
 export enum TransactionEventTag {
     ModuleDeployed = 'ModuleDeployed',
@@ -44,6 +48,7 @@ export enum TransactionEventTag {
     Interrupted = 'Interrupted',
     Resumed = 'Resumed',
     Updated = 'Updated',
+    Upgraded = 'Upgraded',
 }
 
 export type TransactionEvent =
@@ -51,6 +56,7 @@ export type TransactionEvent =
     | UpdatedEvent
     | ResumedEvent
     | InterruptedEvent
+    | UpgradedEvent
     | MemoEvent
     | TransferredWithScheduleEvent
     | AccountCreatedEvent
@@ -85,7 +91,7 @@ export type TransactionEvent =
 export interface InterruptedEvent {
     tag: TransactionEventTag.Interrupted;
     address: ContractAddress;
-    events: string[];
+    events: HexString[];
 }
 
 export interface ResumedEvent {
@@ -97,16 +103,24 @@ export interface ResumedEvent {
 export interface UpdatedEvent {
     tag: TransactionEventTag.Updated;
     address: ContractAddress;
-    instigator: AddressAccount;
+    instigator: Address;
     amount: bigint;
-    message: string;
+    contractVersion: ContractVersion;
+    message: HexString;
     receiveName: string;
-    events: string[];
+    events: HexString[];
+}
+
+export interface UpgradedEvent {
+    tag: TransactionEventTag.Upgraded;
+    address: ContractAddress;
+    from: ModuleReference;
+    to: ModuleReference;
 }
 
 export interface DataRegisteredEvent {
     tag: TransactionEventTag.DataRegistered;
-    data: string;
+    data: HexString;
 }
 
 export interface ContractInitializedEvent {
@@ -114,12 +128,14 @@ export interface ContractInitializedEvent {
     address: ContractAddress;
     amount: bigint;
     contractName: string;
-    events: string[];
+    events: HexString[];
+    contractVersion?: ContractVersion;
+    originRef?: ModuleReference;
 }
 
 export interface ModuleDeployedEvent {
     tag: TransactionEventTag.ModuleDeployed;
-    contents: string;
+    contents: ModuleReference;
 }
 
 // Account and transfer Events
@@ -127,20 +143,20 @@ export interface ModuleDeployedEvent {
 export interface TransferredEvent {
     tag: TransactionEventTag.Transferred;
     amount: bigint;
-    to: AddressAccount;
-    from: AddressAccount;
+    to: Address;
+    from?: Address;
 }
 
 export interface TransferredWithScheduleEvent {
     tag: TransactionEventTag.TransferredWithSchedule;
-    to: AddressAccount;
-    from: AddressAccount;
+    to: Base58String;
+    from?: Base58String;
     amount: ReleaseSchedule[];
 }
 
 export interface MemoEvent {
     tag: TransactionEventTag.TransferMemo;
-    memo: string;
+    memo: HexString;
 }
 
 export interface AccountCreatedEvent {
@@ -178,20 +194,20 @@ export interface NewEncryptedAmountEvent {
 
 export interface CredentialDeployedEvent {
     tag: TransactionEventTag.CredentialDeployed;
-    regid: string;
-    account: string;
+    regid: HexString;
+    account: Base58String;
 }
 
 export interface CredentialKeysUpdatedEvent {
     tag: TransactionEventTag.CredentialKeysUpdated;
-    credId: string;
+    credId: HexString;
 }
 
 export interface CredentialsUpdatedEvent {
     tag: TransactionEventTag.CredentialsUpdated;
-    account: string;
-    newCredIds: string[];
-    removedCredIds: string[];
+    account?: Base58String;
+    newCredIds: HexString[];
+    removedCredIDs: HexString[];
     newThreshold: number;
 }
 
@@ -202,13 +218,13 @@ export interface DelegatorEvent {
         | TransactionEventTag.DelegationAdded
         | TransactionEventTag.DelegationRemoved;
     delegatorId: number;
-    account: string;
+    account: Base58String;
 }
 
 export interface DelegationSetDelegationTargetEvent {
     tag: TransactionEventTag.DelegationSetDelegationTarget;
     delegatorId: number;
-    account: string;
+    account: Base58String;
     delegationTarget:
         | {
               delegateType: DelegationTargetType.Baker;
@@ -220,7 +236,7 @@ export interface DelegationSetDelegationTargetEvent {
 export interface DelegationSetRestakeEarningsEvent {
     tag: TransactionEventTag.DelegationSetRestakeEarnings;
     delegatorId: number;
-    account: string;
+    account: Base58String;
     restakeEarnings: boolean;
 }
 
@@ -229,7 +245,7 @@ export interface DelegationStakeChangedEvent {
         | TransactionEventTag.DelegationStakeDecreased
         | TransactionEventTag.DelegationStakeIncreased;
     delegatorId: number;
-    account: string;
+    account: Base58String;
     newStake: bigint;
 }
 
@@ -249,7 +265,7 @@ export interface BakerAddedEvent {
 export interface BakerRemovedEvent {
     tag: TransactionEventTag.BakerRemoved;
     bakerId: number;
-    account: string;
+    account?: Base58String;
 }
 
 export interface BakerStakeChangedEvent {
@@ -257,58 +273,58 @@ export interface BakerStakeChangedEvent {
         | TransactionEventTag.BakerStakeIncreased
         | TransactionEventTag.BakerStakeDecreased;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     newStake: bigint;
 }
 
 export interface BakerSetRestakeEarningsEvent {
     tag: TransactionEventTag.BakerSetRestakeEarnings;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     restakeEarnings: boolean;
 }
 
 export interface BakerKeysUpdatedEvent {
     tag: TransactionEventTag.BakerKeysUpdated;
     bakerId: number;
-    account: string;
-    signKey: string;
-    electionKey: string;
-    aggregationKey: string;
+    account: Base58String;
+    signKey: HexString;
+    electionKey: HexString;
+    aggregationKey: HexString;
 }
 
 export interface BakerSetOpenStatusEvent {
     tag: TransactionEventTag.BakerSetOpenStatus;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     openStatus: OpenStatusText;
 }
 
 export interface BakerSetMetadataURLEvent {
     tag: TransactionEventTag.BakerSetMetadataURL;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     metadataURL: string;
 }
 
 export interface BakerSetFinalizationRewardCommissionEvent {
     tag: TransactionEventTag.BakerSetFinalizationRewardCommission;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     finalizationRewardCommission: number;
 }
 
 export interface BakerSetBakingRewardCommissionEvent {
     tag: TransactionEventTag.BakerSetBakingRewardCommission;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     bakingRewardCommission: number;
 }
 
 export interface BakerSetTransactionFeeCommissionEvent {
     tag: TransactionEventTag.BakerSetTransactionFeeCommission;
     bakerId: number;
-    account: string;
+    account?: Base58String;
     transactionFeeCommission: number;
 }
 

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -51,7 +51,9 @@ export type TransactionEvent =
     | MemoEvent
     | TransferredWithScheduleEvent
     | AmountEvent
-    | AccountEvent
+    | AccountCreatedEvent
+    | NewEncryptedAmountEvent
+    | EncryptedAmountsRemovedEvent
     | DataRegisteredEvent
     | ContractInitializedEvent
     | ModuleDeployedEvent
@@ -145,12 +147,24 @@ export interface AmountEvent {
     amount: bigint;
 }
 
-export interface AccountEvent {
-    tag:
-        | TransactionEventTag.AccountCreated
-        | TransactionEventTag.EncryptedAmountsRemoved
-        | TransactionEventTag.NewEncryptedAmount;
+export interface AccountCreatedEvent {
+    tag: TransactionEventTag.AccountCreated;
     account: string;
+}
+
+export interface EncryptedAmountsRemovedEvent {
+    tag: TransactionEventTag.EncryptedAmountsRemoved;
+    account: string;
+    inputAmount: string;
+    newAmount: string;
+    upToindex: number;
+}
+
+export interface NewEncryptedAmountEvent {
+    tag: TransactionEventTag.NewEncryptedAmount;
+    account: string;
+    newIndex: number;
+    encryptedAmount: string;
 }
 
 export interface CredentialDeployedEvent {

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -3,6 +3,8 @@ import type {
     ContractAddress,
     AddressAccount,
     ReleaseSchedule,
+    DelegationTargetType,
+    DelegationTargetPassiveDelegation,
 } from '../types';
 import type { UpdateInstructionPayload } from './chainUpdate';
 
@@ -207,7 +209,12 @@ export interface DelegationSetDelegationTargetEvent {
     tag: TransactionEventTag.DelegationSetDelegationTarget;
     delegatorId: number;
     account: string;
-    delegationTarget: number;
+    delegationTarget:
+        | {
+              delegateType: DelegationTargetType.Baker;
+              bakerId: number;
+          }
+        | DelegationTargetPassiveDelegation;
 }
 
 export interface DelegationSetRestakeEarningsEvent {

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -1,4 +1,5 @@
 import type {
+    OpenStatusText,
     ContractAddress,
     AddressAccount,
     ReleaseSchedule,
@@ -273,7 +274,7 @@ export interface BakerSetOpenStatusEvent {
     tag: TransactionEventTag.BakerSetOpenStatus;
     bakerId: number;
     account: string;
-    openStatus: string;
+    openStatus: OpenStatusText;
 }
 
 export interface BakerSetMetadataURLEvent {
@@ -287,21 +288,21 @@ export interface BakerSetFinalizationRewardCommissionEvent {
     tag: TransactionEventTag.BakerSetFinalizationRewardCommission;
     bakerId: number;
     account: string;
-    finalizationRewardCommission: string;
+    finalizationRewardCommission: number;
 }
 
 export interface BakerSetBakingRewardCommissionEvent {
     tag: TransactionEventTag.BakerSetBakingRewardCommission;
     bakerId: number;
     account: string;
-    bakingRewardCommission: string;
+    bakingRewardCommission: number;
 }
 
 export interface BakerSetTransactionFeeCommissionEvent {
     tag: TransactionEventTag.BakerSetTransactionFeeCommission;
     bakerId: number;
     account: string;
-    transactionFeeCommission: string;
+    transactionFeeCommission: number;
 }
 
 export interface UpdateEnqueuedEvent {

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -146,7 +146,7 @@ export interface AccountCreatedEvent {
 }
 
 export interface AmountAddedByDecryptionEvent {
-    tag: TransactionEventTag.AmountAddedByDecryption
+    tag: TransactionEventTag.AmountAddedByDecryption;
     account: string;
     amount: bigint;
 }
@@ -188,7 +188,7 @@ export interface CredentialsUpdatedEvent {
     tag: TransactionEventTag.CredentialsUpdated;
     account: string;
     newCredIds: string[];
-    removedCredIDs: string[];
+    removedCredIds: string[];
     newThreshold: number;
 }
 

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -327,3 +327,26 @@ export interface UpdateEnqueuedEvent {
     effectiveTime: string;
     payload: UpdateInstructionPayload;
 }
+
+export type ContractTraceEvent =
+    | ResumedEvent
+    | InterruptedEvent
+    | UpdatedEvent
+    | UpgradedEvent
+    | TransferredEvent;
+export type BakerEvent =
+    | BakerSetTransactionFeeCommissionEvent
+    | BakerSetBakingRewardCommissionEvent
+    | BakerSetFinalizationRewardCommissionEvent
+    | BakerSetMetadataURLEvent
+    | BakerSetOpenStatusEvent
+    | BakerSetRestakeEarningsEvent
+    | BakerStakeChangedEvent
+    | BakerAddedEvent
+    | BakerRemovedEvent
+    | BakerKeysUpdatedEvent;
+export type DelegationEvent =
+    | DelegatorEvent
+    | DelegationSetDelegationTargetEvent
+    | DelegationSetRestakeEarningsEvent
+    | DelegationStakeChangedEvent;

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -1,0 +1,291 @@
+import type {
+    ContractAddress,
+    AddressAccount,
+    ReleaseSchedule,
+} from '../types';
+import type { UpdateInstructionPayload } from './chainUpdate';
+
+export enum TransactionEventTag {
+    ModuleDeployed = 'ModuleDeployed',
+    ContractInitialized = 'ContractInitialized',
+    AccountCreated = 'AccountCreated',
+    CredentialDeployed = 'CredentialDeployed',
+    BakerAdded = 'BakerAdded',
+    BakerRemoved = 'BakerRemoved',
+    BakerStakeIncreased = 'BakerStakeIncreased',
+    BakerStakeDecreased = 'BakerStakeDecreased',
+    BakerSetRestakeEarnings = 'BakerSetRestakeEarnings',
+    BakerKeysUpdated = 'BakerKeysUpdated',
+    CredentialKeysUpdated = 'CredentialKeysUpdated',
+    NewEncryptedAmount = 'NewEncryptedAmount',
+    EncryptedAmountsRemoved = 'EncryptedAmountsRemoved',
+    AmountAddedByDecryption = 'AmountAddedByDecryption',
+    EncryptedSelfAmountAdded = 'EncryptedSelfAmountAdded',
+    UpdateEnqueued = 'UpdateEnqueued',
+    TransferredWithSchedule = 'TransferredWithSchedule',
+    CredentialsUpdated = 'CredentialsUpdated',
+    DataRegistered = 'DataRegistered',
+    BakerSetOpenStatus = 'BakerSetOpenStatus',
+    BakerSetMetadataURL = 'BakerSetMetadataURL',
+    BakerSetTransactionFeeCommission = 'BakerSetTransactionFeeCommission',
+    BakerSetBakingRewardCommission = 'BakerSetBakingRewardCommission',
+    BakerSetFinalizationRewardCommission = 'BakerSetFinalizationRewardCommission',
+    DelegationStakeIncreased = 'DelegationStakeIncreased',
+    DelegationStakeDecreased = 'DelegationStakeDecreased',
+    DelegationSetRestakeEarnings = 'DelegationSetRestakeEarnings',
+    DelegationSetDelegationTarget = 'DelegationSetDelegationTarget',
+    DelegationAdded = 'DelegationAdded',
+    DelegationRemoved = 'DelegationRemoved',
+    TransferMemo = 'TransferMemo',
+    Transferred = 'Transferred',
+    Interrupted = 'Interrupted',
+    Resumed = 'Resumed',
+    Updated = 'Updated',
+}
+
+export type TransactionEvent =
+    | TransferredEvent
+    | UpdatedEvent
+    | ResumedEvent
+    | InterruptedEvent
+    | MemoEvent
+    | TransferredWithScheduleEvent
+    | AmountEvent
+    | AccountEvent
+    | DataRegisteredEvent
+    | ContractInitializedEvent
+    | ModuleDeployedEvent
+    | CredentialDeployedEvent
+    | CredentialKeysUpdatedEvent
+    | CredentialsUpdatedEvent
+    | DelegatorEvent
+    | DelegationSetDelegationTargetEvent
+    | DelegationSetRestakeEarningsEvent
+    | DelegationStakeChangedEvent
+    | BakerAddedEvent
+    | BakerRemovedEvent
+    | BakerStakeChangedEvent
+    | BakerSetRestakeEarningsEvent
+    | BakerKeysUpdatedEvent
+    | BakerSetOpenStatusEvent
+    | BakerSetMetadataURLEvent
+    | BakerSetFinalizationRewardCommissionEvent
+    | BakerSetBakingRewardCommissionEvent
+    | BakerSetTransactionFeeCommissionEvent
+    | UpdateEnqueuedEvent;
+
+// Contract Events
+
+export interface InterruptedEvent {
+    tag: TransactionEventTag.Interrupted;
+    address: ContractAddress;
+    events: string[];
+}
+
+export interface ResumedEvent {
+    tag: TransactionEventTag.Resumed;
+    address: ContractAddress;
+    success: boolean;
+}
+
+export interface UpdatedEvent {
+    tag: TransactionEventTag.Updated;
+    address: ContractAddress;
+    instigator: AddressAccount;
+    amount: bigint;
+    message: string;
+    receiveName: string;
+    events: [string];
+}
+
+export interface DataRegisteredEvent {
+    tag: TransactionEventTag.DataRegistered;
+    data: string;
+}
+
+export interface ContractInitializedEvent {
+    tag: TransactionEventTag.ContractInitialized;
+    address: ContractAddress;
+    amount: bigint;
+    contractName: string;
+    events: [string];
+}
+
+export interface ModuleDeployedEvent {
+    tag: TransactionEventTag.ModuleDeployed;
+    contents: string;
+}
+
+// Account and transfer Events
+
+export interface TransferredEvent {
+    tag: TransactionEventTag.Transferred;
+    amount: bigint;
+    to: AddressAccount;
+    from: AddressAccount;
+}
+
+export interface TransferredWithScheduleEvent {
+    tag: TransactionEventTag.TransferredWithSchedule;
+    to: AddressAccount;
+    from: AddressAccount;
+    amount: ReleaseSchedule[];
+}
+
+export interface MemoEvent {
+    tag: TransactionEventTag.TransferMemo;
+    memo: string;
+}
+
+export interface AmountEvent {
+    tag:
+        | TransactionEventTag.AmountAddedByDecryption
+        | TransactionEventTag.EncryptedSelfAmountAdded;
+    account: string;
+    amount: bigint;
+}
+
+export interface AccountEvent {
+    tag:
+        | TransactionEventTag.AccountCreated
+        | TransactionEventTag.EncryptedAmountsRemoved
+        | TransactionEventTag.NewEncryptedAmount;
+    account: string;
+}
+
+export interface CredentialDeployedEvent {
+    tag: TransactionEventTag.CredentialDeployed;
+    regid: string;
+    account: string;
+}
+
+export interface CredentialKeysUpdatedEvent {
+    tag: TransactionEventTag.CredentialKeysUpdated;
+    credId: string;
+}
+
+export interface CredentialsUpdatedEvent {
+    tag: TransactionEventTag.CredentialsUpdated;
+    account: string;
+    newCredIds: string[];
+    removedCredIDs: string[];
+    newThreshold: number;
+}
+
+// Delegation Events
+
+export interface DelegatorEvent {
+    tag:
+        | TransactionEventTag.DelegationAdded
+        | TransactionEventTag.DelegationRemoved;
+    delegatorId: number;
+    account: string;
+}
+
+export interface DelegationSetDelegationTargetEvent {
+    tag: TransactionEventTag.DelegationSetDelegationTarget;
+    delegatorId: number;
+    account: string;
+    delegationTarget: number;
+}
+
+export interface DelegationSetRestakeEarningsEvent {
+    tag: TransactionEventTag.DelegationSetRestakeEarnings;
+    delegatorId: number;
+    account: string;
+    restakeEarnings: boolean;
+}
+
+export interface DelegationStakeChangedEvent {
+    tag:
+        | TransactionEventTag.DelegationStakeDecreased
+        | TransactionEventTag.DelegationStakeIncreased;
+    delegatorId: number;
+    account: string;
+    newStake: bigint;
+}
+
+// Baker Events
+
+export interface BakerAddedEvent {
+    tag: TransactionEventTag.BakerAdded;
+    bakerId: number;
+    account: string;
+    signKey: string;
+    electionKey: string;
+    aggregationKey: string;
+    stake: bigint;
+    restakeEarnings: boolean;
+}
+
+export interface BakerRemovedEvent {
+    tag: TransactionEventTag.BakerRemoved;
+    bakerId: number;
+    account: string;
+}
+
+export interface BakerStakeChangedEvent {
+    tag:
+        | TransactionEventTag.BakerStakeIncreased
+        | TransactionEventTag.BakerStakeDecreased;
+    bakerId: number;
+    account: string;
+    newStake: bigint;
+}
+
+export interface BakerSetRestakeEarningsEvent {
+    tag: TransactionEventTag.BakerSetRestakeEarnings;
+    bakerId: number;
+    account: string;
+    restakeEarnings: boolean;
+}
+
+export interface BakerKeysUpdatedEvent {
+    tag: TransactionEventTag.BakerKeysUpdated;
+    bakerId: number;
+    account: string;
+    signKey: string;
+    electionKey: string;
+    aggregationKey: string;
+}
+
+export interface BakerSetOpenStatusEvent {
+    tag: TransactionEventTag.BakerSetOpenStatus;
+    bakerId: number;
+    account: string;
+    openStatus: string;
+}
+
+export interface BakerSetMetadataURLEvent {
+    tag: TransactionEventTag.BakerSetMetadataURL;
+    bakerId: number;
+    account: string;
+    metadataURL: string;
+}
+
+export interface BakerSetFinalizationRewardCommissionEvent {
+    tag: TransactionEventTag.BakerSetFinalizationRewardCommission;
+    bakerId: number;
+    account: string;
+    finalizationRewardCommission: string;
+}
+
+export interface BakerSetBakingRewardCommissionEvent {
+    tag: TransactionEventTag.BakerSetBakingRewardCommission;
+    bakerId: number;
+    account: string;
+    bakingRewardCommission: string;
+}
+
+export interface BakerSetTransactionFeeCommissionEvent {
+    tag: TransactionEventTag.BakerSetTransactionFeeCommission;
+    bakerId: number;
+    account: string;
+    transactionFeeCommission: string;
+}
+
+export interface UpdateEnqueuedEvent {
+    tag: TransactionEventTag.UpdateEnqueued;
+    effectiveTime: string;
+    payload: UpdateInstructionPayload;
+}

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -164,7 +164,7 @@ export interface EncryptedAmountsRemovedEvent {
     account: string;
     inputAmount: string;
     newAmount: string;
-    upToindex: number;
+    upToIndex: number;
 }
 
 export interface NewEncryptedAmountEvent {

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -95,7 +95,7 @@ export interface UpdatedEvent {
     amount: bigint;
     message: string;
     receiveName: string;
-    events: [string];
+    events: string[];
 }
 
 export interface DataRegisteredEvent {
@@ -108,7 +108,7 @@ export interface ContractInitializedEvent {
     address: ContractAddress;
     amount: bigint;
     contractName: string;
-    events: [string];
+    events: string[];
 }
 
 export interface ModuleDeployedEvent {

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -2,12 +2,11 @@ import type {
     OpenStatusText,
     ContractAddress,
     ReleaseSchedule,
-    DelegationTargetType,
-    DelegationTargetPassiveDelegation,
     ContractVersion,
     Address,
     Base58String,
     HexString,
+    EventDelegationTarget,
 } from '../types';
 import type { UpdateInstructionPayload } from './chainUpdate';
 import { ModuleReference } from './moduleReference';
@@ -161,35 +160,35 @@ export interface MemoEvent {
 
 export interface AccountCreatedEvent {
     tag: TransactionEventTag.AccountCreated;
-    account: string;
+    account: Base58String;
 }
 
 export interface AmountAddedByDecryptionEvent {
     tag: TransactionEventTag.AmountAddedByDecryption;
-    account: string;
+    account?: Base58String;
     amount: bigint;
 }
 
 export interface EncryptedSelfAmountAddedEvent {
     tag: TransactionEventTag.EncryptedSelfAmountAdded;
-    account: string;
+    account: Base58String;
     amount: bigint;
     newAmount: string;
 }
 
 export interface EncryptedAmountsRemovedEvent {
     tag: TransactionEventTag.EncryptedAmountsRemoved;
-    account: string;
-    inputAmount: string;
-    newAmount: string;
-    upToIndex: number;
+    account?: Base58String;
+    inputAmount: HexString;
+    newAmount: HexString;
+    upToindex: number;
 }
 
 export interface NewEncryptedAmountEvent {
     tag: TransactionEventTag.NewEncryptedAmount;
-    account: string;
+    account: Base58String;
     newIndex: number;
-    encryptedAmount: string;
+    encryptedAmount: HexString;
 }
 
 export interface CredentialDeployedEvent {
@@ -218,25 +217,20 @@ export interface DelegatorEvent {
         | TransactionEventTag.DelegationAdded
         | TransactionEventTag.DelegationRemoved;
     delegatorId: number;
-    account: Base58String;
+    account?: Base58String;
 }
 
 export interface DelegationSetDelegationTargetEvent {
     tag: TransactionEventTag.DelegationSetDelegationTarget;
     delegatorId: number;
-    account: Base58String;
-    delegationTarget:
-        | {
-              delegateType: DelegationTargetType.Baker;
-              bakerId: number;
-          }
-        | DelegationTargetPassiveDelegation;
+    account?: Base58String;
+    delegationTarget: EventDelegationTarget;
 }
 
 export interface DelegationSetRestakeEarningsEvent {
     tag: TransactionEventTag.DelegationSetRestakeEarnings;
     delegatorId: number;
-    account: Base58String;
+    account?: Base58String;
     restakeEarnings: boolean;
 }
 
@@ -245,7 +239,7 @@ export interface DelegationStakeChangedEvent {
         | TransactionEventTag.DelegationStakeDecreased
         | TransactionEventTag.DelegationStakeIncreased;
     delegatorId: number;
-    account: Base58String;
+    account?: Base58String;
     newStake: bigint;
 }
 

--- a/packages/common/src/types/transactionEvent.ts
+++ b/packages/common/src/types/transactionEvent.ts
@@ -50,8 +50,9 @@ export type TransactionEvent =
     | InterruptedEvent
     | MemoEvent
     | TransferredWithScheduleEvent
-    | AmountEvent
     | AccountCreatedEvent
+    | AmountAddedByDecryptionEvent
+    | EncryptedSelfAmountAddedEvent
     | NewEncryptedAmountEvent
     | EncryptedAmountsRemovedEvent
     | DataRegisteredEvent
@@ -139,17 +140,22 @@ export interface MemoEvent {
     memo: string;
 }
 
-export interface AmountEvent {
-    tag:
-        | TransactionEventTag.AmountAddedByDecryption
-        | TransactionEventTag.EncryptedSelfAmountAdded;
+export interface AccountCreatedEvent {
+    tag: TransactionEventTag.AccountCreated;
+    account: string;
+}
+
+export interface AmountAddedByDecryptionEvent {
+    tag: TransactionEventTag.AmountAddedByDecryption
     account: string;
     amount: bigint;
 }
 
-export interface AccountCreatedEvent {
-    tag: TransactionEventTag.AccountCreated;
+export interface EncryptedSelfAmountAddedEvent {
+    tag: TransactionEventTag.EncryptedSelfAmountAdded;
     account: string;
+    amount: bigint;
+    newAmount: string;
 }
 
 export interface EncryptedAmountsRemovedEvent {

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 6.3.0
+
+### Added Changes
+- Added more GRPCv2 functions:
+    - `getNextAccountSequenceNumber()`
+    - `getAccountInfo()`
+    - `getBlockItemStatus()`
+    - `getConsensusInfo()`
+    - `getModuleSource()`
+    - `getInstanceInfo()`
+    - `invokeInstance()`
+    - `getAccountTransactionSignHash()`
+    - `sendAccountTransaction()`
+    - `sendCredentialDeploymentTransaction()`
+
 ## 6.2.0
 
 ### Added Changes

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -15,6 +15,10 @@
     - `sendAccountTransaction()`
     - `sendCredentialDeploymentTransaction()`
 
+### Fixed
+
+- Amount fields in events in invokeContract in GRPC v1 was string values instead of bigint as the type indicated.
+
 ## 6.2.0
 
 ### Added Changes

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -6,14 +6,19 @@ Wrappers for interacting with the Concordium node, using nodejs.
 
 [Note that this package contains and exports the functions from the common-sdk, check the readme of that package for an overview of those](../common/README.md).
 
-
 **Table of Contents**
 - [ConcordiumNodeClient](#concordiumnodeclient)
     - [Creating a client](#creating-a-client)
+    - [Send Account Transaction](#send-account-transaction)
     - [Create a new account](#create-a-new-account)
     - [getAccountInfo](#getaccountinfo)
     - [getNextAccountSequenceNumber](#getnextaccountsequencenumber)
+    - [getBlockItemStatus](#getblockitemstatus)
+    - [getConsensusStatus](#getconsensusstatus)
     - [getCryptographicParameters](#getcryptographicparameters)
+    - [getInstanceInfo](#getinstanceinfo)
+    - [invokeContract](#invokecontract)
+    - [getModuleSource](#getModuleSource)
 
 # ConcordiumNodeClient
 
@@ -41,6 +46,33 @@ const client = new ConcordiumNodeClient(
 
 The access is controlled by the credentials and the metadata. If the node does not support TLS an insecure connection can be established using `credentials.createInsecure()` instead of `credentials.createSsl()`.
 
+## Send Account Transaction
+The following example demonstrates how to send any account transaction.
+
+See the Constructing transactions section for the [common package](../common#constructing-transactions) for how to create an account transaction.
+See the signing a transaction section for the [common package](../common#sign-an-account-transaction) for how to sign an account transaction.
+
+```js
+
+let accountTransaction: AccountTransaction;
+// Create the transaction
+// ...
+
+let signatures: AccountTransactionSignature;
+// Sign the transaction
+// ...
+
+// Send the transaction to the node, throws on rejection.
+const transactionHash = await client.sendAccountTransaction(accountTransaction, signatures);
+
+// Check the status of the transaction. Should be checked with an appropriate interval,
+// as it will take some time for the transaction to be processed.
+const transactionStatus = await client.getBlockItemStatus(transactionHash);
+```
+
+## Create a new account
+**TODO**
+
 ## getAccountInfo
 Retrieves information about an account. The function must be provided an account address or a credential registration id.
 If a credential registration id is provided, then the node returns the information of the account,
@@ -48,8 +80,8 @@ which the corresponding credential is (or was) deployed to.
 If there is no account that matches the address or credential id at the provided
 block, then undefined will be returned.
 ```js
-const accountAddress = new AccountAddress('3sAHwfehRNEnXk28W7A3XB3GzyBiuQkXLNRmDwDGPUe8JsoAcU');
-const blockHash = Buffer.from('6b01f2043d5621192480f4223644ef659dd5cda1e54a78fc64ad642587c73def', 'hex');
+const accountAddress = new AccountAddress('3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G');
+const blockHash = Buffer.from('fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e', 'hex');
 const accountInfo: AccountInfo = await client.getAccountInfo(accountAddress, blockHash);
 const amount: bigint = accountInfo.amount?.value;
 ```
@@ -60,7 +92,7 @@ header for the next transaction submitted by that account. Along with the sequen
 that indicates whether all transactions are finalized. If this is true, then the sequence number is reliable,
 if not then the next sequence number might be off.
 ```js
-const accountAddress = new AccountAddress('3VwCfvVskERFAJ3GeJy2mNFrzfChqUymSJJCvoLAP9rtAwMGYt');
+const accountAddress = new AccountAddress('3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G');
 const nextAccountSequenceNumber: NextAccountSequenceNumber = await client.getNextAccountSequenceNumber(accountAddress);
 const sequenceNumber: bigint = nextAccountsequenceNumber.sequenceNumber?.value;
 const allFinal: boolean = nextAccountSequenceNumber.allFinal;
@@ -69,11 +101,100 @@ if (allFinal) {
 }
 ```
 
+## getBlockItemStatus
+Retrieves status information about a block item (transaction).
+```js
+const transactionHash = Buffer.from('f1f5f966e36b95d5474e6b85b85c273c81bac347c38621a0d8fefe68b69a430f', 'hex');
+const blockItemStatus: BlockItemStatus = await client.getBlockItemStatus(transactionHash);
+const isFinalized = transactionStatus.status.oneofKind === 'finalized';
+...
+```
+Note that there will be no outcomes for a transaction that has only been received:
+```js
+if (blockItemStatus.status.oneofKind === 'received') {
+    // blockItemStatus.status.received will be empty
+}
+```
+If the transaction has been finalized, then there is exactly one outcome:
+```js
+if (blockItemStatus.status.oneofKind === 'finalized') {
+    const outcomes = blockItemStatus.status.finalized.outcome;
+    // Only one outcome
+}
+```
+
+## getConsensusInfo
+Retrieves the current consensus info from the node.
+```js
+const consensusInfo: ConsensusInfo = await client.getConsensusInfo();
+const bestBlock = consensusInfo.bestBlock?.value;
+...
+```
+
 ## getCryptographicParameters
 Retrieves the global cryptographic parameters for the blockchain at a specific block.
 These are a required input for e.g. creating credentials.
 ```js
-const blockHash = Buffer.from('7f7409679e53875567e2ae812c9fcefe90ced8761d08554756f42bf268a42749', 'hex')
+const blockHash = Buffer.from('fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e', 'hex');
 const cryptographicParameters: CryptographicParameters = await client.getCryptographicParameters(blockHash);
 ...
+```
+
+## getInstanceInfo
+Used to get information about a specific contract instance, at a specific block.
+
+```js
+const blockHash = Buffer.from('fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e', 'hex');
+const contractAddress: ContractAddress = { index: 1n, subindex: 0n };
+
+const instanceInfo: InstanceInfo = await client.getInstanceInfo(contractAddress, blockHash);
+const name = instanceInfo.name;
+...
+```
+
+## invokeContract
+Used to simulate a contract update, and to trigger view functions.
+
+```js
+const instance: ContractAddress = { index: 1n, subindex: 0n };
+const amount = 42n;
+const entrypoint = 'Piggybank.insert';
+const parameter = new Uint8Array();
+const energy = 30000n;
+const invoker = new AccountAddress('3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G');
+const blockHash = Buffer.from('fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e', 'hex');
+
+const result = await client.invokeContract(
+        instance,
+        amount,
+        entrypoint,
+        parameter: Uint8Array,
+        energy: bigint,
+        invoker?: Address,
+        blockHash?: Uint8Array
+);
+
+if (response.result.oneofKind === 'failure') {
+    // Invoke was unsuccesful
+    const rejectReason = response.result.failure.reason; // Describes why the update failed;
+    ...
+} else if (response.result.oneofKind === 'success') {
+    const events = response.result.success.effects; // a list of effects that the update would have
+    const returnValue = response.result.success.returnValue; // If the invoked method has return value
+    ...
+}
+```
+
+Note that some of the parts of the context are optional:
+ - blockHash: defaults to last finalized block
+ - invoker: uses the zero account address, which can be used instead of finding a random address.
+
+## getModuleSource
+This commands gets the source of a module on the chain.
+
+Note that this returns the raw bytes of the source, as a Uint8Array.
+```js
+const blockHash = Buffer.from('fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e', 'hex');
+const moduleRef = Buffer.from('7e8398adc406a97db4d869c3fd7adc813a3183667a3a7db078ebae6f7dce5f64', 'hex');
+const source = await client.getModuleSource(moduleReference, blockHash);
 ```

--- a/packages/nodejs/grpc-migration.md
+++ b/packages/nodejs/grpc-migration.md
@@ -2,3 +2,9 @@
 
 ## General:
 Blockhash inputs are now optional, and if given must be given as a hex encoded string. If the blockhash is not given the function will use the last final block.
+
+## getTransactionStatus
+
+The `getTransactionStatus` has been replaced with the `getBlockItemStatus`.
+
+The `GetBlockItemStatus` endpoints has the same information, but has a simpler structure, with better typing.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {
         "@noble/ed25519": "^1.7.1",
         "@protobuf-ts/plugin": "2.8.1",
+        "@types/bs58check": "^2.1.0",
         "@types/google-protobuf": "^3.15.3",
         "@types/jest": "^26.0.23",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -60,6 +61,7 @@
         "@concordium/common-sdk": "6.2.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpc-transport": "2.8.1",
+        "bs58check": "^2.1.2",
         "buffer": "^6.0.3",
         "google-protobuf": "^3.20.1"
     }

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -871,7 +871,12 @@ export default class ConcordiumNodeClient {
             this.client.invokeContract,
             requestObject
         );
-        const bigIntPropertyKeys = ['usedEnergy', 'index', 'subindex', 'amount'];
+        const bigIntPropertyKeys = [
+            'usedEnergy',
+            'index',
+            'subindex',
+            'amount',
+        ];
         return unwrapJsonResponse<InvokeContractResult>(
             response,
             buildJsonResponseReviver([], bigIntPropertyKeys),

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -871,7 +871,7 @@ export default class ConcordiumNodeClient {
             this.client.invokeContract,
             requestObject
         );
-        const bigIntPropertyKeys = ['usedEnergy', 'index', 'subindex'];
+        const bigIntPropertyKeys = ['usedEnergy', 'index', 'subindex', 'amount'];
         return unwrapJsonResponse<InvokeContractResult>(
             response,
             buildJsonResponseReviver([], bigIntPropertyKeys),

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -2,7 +2,7 @@ import { ChannelCredentials, Metadata } from '@grpc/grpc-js';
 import * as v1 from '@concordium/common-sdk';
 import * as v2 from '../grpc/v2/concordium/types';
 import * as translate from './typeTranslation';
-import { calculateEnergyCost, getAccountTransactionHandler, HexString, serializeAccountTransactionPayload, serializeCredentialDeploymentPayload } from '@concordium/common-sdk';
+import { calculateEnergyCost, getAccountTransactionHandler, HexString } from '@concordium/common-sdk';
 import { QueriesClient } from '../grpc/v2/concordium/service.client';
 import { GrpcTransport } from '@protobuf-ts/grpc-transport';
 import { getBlockHashInput, getAccountIdentifierInput, assertValidHash, assertValidModuleRef, translateSignature } from './util';
@@ -259,7 +259,7 @@ export default class ConcordiumNodeClient {
         transaction: v1.AccountTransaction,
         signature: v1.AccountTransactionSignature
     ): Promise<Uint8Array> {
-        const rawPayload = serializeAccountTransactionPayload(transaction);
+        const rawPayload = v1.serializeAccountTransactionPayload(transaction);
         const transactionSignature: v2.AccountTransactionSignature =
             translateSignature(signature);
 
@@ -316,7 +316,7 @@ export default class ConcordiumNodeClient {
         credentialDeploymentTransaction: v1.CredentialDeploymentTransaction,
         signatures: string[]
     ): Promise<Uint8Array> {
-        const payloadHex = serializeCredentialDeploymentPayload(
+        const payloadHex = v1.serializeCredentialDeploymentPayload(
             signatures,
             credentialDeploymentTransaction
         );

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -2,10 +2,20 @@ import { ChannelCredentials, Metadata } from '@grpc/grpc-js';
 import * as v1 from '@concordium/common-sdk';
 import * as v2 from '../grpc/v2/concordium/types';
 import * as translate from './typeTranslation';
-import { calculateEnergyCost, getAccountTransactionHandler, HexString } from '@concordium/common-sdk';
+import {
+    calculateEnergyCost,
+    getAccountTransactionHandler,
+    HexString,
+} from '@concordium/common-sdk';
 import { QueriesClient } from '../grpc/v2/concordium/service.client';
 import { GrpcTransport } from '@protobuf-ts/grpc-transport';
-import { getBlockHashInput, getAccountIdentifierInput, assertValidHash, assertValidModuleRef, translateSignature } from './util';
+import {
+    getBlockHashInput,
+    getAccountIdentifierInput,
+    assertValidHash,
+    assertValidModuleRef,
+    translateSignature,
+} from './util';
 import { countSignatures } from '@concordium/common-sdk/src/util';
 
 /**
@@ -132,11 +142,10 @@ export default class ConcordiumNodeClient {
     ): Promise<v2.BlockItemStatus> {
         assertValidHash(transactionHash);
         const transactionHashV2: v2.TransactionHash = {
-            value: Buffer.from(transactionHash, 'hex')
-        }
+            value: Buffer.from(transactionHash, 'hex'),
+        };
 
-        return await this.client.getBlockItemStatus(transactionHashV2)
-            .response;
+        return await this.client.getBlockItemStatus(transactionHashV2).response;
     }
 
     /**

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -13,7 +13,6 @@ import {
     getBlockHashInput,
     getAccountIdentifierInput,
     assertValidHash,
-    translateSignature,
 } from './util';
 import { countSignatures } from '@concordium/common-sdk/src/util';
 
@@ -259,7 +258,7 @@ export default class ConcordiumNodeClient {
     ): Promise<HexString> {
         const rawPayload = v1.serializeAccountTransactionPayload(transaction);
         const transactionSignature: v2.AccountTransactionSignature =
-            translateSignature(signature);
+            translate.accountTransactionSignatureToV2(signature);
 
         // Energy cost
         const accountTransactionHandler = getAccountTransactionHandler(

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -240,7 +240,7 @@ export default class ConcordiumNodeClient {
         const response = await this.client.invokeInstance(invokeInstanceRequest)
             .response;
         return translate.invokeInstanceResponse(response);
-   }
+    }
 
     /**
      * Serializes and sends an account transaction to the node to be

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -195,13 +195,15 @@ export default class ConcordiumNodeClient {
     async getInstanceInfo(
         contractAddress: v1.ContractAddress,
         blockHash?: HexString
-    ): Promise<v2.InstanceInfo> {
+    ): Promise<v1.InstanceInfo> {
         const instanceInfoRequest: v2.InstanceInfoRequest = {
             blockHash: getBlockHashInput(blockHash),
             address: contractAddress,
         };
 
-        return await this.client.getInstanceInfo(instanceInfoRequest).response;
+        const response = await this.client.getInstanceInfo(instanceInfoRequest)
+            .response;
+        return translate.instanceInfo(response);
     }
 
     /**

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -138,14 +138,14 @@ export default class ConcordiumNodeClient {
     }
 
     async getModuleSource(
-        blockHash: HexString,
-        moduleRef: Uint8Array
+        moduleRef: Uint8Array,
+        blockHash?: HexString
     ): Promise<v2.VersionedModuleSource> {
         const blockHashInput = getBlockHashInput(blockHash);
         assertValidModuleRef(moduleRef);
 
-        const moduleSourceRequest = {
-            blockHashInput: blockHashInput,
+        const moduleSourceRequest: v2.ModuleSourceRequest = {
+            blockHash: blockHashInput,
             moduleRef: { value: moduleRef },
         };
 
@@ -153,13 +153,13 @@ export default class ConcordiumNodeClient {
     }
 
     async getInstanceInfo(
-        blockHash: HexString,
-        contractAddress: v1.ContractAddress
+        contractAddress: v2.ContractAddress,
+        blockHash?: HexString
     ): Promise<v2.InstanceInfo> {
         const blockHashInput = getBlockHashInput(blockHash);
 
-        const instanceInfoRequest = {
-            blockHashInput: blockHashInput,
+        const instanceInfoRequest: v2.InstanceInfoRequest = {
+            blockHash: blockHashInput,
             address: contractAddress,
         };
 
@@ -167,18 +167,18 @@ export default class ConcordiumNodeClient {
     }
 
     async invokeInstance(
-        blockHash: HexString,
-        instance: v1.ContractAddress,
+        instance: v2.ContractAddress,
         amount: bigint,
         entrypoint: string,
         parameter: Uint8Array,
         energy: bigint,
-        invoker?: v2.Address
+        invoker?: v2.Address,
+        blockHash?: HexString
     ): Promise<v2.InvokeInstanceResponse> {
         const blockHashInput = getBlockHashInput(blockHash);
         assertAmount(amount);
 
-        const request: v2.InvokeInstanceRequest = {
+        const invokeInstanceRequest: v2.InvokeInstanceRequest = {
             blockHash: blockHashInput,
             invoker: invoker,
             instance: instance,
@@ -188,6 +188,6 @@ export default class ConcordiumNodeClient {
             energy: { value: energy },
         };
 
-        return await this.client.invokeInstance(request).response;
+        return await this.client.invokeInstance(invokeInstanceRequest).response;
     }
 }

--- a/packages/nodejs/src/clientV2.ts
+++ b/packages/nodejs/src/clientV2.ts
@@ -137,13 +137,15 @@ export default class ConcordiumNodeClient {
      */
     async getBlockItemStatus(
         transactionHash: HexString
-    ): Promise<v2.BlockItemStatus> {
+    ): Promise<v1.BlockItemStatus> {
         assertValidHash(transactionHash);
         const transactionHashV2: v2.TransactionHash = {
             value: Buffer.from(transactionHash, 'hex'),
         };
 
-        return await this.client.getBlockItemStatus(transactionHashV2).response;
+        const response = await this.client.getBlockItemStatus(transactionHashV2)
+            .response;
+        return translate.blockItemStatus(response);
     }
 
     /**

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -348,3 +348,16 @@ export function consensusInfo(ci: v2.ConsensusInfo): v1.ConsensusStatus {
         }),
     };
 }
+
+export function accountTransactionSignatureToV2(
+    signature: v1.AccountTransactionSignature
+): v2.AccountTransactionSignature {
+    function transSig(a: string): v2.Signature {
+        return { value: Buffer.from(a, 'hex') };
+    }
+    function transCredSig(a: v1.CredentialSignature): v2.AccountSignatureMap {
+        return { signatures: mapRecord(a, transSig) };
+    }
+
+    return { signatures: mapRecord(signature, transCredSig) };
+}

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -451,7 +451,7 @@ function trContractTraceElement(
             };
         default:
             throw Error(
-                'Invalid ContractTraceElement received, not able to tr to Transaction Event!'
+                'Invalid ContractTraceElement received, not able to translate to Transaction Event!'
             );
     }
 }

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -1536,47 +1536,53 @@ function transBlockItemSummaryInBlock(
 export function blockItemStatus(
     itemStatus: v2.BlockItemStatus
 ): v1.BlockItemStatus {
-    switch(itemStatus.status.oneofKind) {
+    switch (itemStatus.status.oneofKind) {
         case 'received':
             return {
                 status: v1.TransactionStatusEnum.Received,
             };
-       case 'committed':
+        case 'committed':
             return {
                 status: v1.TransactionStatusEnum.Committed,
                 outcomes: itemStatus.status.committed.outcomes.map(
                     transBlockItemSummaryInBlock
                 ),
             };
-       case 'finalized':
+        case 'finalized':
             return {
                 status: v1.TransactionStatusEnum.Finalized,
                 outcome: transBlockItemSummaryInBlock(
                     unwrap(itemStatus.status.finalized.outcome)
                 ),
             };
-       default:
+        default:
             throw Error('BlockItemStatus was undefined!');
     }
 }
 
-export function invokeInstanceResponse(invokeResponse: v2.InvokeInstanceResponse): v1.InvokeContractResult  {
+export function invokeInstanceResponse(
+    invokeResponse: v2.InvokeInstanceResponse
+): v1.InvokeContractResult {
     switch (invokeResponse.result.oneofKind) {
         case 'failure':
             return {
                 tag: 'failure',
-                usedEnergy: unwrap(invokeResponse.result.failure.usedEnergy?.value),
-                reason: transRejectReason(invokeResponse.result.failure.reason)
-            }
+                usedEnergy: unwrap(
+                    invokeResponse.result.failure.usedEnergy?.value
+                ),
+                reason: transRejectReason(invokeResponse.result.failure.reason),
+            };
         case 'success': {
             const result = invokeResponse.result.success;
             return {
                 tag: 'success',
                 usedEnergy: unwrap(result.usedEnergy?.value),
-                returnValue: result.returnValue ? Buffer.from(unwrap(result.returnValue)).toString('hex') : undefined,
-                events: result.effects.map(transContractTraceElement)
-            }
-      }
+                returnValue: result.returnValue
+                    ? Buffer.from(unwrap(result.returnValue)).toString('hex')
+                    : undefined,
+                events: result.effects.map(transContractTraceElement),
+            };
+        }
         default:
             throw Error('BlockItemStatus was undefined!');
     }

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -2,6 +2,7 @@ import * as v1 from '@concordium/common-sdk';
 import * as v2 from '../grpc/v2/concordium/types';
 import { mapRecord, unwrap } from './util';
 import { Buffer } from 'buffer/';
+import { TransactionSummary } from '@concordium/common-sdk';
 
 function unwrapToHex(x: Uint8Array | undefined): string {
     return Buffer.from(unwrap(x)).toString('hex');
@@ -348,6 +349,53 @@ export function consensusInfo(ci: v2.ConsensusInfo): v1.ConsensusStatus {
         }),
     };
 }
+
+/*
+function BlockItemSummary(bis: v2.BlockItemSummary): v1.TransactionSummary {
+    return = {
+        hash: unwrapValToHex(bis.hash),
+        cost: unwrap(bis.energyCost?.value),
+        energyCost: unwrap(b)
+
+    }
+}
+
+function transBlockItemSummaryInBlock(bisib: v2.BlockItemSummaryInBlock): [string, v1.TransactionSummary] {
+    
+}
+
+function transBlockItemSummaryInBlocks(bisibs: [v2.BlockItemSummaryInBlock]): Record<string, v1.TransactionSummary> {
+    const ret: Record<string, v1.TransactionSummary> = {};
+    for (const bisib in bisibs) {
+        const [blockHash, outcome] = transBlockItemSummaryInBlock(bisib);
+        ret[blockHash] = outcome
+    }
+    return ret
+}
+*/
+
+// Todo: committed and finalized
+export function blockItemStatus(bis: v2.BlockItemStatus): v1.TransactionStatus {
+    if (bis.status.oneofKind === 'received') {
+        return {
+            status: v1.TransactionStatusEnum.Received,
+        };
+    } else if (bis.status.oneofKind === 'committed') {
+        return {
+            status: v1.TransactionStatusEnum.Committed,
+        };
+    } else if (bis.status.oneofKind === 'finalized') {
+        return {
+            status: v1.TransactionStatusEnum.Finalized,
+        };
+    } else {
+        throw Error('BlockItemStatus was undefined!');
+    }
+}
+
+// ---------------------------- //
+// --- V1 => V2 translation --- //
+// ---------------------------- //
 
 export function accountTransactionSignatureToV2(
     signature: v1.AccountTransactionSignature

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -1243,7 +1243,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.DeployModule,
-                events: [event],
+                event,
             };
         }
         case 'contractInitialized': {
@@ -1260,7 +1260,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.InitContract,
-                events: [event],
+                event,
             };
         }
         case 'contractUpdateIssued': {
@@ -1291,7 +1291,7 @@ function translateAccountTransactionSummary(
                 return {
                     ...base,
                     transactionType: TransactionKindString.Transfer,
-                    events: [event],
+                    event,
                 };
             }
         }
@@ -1299,38 +1299,32 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.AddBaker,
-                events: [
-                    transBakerEvent({ event: effect }) as v1.BakerAddedEvent,
-                ],
+                event: transBakerEvent({ event: effect }) as v1.BakerAddedEvent,
             };
         case 'bakerRemoved':
             return {
                 ...base,
                 transactionType: TransactionKindString.RemoveBaker,
-                events: [
-                    transBakerEvent({ event: effect }) as v1.BakerRemovedEvent,
-                ],
+                event: transBakerEvent({
+                    event: effect,
+                }) as v1.BakerRemovedEvent,
             };
         case 'bakerRestakeEarningsUpdated':
             return {
                 ...base,
                 transactionType:
                     TransactionKindString.UpdateBakerRestakeEarnings,
-                events: [
-                    transBakerEvent({
-                        event: effect,
-                    }) as v1.BakerSetRestakeEarningsEvent,
-                ],
+                event: transBakerEvent({
+                    event: effect,
+                }) as v1.BakerSetRestakeEarningsEvent,
             };
         case 'bakerKeysUpdated':
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateBakerKeys,
-                events: [
-                    transBakerEvent({
-                        event: effect,
-                    }) as v1.BakerKeysUpdatedEvent,
-                ],
+                event: transBakerEvent({
+                    event: effect,
+                }) as v1.BakerKeysUpdatedEvent,
             };
         case 'bakerStakeUpdated': {
             const increased = effect.bakerStakeUpdated.update?.increased;
@@ -1345,7 +1339,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateBakerStake,
-                events: [event],
+                event,
             };
         }
         case 'encryptedAmountTransferred': {
@@ -1391,7 +1385,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.TransferToEncrypted,
-                events: [event],
+                event,
             };
         }
         case 'transferredToPublic': {
@@ -1430,7 +1424,7 @@ function translateAccountTransactionSummary(
                 return {
                     ...base,
                     transactionType: TransactionKindString.TransferWithSchedule,
-                    events: [event],
+                    event,
                 };
             }
         }
@@ -1442,7 +1436,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateCredentialKeys,
-                events: [event],
+                event,
             };
         }
         case 'credentialsUpdated': {
@@ -1456,7 +1450,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateCredentials,
-                events: [event],
+                event,
             };
         }
         case 'dataRegistered': {
@@ -1467,7 +1461,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.RegisterData,
-                events: [event],
+                event,
             };
         }
         case 'bakerConfigured':

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -1243,7 +1243,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.DeployModule,
-                event,
+                moduleDeployed: event,
             };
         }
         case 'contractInitialized': {
@@ -1260,7 +1260,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.InitContract,
-                event,
+                contractInitialized: event,
             };
         }
         case 'contractUpdateIssued': {
@@ -1273,7 +1273,7 @@ function translateAccountTransactionSummary(
             };
         }
         case 'accountTransfer': {
-            const event: v1.TransferredEvent = {
+            const transfer: v1.TransferredEvent = {
                 tag: TransactionEventTag.Transferred,
                 amount: unwrap(effect.accountTransfer.amount?.value),
                 to: transAccountAddress(effect.accountTransfer.receiver),
@@ -1282,16 +1282,14 @@ function translateAccountTransactionSummary(
                 return {
                     ...base,
                     transactionType: TransactionKindString.TransferWithMemo,
-                    events: [
-                        event,
-                        translateMemoEvent(effect.accountTransfer.memo),
-                    ],
+                    transfer,
+                    memo: translateMemoEvent(effect.accountTransfer.memo),
                 };
             } else {
                 return {
                     ...base,
                     transactionType: TransactionKindString.Transfer,
-                    event,
+                    transfer,
                 };
             }
         }
@@ -1299,13 +1297,15 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.AddBaker,
-                event: transBakerEvent({ event: effect }) as v1.BakerAddedEvent,
+                bakerAdded: transBakerEvent({
+                    event: effect,
+                }) as v1.BakerAddedEvent,
             };
         case 'bakerRemoved':
             return {
                 ...base,
                 transactionType: TransactionKindString.RemoveBaker,
-                event: transBakerEvent({
+                bakerRemoved: transBakerEvent({
                     event: effect,
                 }) as v1.BakerRemovedEvent,
             };
@@ -1314,7 +1314,7 @@ function translateAccountTransactionSummary(
                 ...base,
                 transactionType:
                     TransactionKindString.UpdateBakerRestakeEarnings,
-                event: transBakerEvent({
+                bakerRestakeEarningsUpdated: transBakerEvent({
                     event: effect,
                 }) as v1.BakerSetRestakeEarningsEvent,
             };
@@ -1322,7 +1322,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateBakerKeys,
-                event: transBakerEvent({
+                bakerKeysUpdated: transBakerEvent({
                     event: effect,
                 }) as v1.BakerKeysUpdatedEvent,
             };
@@ -1339,7 +1339,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateBakerStake,
-                event,
+                bakerStakeChanged: event,
             };
         }
         case 'encryptedAmountTransferred': {
@@ -1363,20 +1363,23 @@ function translateAccountTransactionSummary(
                     ...base,
                     transactionType:
                         TransactionKindString.EncryptedAmountTransferWithMemo,
-                    events: [removed, added, translateMemoEvent(transfer.memo)],
+                    removed,
+                    added,
+                    memo: translateMemoEvent(transfer.memo),
                 };
             } else {
                 return {
                     ...base,
                     transactionType:
                         TransactionKindString.EncryptedAmountTransfer,
-                    events: [removed, added],
+                    removed,
+                    added,
                 };
             }
         }
         case 'transferredToEncrypted': {
             const transfer = effect.transferredToEncrypted;
-            const event: v1.EncryptedSelfAmountAddedEvent = {
+            const added: v1.EncryptedSelfAmountAddedEvent = {
                 tag: TransactionEventTag.EncryptedSelfAmountAdded,
                 account: unwrapToBase58(transfer.account),
                 amount: unwrap(transfer.amount?.value),
@@ -1385,7 +1388,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.TransferToEncrypted,
-                event,
+                added,
             };
         }
         case 'transferredToPublic': {
@@ -1403,7 +1406,8 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.TransferToPublic,
-                events: [removed, added],
+                removed,
+                added,
             };
         }
         case 'transferredWithSchedule': {
@@ -1418,7 +1422,8 @@ function translateAccountTransactionSummary(
                     ...base,
                     transactionType:
                         TransactionKindString.TransferWithScheduleAndMemo,
-                    events: [event, translateMemoEvent(transfer.memo)],
+                    transfer: event,
+                    memo: translateMemoEvent(transfer.memo),
                 };
             } else {
                 return {
@@ -1436,7 +1441,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateCredentialKeys,
-                event,
+                keysUpdated: event,
             };
         }
         case 'credentialsUpdated': {
@@ -1450,7 +1455,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.UpdateCredentials,
-                event,
+                credentialsUpdated: event,
             };
         }
         case 'dataRegistered': {
@@ -1461,7 +1466,7 @@ function translateAccountTransactionSummary(
             return {
                 ...base,
                 transactionType: TransactionKindString.RegisterData,
-                event,
+                dataRegistered: event,
             };
         }
         case 'bakerConfigured':

--- a/packages/nodejs/src/typeTranslation.ts
+++ b/packages/nodejs/src/typeTranslation.ts
@@ -378,15 +378,6 @@ export function consensusInfo(ci: v2.ConsensusInfo): v1.ConsensusStatus {
     };
 }
 
-function transContractAddress(
-    contractAddress: v2.ContractAddress | undefined
-): v1.ContractAddress {
-    return {
-        index: unwrap(contractAddress?.index),
-        subindex: unwrap(contractAddress?.subindex),
-    };
-}
-
 function transAccountAddress(
     accountAddress: v2.AccountAddress | undefined
 ): v1.AddressAccount {
@@ -408,14 +399,14 @@ function transAddress(
     } else if (contractAddress.index) {
         return {
             type: 'AddressContract',
-            address: transContractAddress(contractAddress),
+            address: contractAddress,
         };
     } else if (address.type.oneofKind === 'account') {
         return transAccountAddress(address.type.account);
     } else if (address.type.oneofKind === 'contract') {
         return {
             type: 'AddressContract',
-            address: transContractAddress(address.type.contract),
+            address: address.type.contract,
         };
     } else {
         throw Error('Invalid address encountered!');
@@ -448,19 +439,19 @@ function transContractTraceElement(
         case 'interrupted':
             return {
                 tag: TransactionEventTag.Interrupted,
-                address: transContractAddress(element.interrupted.address),
+                address: unwrap(element.interrupted.address),
                 events: element.interrupted.events.map(unwrapValToHex),
             };
         case 'resumed':
             return {
                 tag: TransactionEventTag.Resumed,
-                address: transContractAddress(element.resumed.address),
+                address: unwrap(element.resumed.address),
                 success: unwrap(element.resumed.success),
             };
         case 'upgraded':
             return {
                 tag: TransactionEventTag.Upgraded,
-                address: transContractAddress(element.upgraded.address),
+                address: unwrap(element.upgraded.address),
                 from: transModuleRef(element.upgraded.from),
                 to: transModuleRef(element.upgraded.to),
             };
@@ -1060,7 +1051,7 @@ function translateCommissionRange(
 }
 function translateUpdatePublicKey(key: v2.UpdatePublicKey): v1.VerifyKey {
     return {
-        schemeId: 'Ed25516',
+        schemeId: 'Ed25519',
         verifyKey: unwrapValToHex(key),
     };
 }

--- a/packages/nodejs/src/types.ts
+++ b/packages/nodejs/src/types.ts
@@ -1,9 +1,9 @@
 import {
-    AccountAddress as AccountAddressLocal,
-    CredentialRegistrationId as CredentialRegistrationIdLocal,
+    AccountAddress,
+    CredentialRegistrationId,
 } from '@concordium/common-sdk';
 
 export type AccountIdentifierInput =
-    | AccountAddressLocal
-    | CredentialRegistrationIdLocal
+    | AccountAddress
+    | CredentialRegistrationId
     | bigint;

--- a/packages/nodejs/src/types.ts
+++ b/packages/nodejs/src/types.ts
@@ -1,0 +1,9 @@
+import {
+    AccountAddress as AccountAddressLocal,
+    CredentialRegistrationId as CredentialRegistrationIdLocal,
+} from '@concordium/common-sdk';
+
+export type AccountIdentifierInput =
+    | AccountAddressLocal
+    | CredentialRegistrationIdLocal
+    | bigint;

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -102,25 +102,27 @@ export function getAccountIdentifierInput(
     return { accountIdentifierInput: returnIdentifier };
 }
 
-export function getInvokerInput(invoker?: v1.AccountAddress | v1.ContractAddress): v2.Address | undefined {
+export function getInvokerInput(
+    invoker?: v1.AccountAddress | v1.ContractAddress
+): v2.Address | undefined {
     if (!invoker) {
         return undefined;
     } else if ((<v1.AccountAddress>invoker).decodedAddress) {
         return {
             type: {
                 oneofKind: 'account',
-                account: {value:  (<v1.AccountAddress>invoker).decodedAddress}
-            }
-        }
+                account: { value: (<v1.AccountAddress>invoker).decodedAddress },
+            },
+        };
     } else if ((<v1.ContractAddress>invoker).index) {
         return {
             type: {
                 oneofKind: 'contract',
-                contract: (<v1.ContractAddress>invoker)
-            }
-        }
+                contract: <v1.ContractAddress>invoker,
+            },
+        };
     } else {
-            throw new Error('Unexpected input to build invoker');
+        throw new Error('Unexpected input to build invoker');
     }
 }
 

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -48,7 +48,7 @@ export function unwrapJsonResponse<T>(
 
 /**
  * Loads the module as a buffer, given the given filePath.
- * @param filepath the location of the module
+ * @param filePath the location of the module
  * @returns the module as a buffer
  */
 export function getModuleBuffer(filePath: string): Buffer {
@@ -100,6 +100,28 @@ export function getAccountIdentifierInput(
     }
 
     return { accountIdentifierInput: returnIdentifier };
+}
+
+export function getInvokerInput(invoker?: v1.AccountAddress | v1.ContractAddress): v2.Address | undefined {
+    if (!invoker) {
+        return undefined;
+    } else if ((<v1.AccountAddress>invoker).decodedAddress) {
+        return {
+            type: {
+                oneofKind: 'account',
+                account: {value:  (<v1.AccountAddress>invoker).decodedAddress}
+            }
+        }
+    } else if ((<v1.ContractAddress>invoker).index) {
+        return {
+            type: {
+                oneofKind: 'contract',
+                contract: (<v1.ContractAddress>invoker)
+            }
+        }
+    } else {
+            throw new Error('Unexpected input to build invoker');
+    }
 }
 
 export function assertValidHash(hash: HexString): void {

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -75,6 +75,11 @@ export function getBlockHashInput(blockHash?: HexString): v2.BlockHashInput {
     return { blockHashInput: blockHashInput };
 }
 
+/**
+ * Gets an GRPCv2 AccountIdentifierInput from a GRPCv1 AccountIdentifierInput.
+ * @param accountIdentifier a GRPCv1 AccountIdentifierInput.
+ * @returns a GRPCv2 AccountIdentifierInput.
+ */
 export function getAccountIdentifierInput(
     accountIdentifier: v1.AccountIdentifierInput
 ): v2.AccountIdentifierInput {
@@ -87,9 +92,8 @@ export function getAccountIdentifierInput(
         returnIdentifier.address = { value: address };
     } else if ((<CredRegId>accountIdentifier).credId !== undefined) {
         const credId = (<CredRegId>accountIdentifier).credId;
-        const credIdBytes = Buffer.from(credId, 'hex');
         returnIdentifier.oneofKind = 'credId';
-        returnIdentifier.credId = { value: credIdBytes };
+        returnIdentifier.credId = { value: Buffer.from(credId, 'hex') };
     } else {
         returnIdentifier.oneofKind = 'accountIndex';
         returnIdentifier.accountIndex = { value: accountIdentifier };
@@ -147,16 +151,28 @@ export function assertValidModuleRef(moduleRef: Uint8Array): void {
     }
 }
 
-export function assertAmount(amount: bigint): void {
-    if (amount < 0n) {
-        throw new Error(
-            'A micro CCD amount must be a non-negative integer but was: ' +
-                amount
-        );
-    } else if (amount > 18446744073709551615n) {
-        throw new Error(
-            'A micro CCD amount must be representable as an unsigned 64 bit integer but was: ' +
-                amount
-        );
+/**
+ * Gets an GRPCv2 AccountTransactionSignature from a GRPCv1 AccountTransactionSignature.
+ * @param accountIdentifier a GRPCv1 AccountTransactionSignature.
+ * @returns a GRPCv2 AccountTransactionSignature.
+ */
+export function translateSignature(
+    signature: v1.AccountTransactionSignature
+): v2.AccountTransactionSignature {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const accountTransactionSignature: any = { signatures: {} };
+
+    for (const i in signature) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const accountSignatureMap: any = { signatures: {} };
+
+        for (const j in signature[i]) {
+            accountSignatureMap.signatures[i] = {
+                value: Buffer.from(signature[i][j], 'hex'),
+            };
+        }
+        accountTransactionSignature.signatures[i] = accountSignatureMap;
     }
+
+    return accountTransactionSignature;
 }

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -138,7 +138,7 @@ export function unwrap<A>(x: A | undefined): A {
     }
 }
 
-export function assertValidModuleRef(moduleRef: Uint8Array) {
+export function assertValidModuleRef(moduleRef: Uint8Array): void {
     if (moduleRef.length !== 32) {
         throw new Error(
             'The input was not a valid module reference, must be 32 bytes: ' +
@@ -147,7 +147,7 @@ export function assertValidModuleRef(moduleRef: Uint8Array) {
     }
 }
 
-export function assertAmount(amount: bigint) {
+export function assertAmount(amount: bigint): void {
     if (amount < 0n) {
         throw new Error(
             'A micro CCD amount must be a non-negative integer but was: ' +

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -141,38 +141,3 @@ export function unwrap<A>(x: A | undefined): A {
         return x;
     }
 }
-
-export function assertValidModuleRef(moduleRef: Uint8Array): void {
-    if (moduleRef.length !== 32) {
-        throw new Error(
-            'The input was not a valid module reference, must be 32 bytes: ' +
-                Buffer.from(moduleRef).toString('hex')
-        );
-    }
-}
-
-/**
- * Gets an GRPCv2 AccountTransactionSignature from a GRPCv1 AccountTransactionSignature.
- * @param accountIdentifier a GRPCv1 AccountTransactionSignature.
- * @returns a GRPCv2 AccountTransactionSignature.
- */
-export function translateSignature(
-    signature: v1.AccountTransactionSignature
-): v2.AccountTransactionSignature {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const accountTransactionSignature: any = { signatures: {} };
-
-    for (const i in signature) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const accountSignatureMap: any = { signatures: {} };
-
-        for (const j in signature[i]) {
-            accountSignatureMap.signatures[i] = {
-                value: Buffer.from(signature[i][j], 'hex'),
-            };
-        }
-        accountTransactionSignature.signatures[i] = accountSignatureMap;
-    }
-
-    return accountTransactionSignature;
-}

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -137,3 +137,26 @@ export function unwrap<A>(x: A | undefined): A {
         return x;
     }
 }
+
+export function assertValidModuleRef(moduleRef: Uint8Array) {
+    if (moduleRef.length !== 32) {
+        throw new Error(
+            'The input was not a valid module reference, must be 32 bytes: ' +
+                Buffer.from(moduleRef).toString('hex')
+        );
+    }
+}
+
+export function assertAmount(amount: bigint) {
+    if (amount < 0n) {
+        throw new Error(
+            'A micro CCD amount must be a non-negative integer but was: ' +
+                amount
+        );
+    } else if (amount > 18446744073709551615n) {
+        throw new Error(
+            'A micro CCD amount must be representable as an unsigned 64 bit integer but was: ' +
+                amount
+        );
+    }
+}

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -4,7 +4,11 @@ import * as v2 from '../grpc/v2/concordium/types';
 import ConcordiumNodeClientV1 from '../src/client';
 import ConcordiumNodeClientV2 from '../src/clientV2';
 import { testnetBulletproofGenerators } from './resources/bulletproofgenerators';
-import { getAccountIdentifierInput, getBlockHashInput } from '../src/util';
+import {
+    getAccountIdentifierInput,
+    getBlockHashInput,
+    unwrap,
+} from '../src/util';
 import {
     buildBasicAccountSigner,
     calculateEnergyCost,
@@ -283,22 +287,16 @@ test('getModuleSource', async () => {
     expect(localModuleHex).toEqual(moduleSource);
 });
 
-test('getConsensusInfo', async () => {
-    const genesisBlock = Buffer.from(
-        'QiEzLTThaUFowqDAs/0PJzgJYSyxPQANXC4A6F9Q95Y=',
-        'base64'
-    );
+test('getConsensusStatus', async () => {
+    const genesisBlock =
+        '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
 
-    const consensusInfo = await clientV2.client.getConsensusInfo(v2.Empty)
-        .response;
+    const ci = await clientV2.getConsensusStatus();
+    const lastFinTime = unwrap(ci.lastFinalizedTime?.getTime()) / 1000;
 
-    expect(consensusInfo.genesisBlock?.value).toEqual(genesisBlock);
-    expect(consensusInfo.lastFinalizedTime?.value).toBeGreaterThan(
-        1669214033937n
-    );
-    expect(consensusInfo.lastFinalizedBlockHeight?.value).toBeGreaterThan(
-        1395315n
-    );
+    expect(ci.genesisBlock).toEqual(genesisBlock);
+    expect(ci.lastFinalizedBlockHeight).toBeGreaterThan(1395315n);
+    expect(lastFinTime).toBeGreaterThan(1669214033937n);
 });
 
 test('sendBlockItem', async () => {

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -175,14 +175,20 @@ test('accountInfo implementations is the same', async () => {
     expect(oldBaker).toEqual(newBaker);
 });
 
-test('getBlockItemStatus', async () => {
+test('getBlockItemStatus on chain update', async () => {
     const transactionHash =
         '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650';
     const blockItemStatus = await clientV2.getBlockItemStatus(transactionHash);
 
-    expect(v2.BlockItemStatus.toJson(blockItemStatus)).toEqual(
-        expected.blockItemStatus
-    );
+    expect(blockItemStatus).toEqual(expected.blockItemStatusUpdate);
+});
+
+test('getBlockItemStatus on simple transfer', async () => {
+    const transactionHash =
+        '502332239efc0407eebef5c73c390080e5d7e1b127ff29f786a62b3c9ab6cfe7';
+    const blockItemStatus = await clientV2.getBlockItemStatus(transactionHash);
+
+    expect(blockItemStatus).toEqual(expected.blockItemStatusTransfer);
 });
 
 test('getInstanceInfo', async () => {

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -287,4 +287,22 @@ test('accountInfo implementations is the same', async () => {
     expect(oldCredId).toEqual(newCredId);
     expect(oldDeleg).toEqual(newDeleg);
     expect(oldBaker).toEqual(newBaker);
+})
+
+test('getBlockItemStatus', async () => {
+    const transactionHash = '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650';
+    const blockItemStatus = await clientV2.getBlockItemStatus(transactionHash);
+
+    const expectedBlockItemStatus = Buffer.from(
+        'GmwKagoiCiAtnhoIGBmtjb+B1aiC6i9TUss0KfwSsOwYwTGjYHUaZhJECgASABoiCiA96CO4dtBc3TOjEaD4QSQHn19nevslNMSUP4MFk+3GUDIaCgASFiIUChIIgICnqLnVuJL0ARDDqpuv4gQ=',
+        'base64'
+    );
+    expect(blockItemStatus).toEqual(
+        v2.BlockItemStatus.fromBinary(expectedBlockItemStatus)
+    );
+});
+
+test('getConsensusInfo', async () => {
+    const consensusInfo = await clientV2.getConsensusInfo();
+    console.log(consensusInfo);
 });

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -293,16 +293,33 @@ test('getBlockItemStatus', async () => {
     const transactionHash = '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650';
     const blockItemStatus = await clientV2.getBlockItemStatus(transactionHash);
 
-    const expectedBlockItemStatus = Buffer.from(
-        'GmwKagoiCiAtnhoIGBmtjb+B1aiC6i9TUss0KfwSsOwYwTGjYHUaZhJECgASABoiCiA96CO4dtBc3TOjEaD4QSQHn19nevslNMSUP4MFk+3GUDIaCgASFiIUChIIgICnqLnVuJL0ARDDqpuv4gQ=',
-        'base64'
-    );
-    expect(blockItemStatus).toEqual(
-        v2.BlockItemStatus.fromBinary(expectedBlockItemStatus)
-    );
-});
+    const expected = {
+        finalized: {
+            outcome: {
+                blockHash: {
+                    value: 'LZ4aCBgZrY2/gdWoguovU1LLNCn8ErDsGMExo2B1GmY=',
+                },
+                outcome: {
+                    index: {},
+                    energyCost: {},
+                    hash: {
+                        value: 'PegjuHbQXN0zoxGg+EEkB59fZ3r7JTTElD+DBZPtxlA=',
+                    },
+                    update: {
+                        effectiveTime: {},
+                        payload: {
+                            microCcdPerEuroUpdate: {
+                                value: {
+                                    numerator: '17592435270983729152',
+                                    denominator: '163844642115',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
 
-test('getConsensusInfo', async () => {
-    const consensusInfo = await clientV2.getConsensusInfo();
-    console.log(consensusInfo);
+    expect(v2.BlockItemStatus.toJson(blockItemStatus)).toEqual(expected);
 });

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -10,6 +10,7 @@ import { serializeAccountTransactionPayload } from '@concordium/common-sdk/src';
 import { getCredentialDeploymentSignDigest, serializeAccountTransaction } from '@concordium/common-sdk/lib/serialization';
 import { getModuleBuffer, getIdentityInput } from './testHelpers';
 import * as ed from '@noble/ed25519';
+import * as expected from './resources/expectedJsons';
 
 /**
  * Creates a client to communicate with a local concordium-node
@@ -92,97 +93,10 @@ test('NextAccountSequenceNumber', async () => {
     expect(nan.allFinal).toBeDefined();
 });
 
-test('AccountInfo', async () => {
+test('getAccountInfo', async () => {
     const accountInfo = await getAccountInfoV2(clientV2, testAccount);
 
-    const expected = {
-        sequenceNumber: {
-            value: '19',
-        },
-        amount: {
-            value: '35495453082577742',
-        },
-        schedule: {
-            total: {},
-        },
-        creds: {
-            '0': {
-                normal: {
-                    keys: {
-                        keys: {
-                            '0': {
-                                ed25519Key:
-                                    'npdcg40DcTbP9U9/W3QZIt2bwx5d08nreToCa30fUSU=',
-                            },
-                            '1': {
-                                ed25519Key:
-                                    'LTIrh0T6XQGCOtzj9qE7vr3XuFA8CMzD2El+bEYCGXY=',
-                            },
-                            '2': {
-                                ed25519Key:
-                                    'mnffP4aSBqfAhbwauCHx4kh2KiK7N0cbPO/Lg3QHZMk=',
-                            },
-                        },
-                        threshold: {
-                            value: 2,
-                        },
-                    },
-                    credId: {
-                        value: 'qnMARbzSC7XCQ0nbKdlJ92fnL3zORZ3BY8S5PHgKfX9lgB3aj/fk/Ab98aGyRidv',
-                    },
-                    ipId: {},
-                    policy: {
-                        createdAt: {
-                            year: 2022,
-                            month: 6,
-                        },
-                        validTo: {
-                            year: 2023,
-                            month: 6,
-                        },
-                    },
-                    arThreshold: {
-                        value: 1,
-                    },
-                    commitments: {
-                        prf: {
-                            value: 'uJMOSJdpAvZ/DLtQuMKRH8wGRvvM9L+2pELvfUCoNR9IrnIG7oCD4o01e+gIgD+C',
-                        },
-                        credCounter: {
-                            value: 'sKpl9CCp8/q2HT+HXuvMIh5DFUv68bY2Xazpm/8gd43nADQ3YxIi6EX9mRfI0odL',
-                        },
-                        maxAccounts: {
-                            value: 'hp4r3bLGBwPs1RK1W3crr3VpH4G7xFNi+I5avNq4WiNxSpLUb+QEVzZNUGq8IgKj',
-                        },
-                        idCredSecSharingCoeff: [
-                            {
-                                value: 'i6xECi5GzL+/p2jGrZnyq/JfizJ6eV7PI7K4BMMnAi8G0KztC17tZYmaPvMCmATs',
-                            },
-                        ],
-                    },
-                },
-            },
-        },
-        threshold: {
-            value: 1,
-        },
-        encryptedBalance: {
-            selfAmount: {
-                value: 'wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-            },
-        },
-        encryptionKey: {
-            value: 'sUy/5EoCxrH3hxEXbV9DcpU2eqTyqMJVHuENJaA63GnWGjMqBYlxkZ2tcxLh/JTFqnMARbzSC7XCQ0nbKdlJ92fnL3zORZ3BY8S5PHgKfX9lgB3aj/fk/Ab98aGyRidv',
-        },
-        index: {
-            value: '11',
-        },
-        address: {
-            value: 'aXUkBsyTn8kMpqc7V87hCZY1R/lCAG0hkUSST4SF+w0=',
-        },
-    };
-
-    expect(v2.AccountInfo.toJson(accountInfo)).toEqual(expected);
+    expect(v2.AccountInfo.toJson(accountInfo)).toEqual(expected.accountInfo);
 });
 
 test('getAccountInfo: Invalid hash throws error', async () => {
@@ -201,38 +115,12 @@ test('getAccountInfo for baker', async () => {
     const accInfo = await getAccountInfoV2(clientV2, testAccBaker);
     const accountIndexInfo = await getAccountInfoV2(clientV2, 5n);
 
-    const expected = {
-        baker: {
-            stakedAmount: { value: '7349646704751788' },
-            restakeEarnings: true,
-            bakerInfo: {
-                bakerId: { value: '5' },
-                electionKey: {
-                    value: 'oJBoHsezXvOnce1D67Zyj9leSyZ6vt+pXx3BdyAZPcs=',
-                },
-                signatureKey: {
-                    value: 'w4XMtcigcQoWLywQcSN0RlD/NfAAQL+iYtl0v7PD+PE=',
-                },
-                aggregationKey: {
-                    value: 'sYoC3nSCblX26twPMdDZpu37KZPQMOZRNvHhJWppulI6y0D6TTBNBmiqMHwZJXoKEHJucBSckE4e8prtsmecglmX4/FO3TA78nbywLDFpMSHD/8MBDFQvga3FUZr5WTE',
-                },
-            },
-            poolInfo: {
-                openStatus: 'OPEN_STATUS_CLOSED_FOR_ALL',
-                commissionRates: {
-                    finalization: { partsPerHundredThousand: 100000 },
-                    baking: { partsPerHundredThousand: 10000 },
-                    transaction: { partsPerHundredThousand: 10000 },
-                },
-            },
-        },
-    };
     if (accInfo.stake && accountIndexInfo.stake) {
         const stake = v2.AccountStakingInfo.toJson(accInfo.stake);
         const stakeAccountIndex = v2.AccountStakingInfo.toJson(
             accountIndexInfo.stake
         );
-        expect(stake).toEqual(expected);
+        expect(stake).toEqual(expected.stakingInfoBaker);
         expect(stake).toEqual(stakeAccountIndex);
     } else {
         throw Error('Stake field not found in accountInfo.');
@@ -242,17 +130,10 @@ test('getAccountInfo for baker', async () => {
 test('getAccountInfo for delegator', async () => {
     const accInfo = await getAccountInfoV2(clientV2, testAccDeleg);
 
-    const expected = {
-        delegator: {
-            stakedAmount: { value: '620942412516' },
-            restakeEarnings: true,
-            target: { passive: {} },
-        },
-    };
-
     if (accInfo.stake) {
-        const stakeJson = v2.AccountStakingInfo.toJson(accInfo.stake);
-        expect(stakeJson).toEqual(expected);
+        expect(v2.AccountStakingInfo.toJson(accInfo.stake)).toEqual(
+            expected.stakingInfoDelegator
+        );
     } else {
         throw Error('Stake field not found in accountInfo.');
     }
@@ -302,35 +183,9 @@ test('getBlockItemStatus', async () => {
     const transactionHash = '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650';
     const blockItemStatus = await clientV2.getBlockItemStatus(transactionHash);
 
-    const expected = {
-        finalized: {
-            outcome: {
-                blockHash: {
-                    value: 'LZ4aCBgZrY2/gdWoguovU1LLNCn8ErDsGMExo2B1GmY=',
-                },
-                outcome: {
-                    index: {},
-                    energyCost: {},
-                    hash: {
-                        value: 'PegjuHbQXN0zoxGg+EEkB59fZ3r7JTTElD+DBZPtxlA=',
-                    },
-                    update: {
-                        effectiveTime: {},
-                        payload: {
-                            microCcdPerEuroUpdate: {
-                                value: {
-                                    numerator: '17592435270983729152',
-                                    denominator: '163844642115',
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    };
-
-    expect(v2.BlockItemStatus.toJson(blockItemStatus)).toEqual(expected);
+    expect(v2.BlockItemStatus.toJson(blockItemStatus)).toEqual(
+        expected.blockItemStatus
+    );
 });
 
 test('getInstanceInfo', async () => {
@@ -343,30 +198,7 @@ test('getInstanceInfo', async () => {
         testBlockHash
     );
 
-    const expected = {
-        v1: {
-            owner: {
-                value: '0YBPp1cC7ISiGOEh3OLFvm9rCgolsXjymRwBmxeX1R4=',
-            },
-            amount: {},
-            methods: [
-                {
-                    value: 'weather.get',
-                },
-                {
-                    value: 'weather.set',
-                },
-            ],
-            name: {
-                value: 'init_weather',
-            },
-            sourceModule: {
-                value: 'Z9VoQzvXLkMmJB8mIhPXf0RtuLoD37o1GuNcGy5+UQk=',
-            },
-        },
-    };
-
-    expect(v2.InstanceInfo.toJson(instanceInfo)).toEqual(expected);
+    expect(v2.InstanceInfo.toJson(instanceInfo)).toEqual(expected.instanceInfo);
 });
 
 test('invokeInstance on v0 contract', async () => {
@@ -385,29 +217,8 @@ test('invokeInstance on v0 contract', async () => {
         testBlockHash
     );
 
-    const expected = {
-        success: {
-            usedEnergy: { value: '342' },
-            effects: [
-                {
-                    updated: {
-                        address: { index: '6' },
-                        instigator: {
-                            account: {
-                                value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
-                            },
-                        },
-                        amount: { value: '42' },
-                        parameter: {},
-                        receiveName: { value: 'PiggyBank.insert' },
-                    },
-                },
-            ],
-        },
-    };
-
     const responseJson = v2.InvokeInstanceResponse.toJson(invokeInstanceResponse);
-    expect(responseJson).toEqual(expected);
+    expect(responseJson).toEqual(expected.invokeInstanceResponseV0);
 });
 
 test('getModuleSource', async () => {
@@ -442,9 +253,6 @@ test('getConsensusInfo', async () => {
 
     const consensusInfo = await clientV2.getConsensusInfo();
 
-    expect(consensusInfo.blocksReceivedCount).toBeGreaterThan(9571n);
-    expect(consensusInfo.blocksVerifiedCount).toBeGreaterThan(9571n);
-    expect(consensusInfo.finalizationCount).toBeGreaterThan(8640n);
     expect(consensusInfo.genesisBlock?.value).toEqual(genesisBlock);
     expect(consensusInfo.lastFinalizedTime?.value).toBeGreaterThan(
         1669214033937n

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -226,7 +226,6 @@ test('Failed invoke contract', async () => {
 
     expect(result.usedEnergy).toBe(340n);
     expect(result.reason.tag).toBe(v1.RejectReasonTag.RejectedReceive);
-
 });
 
 test('Invoke contract on v0 contract', async () => {
@@ -260,14 +259,8 @@ test('Invoke contract same in v1 and v2 on v1 contract', async () => {
         parameter: undefined,
         energy: 30000n,
     };
-    const resultV1 = await clientV1.invokeContract(
-        context,
-        testBlockHash
-    );
-   const resultV2 = await clientV2.invokeContract(
-        context,
-        testBlockHash
-    );
+    const resultV1 = await clientV1.invokeContract(context, testBlockHash);
+    const resultV2 = await clientV2.invokeContract(context, testBlockHash);
 
     expect(resultV2).toEqual(resultV1);
 });

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -5,9 +5,19 @@ import ConcordiumNodeClientV1 from '../src/client';
 import ConcordiumNodeClientV2 from '../src/clientV2';
 import { testnetBulletproofGenerators } from './resources/bulletproofgenerators';
 import { getAccountIdentifierInput, getBlockHashInput } from '../src/util';
-import { buildBasicAccountSigner, calculateEnergyCost, createCredentialDeploymentTransaction, getAccountTransactionHandler, sha256, signTransaction } from '@concordium/common-sdk';
+import {
+    buildBasicAccountSigner,
+    calculateEnergyCost,
+    createCredentialDeploymentTransaction,
+    getAccountTransactionHandler,
+    sha256,
+    signTransaction,
+} from '@concordium/common-sdk';
 import { serializeAccountTransactionPayload } from '@concordium/common-sdk/src';
-import { getCredentialDeploymentSignDigest, serializeAccountTransaction } from '@concordium/common-sdk/lib/serialization';
+import {
+    getCredentialDeploymentSignDigest,
+    serializeAccountTransaction,
+} from '@concordium/common-sdk/lib/serialization';
 import { getModuleBuffer, getIdentityInput } from './testHelpers';
 import * as ed from '@noble/ed25519';
 import * as expected from './resources/expectedJsons';
@@ -177,10 +187,11 @@ test('accountInfo implementations is the same', async () => {
     expect(oldCredId).toEqual(newCredId);
     expect(oldDeleg).toEqual(newDeleg);
     expect(oldBaker).toEqual(newBaker);
-})
+});
 
 test('getBlockItemStatus', async () => {
-    const transactionHash = '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650';
+    const transactionHash =
+        '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650';
     const blockItemStatus = await clientV2.getBlockItemStatus(transactionHash);
 
     expect(v2.BlockItemStatus.toJson(blockItemStatus)).toEqual(
@@ -217,7 +228,9 @@ test('invokeInstance on v0 contract', async () => {
         testBlockHash
     );
 
-    const responseJson = v2.InvokeInstanceResponse.toJson(invokeInstanceResponse);
+    const responseJson = v2.InvokeInstanceResponse.toJson(
+        invokeInstanceResponse
+    );
     expect(responseJson).toEqual(expected.invokeInstanceResponseV0);
 });
 
@@ -268,9 +281,7 @@ test('sendBlockItem', async () => {
     );
     const privateKey =
         '1f7d20585457b542b22b51f218f0636c8e05ead4b64074e6eafd1d418b04e4ac';
-    const nextNonce = (
-        await clientV2.getNextAccountNonce(senderAccount)
-    );
+    const nextNonce = await clientV2.getNextAccountNonce(senderAccount);
 
     // Create local transaction
     const header: v1.AccountTransactionHeader = {
@@ -308,9 +319,7 @@ test('transactionHash', async () => {
     );
     const privateKey =
         '1f7d20585457b542b22b51f218f0636c8e05ead4b64074e6eafd1d418b04e4ac';
-    const nextNonce = (
-        await clientV2.getNextAccountNonce(senderAccount)
-    );
+    const nextNonce = await clientV2.getNextAccountNonce(senderAccount);
 
     // Create local transaction
     const headerLocal: v1.AccountTransactionHeader = {

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -201,7 +201,7 @@ test('getInstanceInfo', async () => {
         testBlockHash
     );
 
-    expect(v2.InstanceInfo.toJson(instanceInfo)).toEqual(expected.instanceInfo);
+    expect(instanceInfo).toEqual(expected.instanceInfo);
 });
 
 test('Failed invoke contract', async () => {

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -234,6 +234,47 @@ test('invokeInstance on v0 contract', async () => {
     expect(responseJson).toEqual(expected.invokeInstanceResponseV0);
 });
 
+test('invokeInstance on v0 contract', async () => {
+    const contractAddress = {
+        index: 6n,
+        subindex: 0n,
+    };
+
+    const invokeInstanceResponse = await clientV2.invokeInstance(
+        contractAddress,
+        new v1.CcdAmount(42n),
+        'PiggyBank.insert',
+        new Uint8Array(),
+        30000n,
+        undefined,
+        testBlockHash
+    );
+
+    const expected = {
+        success: {
+            usedEnergy: { value: '342' },
+            effects: [
+                {
+                    updated: {
+                        address: { index: '6' },
+                        instigator: {
+                            account: {
+                                value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+                            },
+                        },
+                        amount: { value: '42' },
+                        parameter: {},
+                        receiveName: { value: 'PiggyBank.insert' },
+                    },
+                },
+            ],
+        },
+    };
+
+    const responseJson = v2.InvokeInstanceResponse.toJson(invokeInstanceResponse);
+    expect(responseJson).toEqual(expected);
+});
+
 test('getModuleSource', async () => {
     const localModuleBytes = getModuleBuffer('test/resources/piggy_bank.wasm');
     const moduleRef = Buffer.from(

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -169,22 +169,6 @@ test('accountInfo implementations is the same', async () => {
     const oldDeleg = await clientV1.getAccountInfo(testAccDeleg, testBlockHash);
     const newDeleg = await clientV2.getAccountInfo(testAccDeleg, testBlockHash);
 
-    // Tempoary
-    /*
-    if (oldReg?.accountCredentials[0].value.type === 'normal') {
-        oldReg.accountCredentials[0].value.contents.arData = {};
-    }
-    if (oldCredId?.accountCredentials[0].value.type === 'normal') {
-        oldCredId.accountCredentials[0].value.contents.arData = {};
-    }
-    if (oldBaker?.accountCredentials[0].value.type === 'normal') {
-        oldBaker.accountCredentials[0].value.contents.arData = {};
-    }
-    if (oldDeleg?.accountCredentials[0].value.type === 'normal') {
-        oldDeleg.accountCredentials[0].value.contents.arData = {};
-    }
-    */
-
     expect(oldReg).toEqual(newReg);
     expect(oldCredId).toEqual(newCredId);
     expect(oldDeleg).toEqual(newDeleg);

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -1,0 +1,193 @@
+export const accountInfo = {
+    sequenceNumber: {
+        value: '19',
+    },
+    amount: {
+        value: '35495453082577742',
+    },
+    schedule: {
+        total: {},
+    },
+    creds: {
+        '0': {
+            normal: {
+                keys: {
+                    keys: {
+                        '0': {
+                            ed25519Key:
+                                'npdcg40DcTbP9U9/W3QZIt2bwx5d08nreToCa30fUSU=',
+                        },
+                        '1': {
+                            ed25519Key:
+                                'LTIrh0T6XQGCOtzj9qE7vr3XuFA8CMzD2El+bEYCGXY=',
+                        },
+                        '2': {
+                            ed25519Key:
+                                'mnffP4aSBqfAhbwauCHx4kh2KiK7N0cbPO/Lg3QHZMk=',
+                        },
+                    },
+                    threshold: {
+                        value: 2,
+                    },
+                },
+                credId: {
+                    value: 'qnMARbzSC7XCQ0nbKdlJ92fnL3zORZ3BY8S5PHgKfX9lgB3aj/fk/Ab98aGyRidv',
+                },
+                ipId: {},
+                policy: {
+                    createdAt: {
+                        year: 2022,
+                        month: 6,
+                    },
+                    validTo: {
+                        year: 2023,
+                        month: 6,
+                    },
+                },
+                arThreshold: {
+                    value: 1,
+                },
+                commitments: {
+                    prf: {
+                        value: 'uJMOSJdpAvZ/DLtQuMKRH8wGRvvM9L+2pELvfUCoNR9IrnIG7oCD4o01e+gIgD+C',
+                    },
+                    credCounter: {
+                        value: 'sKpl9CCp8/q2HT+HXuvMIh5DFUv68bY2Xazpm/8gd43nADQ3YxIi6EX9mRfI0odL',
+                    },
+                    maxAccounts: {
+                        value: 'hp4r3bLGBwPs1RK1W3crr3VpH4G7xFNi+I5avNq4WiNxSpLUb+QEVzZNUGq8IgKj',
+                    },
+                    idCredSecSharingCoeff: [
+                        {
+                            value: 'i6xECi5GzL+/p2jGrZnyq/JfizJ6eV7PI7K4BMMnAi8G0KztC17tZYmaPvMCmATs',
+                        },
+                    ],
+                },
+            },
+        },
+    },
+    threshold: {
+        value: 1,
+    },
+    encryptedBalance: {
+        selfAmount: {
+            value: 'wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        },
+    },
+    encryptionKey: {
+        value: 'sUy/5EoCxrH3hxEXbV9DcpU2eqTyqMJVHuENJaA63GnWGjMqBYlxkZ2tcxLh/JTFqnMARbzSC7XCQ0nbKdlJ92fnL3zORZ3BY8S5PHgKfX9lgB3aj/fk/Ab98aGyRidv',
+    },
+    index: {
+        value: '11',
+    },
+    address: {
+        value: 'aXUkBsyTn8kMpqc7V87hCZY1R/lCAG0hkUSST4SF+w0=',
+    },
+};
+
+export const stakingInfoBaker = {
+    baker: {
+        stakedAmount: { value: '7349646704751788' },
+        restakeEarnings: true,
+        bakerInfo: {
+            bakerId: { value: '5' },
+            electionKey: {
+                value: 'oJBoHsezXvOnce1D67Zyj9leSyZ6vt+pXx3BdyAZPcs=',
+            },
+            signatureKey: {
+                value: 'w4XMtcigcQoWLywQcSN0RlD/NfAAQL+iYtl0v7PD+PE=',
+            },
+            aggregationKey: {
+                value: 'sYoC3nSCblX26twPMdDZpu37KZPQMOZRNvHhJWppulI6y0D6TTBNBmiqMHwZJXoKEHJucBSckE4e8prtsmecglmX4/FO3TA78nbywLDFpMSHD/8MBDFQvga3FUZr5WTE',
+            },
+        },
+        poolInfo: {
+            openStatus: 'OPEN_STATUS_CLOSED_FOR_ALL',
+            commissionRates: {
+                finalization: { partsPerHundredThousand: 100000 },
+                baking: { partsPerHundredThousand: 10000 },
+                transaction: { partsPerHundredThousand: 10000 },
+            },
+        },
+    },
+};
+
+export const stakingInfoDelegator = {
+    delegator: {
+        stakedAmount: { value: '620942412516' },
+        restakeEarnings: true,
+        target: { passive: {} },
+    },
+};
+
+export const blockItemStatus = {
+    finalized: {
+        outcome: {
+            blockHash: {
+                value: 'LZ4aCBgZrY2/gdWoguovU1LLNCn8ErDsGMExo2B1GmY=',
+            },
+            outcome: {
+                index: {},
+                energyCost: {},
+                hash: {
+                    value: 'PegjuHbQXN0zoxGg+EEkB59fZ3r7JTTElD+DBZPtxlA=',
+                },
+                update: {
+                    effectiveTime: {},
+                    payload: {
+                        microCcdPerEuroUpdate: {
+                            value: {
+                                numerator: '17592435270983729152',
+                                denominator: '163844642115',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const instanceInfo = {
+    v1: {
+        owner: {
+            value: '0YBPp1cC7ISiGOEh3OLFvm9rCgolsXjymRwBmxeX1R4=',
+        },
+        amount: {},
+        methods: [
+            {
+                value: 'weather.get',
+            },
+            {
+                value: 'weather.set',
+            },
+        ],
+        name: {
+            value: 'init_weather',
+        },
+        sourceModule: {
+            value: 'Z9VoQzvXLkMmJB8mIhPXf0RtuLoD37o1GuNcGy5+UQk=',
+        },
+    },
+};
+
+export const invokeInstanceResponseV0 = {
+    success: {
+        usedEnergy: { value: '342' },
+        effects: [
+            {
+                updated: {
+                    address: { index: '6' },
+                    instigator: {
+                        account: {
+                            value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+                        },
+                    },
+                    amount: { value: '42' },
+                    parameter: {},
+                    receiveName: { value: 'PiggyBank.insert' },
+                },
+            },
+        ],
+    },
+};

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -198,22 +198,25 @@ export const instanceInfo = {
 };
 
 export const invokeInstanceResponseV0 = {
-    success: {
-        usedEnergy: { value: '342' },
-        effects: [
-            {
-                updated: {
-                    address: { index: '6' },
-                    instigator: {
-                        account: {
-                            value: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
-                        },
-                    },
-                    amount: { value: '42' },
-                    parameter: {},
-                    receiveName: { value: 'PiggyBank.insert' },
-                },
+    tag: 'success',
+    usedEnergy: 342n,
+    returnValue: undefined,
+    events: [
+        {
+            tag: "Updated",
+            events: [],
+            amount: 1n,
+            address: {
+                index: 6n,
+                subindex: 0n,
             },
-        ],
-    },
+            contractVersion: 0,
+            instigator: {
+                type: "AddressAccount",
+                address: "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
+            },
+            message: '',
+            receiveName: 'PiggyBank.insert',
+        },
+    ]
 };

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -1,3 +1,5 @@
+import { AccountAddress, CcdAmount, ModuleReference } from "@concordium/common-sdk";
+
 export const accountInfo = {
     sequenceNumber: {
         value: '19',
@@ -161,7 +163,7 @@ export const blockItemStatusTransfer = {
             hash: '502332239efc0407eebef5c73c390080e5d7e1b127ff29f786a62b3c9ab6cfe7',
             sender: '4fKPBDf9r5vhEpoeNY7SJbZv8bAJvYYyJSEggZkNyQPgao8iLy',
             transactionType: 'transfer',
-            event: {
+            transfer: {
                 amount: 1000000n,
                 tag: 'Transferred',
                 to: {
@@ -175,26 +177,15 @@ export const blockItemStatusTransfer = {
 };
 
 export const instanceInfo = {
-    v1: {
-        owner: {
-            value: '0YBPp1cC7ISiGOEh3OLFvm9rCgolsXjymRwBmxeX1R4=',
-        },
-        amount: {},
+    version: 1,
+        owner: new AccountAddress('4Y1c27ZRpRut9av69n3i1uhfeDp4XGuvsm9fkEjFvgpoxXWxQB'),
+        amount: new CcdAmount(0n),
         methods: [
-            {
-                value: 'weather.get',
-            },
-            {
-                value: 'weather.set',
-            },
+            'weather.get',
+            'weather.set',
         ],
-        name: {
-            value: 'init_weather',
-        },
-        sourceModule: {
-            value: 'Z9VoQzvXLkMmJB8mIhPXf0RtuLoD37o1GuNcGy5+UQk=',
-        },
-    },
+        name: 'init_weather',
+    sourceModule: new ModuleReference('67d568433bd72e4326241f262213d77f446db8ba03dfba351ae35c1b2e7e5109'),
 };
 
 export const invokeInstanceResponseV0 = {

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -44,6 +44,12 @@ export const accountInfo = {
                         month: 6,
                     },
                 },
+                arData: {
+                    1: {
+                        encIdCredPubShare:
+                            'qR5XDlS57nwwRXC8OgZup13YMwhsaDpCHBHlZUgt4B/8L7dCQIzx29bHRM3eiDVGkSDOag4MEvv9U+m+gWVpAKlRCfgEGOfLulEMRX8VoMs0e9w/VQjUbOyHqSFGhqYd',
+                    },
+                },
                 arThreshold: {
                     value: 1,
                 },

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -1,5 +1,3 @@
-import { BlockItemStatus } from '@concordium/common-sdk';
-
 export const accountInfo = {
     sequenceNumber: {
         value: '19',

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -1,3 +1,5 @@
+import { BlockItemStatus } from '@concordium/common-sdk';
+
 export const accountInfo = {
     sequenceNumber: {
         value: '19',
@@ -126,28 +128,48 @@ export const stakingInfoDelegator = {
     },
 };
 
-export const blockItemStatus = {
-    finalized: {
-        outcome: {
-            blockHash: {
-                value: 'LZ4aCBgZrY2/gdWoguovU1LLNCn8ErDsGMExo2B1GmY=',
-            },
-            outcome: {
-                index: {},
-                energyCost: {},
-                hash: {
-                    value: 'PegjuHbQXN0zoxGg+EEkB59fZ3r7JTTElD+DBZPtxlA=',
-                },
+export const blockItemStatusUpdate = {
+    status: 'finalized',
+    outcome: {
+        blockHash:
+            '2d9e1a081819ad8dbf81d5a882ea2f5352cb3429fc12b0ec18c131a360751a66',
+        summary: {
+            index: 0n,
+            energyCost: 0n,
+            hash: '3de823b876d05cdd33a311a0f84124079f5f677afb2534c4943f830593edc650',
+            type: 'updateTransaction',
+            effectiveTime: 0n,
+            payload: {
+                updateType: 'microGtuPerEuro',
                 update: {
-                    effectiveTime: {},
-                    payload: {
-                        microCcdPerEuroUpdate: {
-                            value: {
-                                numerator: '17592435270983729152',
-                                denominator: '163844642115',
-                            },
-                        },
-                    },
+                    numerator: 17592435270983729152n,
+                    denominator: 163844642115n,
+                },
+            },
+        },
+    },
+};
+
+export const blockItemStatusTransfer = {
+    status: 'finalized',
+    outcome: {
+        blockHash:
+            '577513ab772da146c7abb9f30c521668d7ef4fa01f4838cc51d5f59e27c7a5fc',
+        summary: {
+            type: 'accountTransaction',
+            index: 0n,
+            cost: 1480606n,
+            energyCost: 501n,
+            hash: '502332239efc0407eebef5c73c390080e5d7e1b127ff29f786a62b3c9ab6cfe7',
+            sender: '4fKPBDf9r5vhEpoeNY7SJbZv8bAJvYYyJSEggZkNyQPgao8iLy',
+            transactionType: 'transfer',
+            event: {
+                amount: 1000000n,
+                tag: 'Transferred',
+                to: {
+                    address:
+                        '3BpVX13dw29JruyMzCfde96hoB7DtQ53WMGVDMrmPtuYAbzADj',
+                    type: 'AddressAccount',
                 },
             },
         },

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -1,4 +1,8 @@
-import { AccountAddress, CcdAmount, ModuleReference } from "@concordium/common-sdk";
+import {
+    AccountAddress,
+    CcdAmount,
+    ModuleReference,
+} from '@concordium/common-sdk';
 
 export const accountInfo = {
     sequenceNumber: {
@@ -178,14 +182,15 @@ export const blockItemStatusTransfer = {
 
 export const instanceInfo = {
     version: 1,
-        owner: new AccountAddress('4Y1c27ZRpRut9av69n3i1uhfeDp4XGuvsm9fkEjFvgpoxXWxQB'),
-        amount: new CcdAmount(0n),
-        methods: [
-            'weather.get',
-            'weather.set',
-        ],
-        name: 'init_weather',
-    sourceModule: new ModuleReference('67d568433bd72e4326241f262213d77f446db8ba03dfba351ae35c1b2e7e5109'),
+    owner: new AccountAddress(
+        '4Y1c27ZRpRut9av69n3i1uhfeDp4XGuvsm9fkEjFvgpoxXWxQB'
+    ),
+    amount: new CcdAmount(0n),
+    methods: ['weather.get', 'weather.set'],
+    name: 'init_weather',
+    sourceModule: new ModuleReference(
+        '67d568433bd72e4326241f262213d77f446db8ba03dfba351ae35c1b2e7e5109'
+    ),
 };
 
 export const invokeInstanceResponseV0 = {

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -203,7 +203,7 @@ export const invokeInstanceResponseV0 = {
     returnValue: undefined,
     events: [
         {
-            tag: "Updated",
+            tag: 'Updated',
             events: [],
             amount: 1n,
             address: {
@@ -212,11 +212,11 @@ export const invokeInstanceResponseV0 = {
             },
             contractVersion: 0,
             instigator: {
-                type: "AddressAccount",
-                address: "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
+                type: 'AddressAccount',
+                address: '3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G',
             },
             message: '',
             receiveName: 'PiggyBank.insert',
         },
-    ]
+    ],
 };

--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.0
+
+### Added
+
+- `serialize_credential_deployment_payload()`
+
 ## 0.9.0 2023-1-4
 
 ### Added

--- a/packages/rust-bindings/src/aux_functions.rs
+++ b/packages/rust-bindings/src/aux_functions.rs
@@ -814,3 +814,17 @@ pub fn create_id_proof_aux(input: IdProofInput) -> Result<String> {
 
     Ok(json!(out).to_string())
 }
+
+pub fn serialize_credential_deployment_payload_aux(
+    signatures: Vec<String>,
+    unsigned_info: &str,
+) -> Result<Vec<u8>> {
+    let cdi = get_credential_deployment_info(signatures, unsigned_info)?;
+
+    let acc_cred = AccountCredential::Normal { cdi };
+
+    let mut acc_cred_ser = Vec::<u8>::new();
+    acc_cred.serial(&mut acc_cred_ser);
+
+    Ok(acc_cred_ser)
+}

--- a/packages/rust-bindings/src/external_functions.rs
+++ b/packages/rust-bindings/src/external_functions.rs
@@ -9,6 +9,7 @@ pub fn generate_unsigned_credential_ext(input: &str) -> String {
     }
 }
 
+// Will be deprecated after GRPCv1 is deprecated
 #[wasm_bindgen(js_name = getDeploymentDetails)]
 pub fn get_credential_deployment_details_ext(
     signatures: &JsValue,
@@ -311,4 +312,14 @@ pub fn get_attribute_commitment_randomness_ext(
         credential_counter,
         attribute,
     ))
+}
+
+#[wasm_bindgen(js_name = serializeCredentialDeploymentPayload)]
+pub fn serialize_credential_deployment_payload_ext(
+    signatures: &JsValue,
+    unsigned_info: &str,
+) -> Result<Vec<u8>, String> {
+    let signatures_vec: Vec<HexString> = signatures.into_serde().unwrap();
+    serialize_credential_deployment_payload_aux(signatures_vec, unsigned_info)
+        .map_err(|e| format!("Unable to get credential deployment payload due to: {}", e))
 }

--- a/packages/rust-bindings/src/helpers.rs
+++ b/packages/rust-bindings/src/helpers.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use concordium_base::{common::types::KeyIndex, id::types::*};
+use concordium_base::{common::{types::KeyIndex, base16_decode_string}, id::types::*};
 use serde_json::{from_value, Value as SerdeValue};
 use std::{collections::BTreeMap, convert::TryInto};
 
@@ -17,7 +17,7 @@ pub fn build_signature_map(signatures: &[String]) -> BTreeMap<KeyIndex, AccountO
         .map(|(index, key)| {
             (
                 KeyIndex(index.try_into().unwrap()),
-                serde_json::from_str(key).unwrap(),
+                base16_decode_string(key).unwrap(),
             )
         })
         .collect()

--- a/packages/rust-bindings/src/helpers.rs
+++ b/packages/rust-bindings/src/helpers.rs
@@ -1,5 +1,8 @@
 use anyhow::{anyhow, Result};
-use concordium_base::{common::{types::KeyIndex, base16_decode_string}, id::types::*};
+use concordium_base::{
+    common::{base16_decode_string, types::KeyIndex},
+    id::types::*,
+};
 use serde_json::{from_value, Value as SerdeValue};
 use std::{collections::BTreeMap, convert::TryInto};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,11 +1354,13 @@ __metadata:
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/grpc-transport": 2.8.1
     "@protobuf-ts/plugin": 2.8.1
+    "@types/bs58check": ^2.1.0
     "@types/google-protobuf": ^3.15.3
     "@types/jest": ^26.0.23
     "@typescript-eslint/eslint-plugin": ^4.28.1
     "@typescript-eslint/parser": ^4.28.1
     babel-jest: ^27.0.6
+    bs58check: ^2.1.2
     buffer: ^6.0.3
     cross-env: 5.0.5
     eslint: ^7.29.0


### PR DESCRIPTION
## Purpose

Introduce the rest of the GRPCv2 functions that the browser wallet needs. See #102.

## Changes

- Common:
    - `serializeAccountTransactionPayload()`
    - `serializeCredentialDeploymentPayload()`
- Rust:
    - `serialize_credential_deployment_payload()`
- NodeJS
    - `getNextAccountSequenceNumber()`
    - `getAccountInfo()`
    - `getBlockItemStatus()`
    - `getConsensusInfo()`
    - `getModuleSource()`
    - `getInstanceInfo()`
    - `invokeInstance()`
    - `getAccountTransactionSignHash()`
    - `sendAccountTransaction()`
    - `sendCredentialDeploymentTransaction()`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
