### PR TITLE
Id fixes for country codes and age helpers 

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "6.1.0-beta.1",
+    "version": "6.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/common/src/idProofs.ts
+++ b/packages/common/src/idProofs.ts
@@ -164,7 +164,7 @@ function verifySetStatement(
     statement: MembershipStatement | NonMembershipStatement,
     typeName: string
 ) {
-    if (statement.set  === undefined) {
+    if (statement.set === undefined) {
         throw new Error(typeName + 'statements must contain a lower field');
     }
     if (statement.set.length === 0) {

--- a/packages/common/src/idProofs.ts
+++ b/packages/common/src/idProofs.ts
@@ -51,11 +51,13 @@ export const EU_MEMBERS = [
 
 /**
  * Given a number x, return the date string for x years ago.
+ * @param yearsAgo how many years to go back from today
+ * @param daysOffset optional, how many days should be added to the current date
  * @returns YYYYMMDD for x years ago today in local time.
  */
 export function getPastDate(yearsAgo: number, daysOffset = 0): string {
     const date = new Date();
-    date.setDate(date.getDate() - daysOffset);
+    date.setDate(date.getDate() + daysOffset);
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
     const day = date.getDate().toString().padStart(2, '0');
     const year = (date.getFullYear() - yearsAgo).toString();

--- a/packages/common/src/idProofs.ts
+++ b/packages/common/src/idProofs.ts
@@ -124,6 +124,12 @@ function isISO3166_2(code: string) {
 }
 
 function verifyRangeStatement(statement: RangeStatement) {
+    if (statement.lower === undefined) {
+        throw new Error('Range statements must contain a lower field');
+    }
+    if (statement.upper === undefined) {
+        throw new Error('Range statements must contain an upper field');
+    }
     if (statement.upper < statement.lower) {
         throw new Error('Upper bound must be greater than lower bound');
     }
@@ -158,6 +164,9 @@ function verifySetStatement(
     statement: MembershipStatement | NonMembershipStatement,
     typeName: string
 ) {
+    if (statement.set  === undefined) {
+        throw new Error(typeName + 'statements must contain a lower field');
+    }
     if (statement.set.length === 0) {
         throw new Error(typeName + ' statements may not use empty sets');
     }
@@ -208,6 +217,12 @@ function verifyAtomicStatement(
     statement: AtomicStatement,
     existingStatements: IdStatement
 ) {
+    if (statement.type === undefined) {
+        throw new Error('Statements must contain a type field');
+    }
+    if (statement.attributeTag === undefined) {
+        throw new Error('Statements must contain an attributeTag field');
+    }
     if (!(statement.attributeTag in AttributeKeyString)) {
         throw new Error('Unknown attributeTag: ' + statement.attributeTag);
     }

--- a/packages/common/src/idProofs.ts
+++ b/packages/common/src/idProofs.ts
@@ -53,8 +53,9 @@ export const EU_MEMBERS = [
  * Given a number x, return the date string for x years ago.
  * @returns YYYYMMDD for x years ago today in local time.
  */
-export function getPastDate(yearsAgo: number): string {
+export function getPastDate(yearsAgo: number, daysOffset = 0): string {
     const date = new Date();
+    date.setDate(date.getDate() - daysOffset);
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
     const day = date.getDate().toString().padStart(2, '0');
     const year = (date.getFullYear() - yearsAgo).toString();
@@ -366,12 +367,16 @@ export class IdStatementBuilder implements StatementBuilder {
 
     /**
      * Add to the statement that the age is at maximum the given value.
-     * This adds a range statement that the date of birth is between <age> years ago and 1st of january 9999.
+     * This adds a range statement that the date of birth is between <age + 1> years ago and 1st of january 9999.
      * @param age: the maximum age allowed.
      * @returns the updated builder
      */
     addMaximumAge(age: number): IdStatementBuilder {
-        return this.addRange(AttributesKeys.dob, getPastDate(age), MAX_DATE);
+        return this.addRange(
+            AttributesKeys.dob,
+            getPastDate(age + 1, 1),
+            MAX_DATE
+        );
     }
 
     /**
@@ -384,7 +389,7 @@ export class IdStatementBuilder implements StatementBuilder {
     addAgeInRange(minAge: number, maxAge: number): IdStatementBuilder {
         return this.addRange(
             AttributesKeys.dob,
-            getPastDate(maxAge),
+            getPastDate(maxAge + 1, 1),
             getPastDate(minAge)
         );
     }

--- a/packages/common/src/idProofs.ts
+++ b/packages/common/src/idProofs.ts
@@ -107,7 +107,7 @@ function isISO8601(date: string): boolean {
 }
 
 function isISO3166_1Alpha2(code: string) {
-    return Boolean(whereAlpha2(code));
+    return Boolean(whereAlpha2(code)) && /^[A-Z][A-Z]$/.test(code);
 }
 
 /**
@@ -165,7 +165,7 @@ function verifySetStatement(
             if (!statement.set.every(isISO3166_1Alpha2)) {
                 throw new Error(
                     statement.attributeTag +
-                        ' values must be ISO3166-1 Alpha 2 codes'
+                        ' values must be ISO3166-1 Alpha 2 codes in upper case'
                 );
             }
             break;
@@ -176,7 +176,7 @@ function verifySetStatement(
                 )
             ) {
                 throw new Error(
-                    'idDocIssuer must be ISO3166-1 Alpha 2 or ISO3166-2 codes'
+                    'idDocIssuer must be ISO3166-1 Alpha 2  in upper case or ISO3166-2 codes'
                 );
             }
             break;

--- a/packages/common/test/idProofs.test.ts
+++ b/packages/common/test/idProofs.test.ts
@@ -172,7 +172,7 @@ test('Maximum age 17 gives negative inf - 17.9999 range', () => {
         .addMaximumAge(17)
         .getStatement()[0] as RangeStatement;
     expect(statement.upper).toBe('99990101');
-    expect(statement.lower).toBe('20020101');
+    expect(statement.lower).toBe('20020103');
 });
 
 test('Age between 14 and 17 gives 14 - 17.9999 range', () => {
@@ -182,7 +182,7 @@ test('Age between 14 and 17 gives 14 - 17.9999 range', () => {
         .addAgeInRange(14, 17)
         .getStatement()[0] as RangeStatement;
     expect(statement.upper).toBe('20060102');
-    expect(statement.lower).toBe('20020101');
+    expect(statement.lower).toBe('20020103');
 });
 
 test('Age between 1 and 1 gives 1 - 1.9999 range', () => {
@@ -192,5 +192,5 @@ test('Age between 1 and 1 gives 1 - 1.9999 range', () => {
         .addAgeInRange(1, 1)
         .getStatement()[0] as RangeStatement;
     expect(statement.upper).toBe('20190102');
-    expect(statement.lower).toBe('20180101');
+    expect(statement.lower).toBe('20180103');
 });

--- a/packages/common/test/idProofs.test.ts
+++ b/packages/common/test/idProofs.test.ts
@@ -3,6 +3,7 @@ import {
     StatementTypes,
     attributesWithRange,
     attributesWithSet,
+    RangeStatement,
 } from '../src/idProofTypes';
 import { getIdProof, IdStatementBuilder } from '../src/idProofs';
 import fs from 'fs';
@@ -147,4 +148,19 @@ test('Can create id Proof', () => {
     expect(proofValue[0].proof).toBeDefined();
     expect(proofValue[1].proof).toBeDefined();
     expect(proofValue[2].proof).toBeDefined();
+});
+
+test('Non uppercase ISO3166_1Alpha2 are rejected', () => {
+    const builder = new IdStatementBuilder(true);
+    expect(() =>
+        builder.addMembership(AttributesKeys.nationality, ['dk'])
+    ).toThrow();
+    expect(() =>
+        builder.addMembership(AttributesKeys.nationality, ['Dk'])
+    ).toThrow();
+    expect(() =>
+        builder.addMembership(AttributesKeys.nationality, ['dK'])
+    ).toThrow();
+    builder.addMembership(AttributesKeys.nationality, ['DK']);
+    expect(builder.getStatement().length).toBe(1);
 });

--- a/packages/common/test/idProofs.test.ts
+++ b/packages/common/test/idProofs.test.ts
@@ -164,3 +164,33 @@ test('Non uppercase ISO3166_1Alpha2 are rejected', () => {
     builder.addMembership(AttributesKeys.nationality, ['DK']);
     expect(builder.getStatement().length).toBe(1);
 });
+
+test('Maximum age 17 gives negative inf - 17.9999 range', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2020-01-02'));
+    const builder = new IdStatementBuilder(true);
+    const statement = builder
+        .addMaximumAge(17)
+        .getStatement()[0] as RangeStatement;
+    expect(statement.upper).toBe('99990101');
+    expect(statement.lower).toBe('20020101');
+});
+
+test('Age between 14 and 17 gives 14 - 17.9999 range', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2020-01-02'));
+    const builder = new IdStatementBuilder(true);
+    const statement = builder
+        .addAgeInRange(14, 17)
+        .getStatement()[0] as RangeStatement;
+    expect(statement.upper).toBe('20060102');
+    expect(statement.lower).toBe('20020101');
+});
+
+test('Age between 1 and 1 gives 1 - 1.9999 range', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2020-01-02'));
+    const builder = new IdStatementBuilder(true);
+    const statement = builder
+        .addAgeInRange(1, 1)
+        .getStatement()[0] as RangeStatement;
+    expect(statement.upper).toBe('20190102');
+    expect(statement.lower).toBe('20180101');
+});

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -55,7 +55,7 @@
         "build": "([ ! -e \"grpc\" ] && yarn generate) || true && tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "6.1.0-beta.1",
+        "@concordium/common-sdk": "6.1.0",
         "@grpc/grpc-js": "^1.3.4",
         "buffer": "^6.0.3",
         "google-protobuf": "^3.20.1"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "3.1.0-beta.1",
+    "version": "3.1.0",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
@@ -48,7 +48,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "6.1.0-beta.1",
+        "@concordium/common-sdk": "6.1.0",
         "@concordium/rust-bindings": "0.8.0",
         "buffer": "^6.0.3",
         "process": "^0.11.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@6.1.0-beta.1, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@6.1.0, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
@@ -1349,7 +1349,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 6.1.0-beta.1
+    "@concordium/common-sdk": 6.1.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@types/google-protobuf": ^3.15.3
@@ -1384,7 +1384,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 6.1.0-beta.1
+    "@concordium/common-sdk": 6.1.0
     "@concordium/rust-bindings": 0.8.0
     "@typescript-eslint/eslint-plugin": ^4.28.1
     "@typescript-eslint/parser": ^4.28.1


### PR DESCRIPTION
## Purpose

 - Restrict ISO3166_1Alpha2 codes to be upper case.
 - Fix how age helpers handle upper bound of an age.
 - Add explicit checks for each field when verifying statements.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

