### PR TITLE
Grpcv2-PR3: Streams and getblocks

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.4.0
+
+- Added `getFinalizedBlocks()` & `getBlocks()` GRPCv2 functions.
+- Added public helper function `waitForTransactionFinalization()` to client
+
 ## 6.3.0
 
 ### Added

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -368,6 +368,7 @@ export default class ConcordiumNodeClient {
             }
 
             try {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 for await (const _ of blockStream) {
                     const response = await this.getBlockItemStatus(
                         transactionHash

--- a/packages/common/src/GRPCTypeTranslation.ts
+++ b/packages/common/src/GRPCTypeTranslation.ts
@@ -1653,6 +1653,15 @@ export function instanceInfo(instanceInfo: v2.InstanceInfo): v1.InstanceInfo {
     }
 }
 
+export function commonBlockInfo(
+    blockInfo: v2.ArrivedBlockInfo | v2.FinalizedBlockInfo
+): v1.CommonBlockInfo {
+    return {
+        hash: unwrapValToHex(blockInfo.hash),
+        height: unwrap(blockInfo.height?.value),
+    };
+}
+
 // ---------------------------- //
 // --- V1 => V2 translation --- //
 // ---------------------------- //

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -540,6 +540,14 @@ export interface BlockInfo {
     transactionEnergyCost: bigint;
 }
 
+export interface CommonBlockInfo {
+    hash: HexString;
+    height: bigint;
+}
+
+export type ArrivedBlockInfo = CommonBlockInfo;
+export type FinalizedBlockInfo = CommonBlockInfo;
+
 export interface ConsensusStatus {
     bestBlock: string;
     genesisBlock: string;

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -130,6 +130,16 @@ export function secondsSinceEpoch(date: Date): bigint {
     return BigInt(Math.floor(date.getTime() / 1000));
 }
 
+// Retrieves a value that might be undefined. Throws if value is undefined
+export function unwrap<A>(x: A | undefined): A {
+    if (x === undefined) {
+        console.trace();
+        throw Error('Undefined value found.');
+    } else {
+        return x;
+    }
+}
+
 // Maps a `Record<A,C>` to a `Record<B,D>`.
 // Works the same way as a list mapping, allowing both a value and key mapping.
 // If `keyMapper()` is not provided, it will map `Record<A,C>` to `Record<A,D>`
@@ -152,12 +162,27 @@ export function mapRecord<
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-// Retrieves a value that might be undefined. Throws if value is undefined
-export function unwrap<A>(x: A | undefined): A {
-    if (x === undefined) {
-        console.trace();
-        throw Error('Undefined value found.');
-    } else {
-        return x;
-    }
+// Maps an infinite stream of type A to an infinite stream of type B
+export function mapAsyncIterable<A, B>(
+    stream: AsyncIterable<A>,
+    mapper: (x: A) => B
+): AsyncIterable<B> {
+    return {
+        [Symbol.asyncIterator]() {
+            return {
+                async next() {
+                    for await (const val of stream) {
+                        return {
+                            done: false,
+                            value: mapper(val),
+                        };
+                    }
+                    return {
+                        done: true,
+                        value: undefined,
+                    };
+                },
+            };
+        },
+    };
 }

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -162,9 +162,9 @@ export function mapRecord<
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-/** 
+/**
  * Maps an infinite stream of type A to an infinite stream of type B
- * @param mapper: function used to map each element from type A to B.   
+ * @param mapper: function used to map each element from type A to B.
  */
 export function mapAsyncIterable<A, B>(
     stream: AsyncIterable<A>,

--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -162,7 +162,10 @@ export function mapRecord<
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-// Maps an infinite stream of type A to an infinite stream of type B
+/** 
+ * Maps an infinite stream of type A to an infinite stream of type B
+ * @param mapper: function used to map each element from type A to B.   
+ */
 export function mapAsyncIterable<A, B>(
     stream: AsyncIterable<A>,
     mapper: (x: A) => B

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -228,3 +228,80 @@ const blockHash = 'fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e307
 const moduleRef = '7e8398adc406a97db4d869c3fd7adc813a3183667a3a7db078ebae6f7dce5f64';
 const source = await client.getModuleSource(moduleReference, blockHash);
 ```
+
+## getBlocks
+Returns a stream of blocks that is iterable. The following code will recieved blocks
+as long as there is a connection to the node:
+
+```js
+// Create stream
+const blockStream = client.getBlocks();
+
+// Prints blocks infinitely
+for await (const block of blockStream) {
+    console.log(block)
+}
+```
+
+You can pass it an abort signal to close the connection. This is particurlary useful for this
+function as it otherwise continues forever. An example of how to use `AbortSignal` can be seen below:
+
+```js
+// Create abort controller and block stream
+const ac = new AbortController();
+const blockStream = client.getBlocks(ac.signal);
+
+// Only get one item then break
+for await (const block of blockStream) {
+    console.log(block)
+    break
+}
+
+// Closes the stream
+ac.abort();
+```
+
+## getFinalizedBlocks
+Works exactly like `getBlocks()` but only returns finalized blocks:
+
+```js
+// Create stream
+const blockStream = client.getFinalizedBlocks();
+
+// Prints blocks infinitely
+for await (const block of blockStream) {
+    console.log(block)
+}
+```
+
+Likewise, you can also pass it an `AbortSignal`:
+
+```js
+// Create abort controller and block stream
+const ac = new AbortController();
+const blockStream = client.getFinalizedBlocks(ac.signal);
+
+// Only get one item then break
+for await (const block of blockStream) {
+    console.log(block)
+    break
+}
+
+// Closes the stream
+ac.abort();
+```
+
+### waitForTransactionFinalization
+This function waits for the given transaction hash (given as a hex string) to finalize and then returns
+the blockhash of the block that contains given transaction as a hex string.
+
+```js
+const transactionHash = await client.sendAccountTransaction(
+    someTransaction,
+    signature
+);
+
+const blockHash = await client.waitForTransactionFinalization(
+    transactionHash
+);
+```

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -230,7 +230,7 @@ const source = await client.getModuleSource(moduleReference, blockHash);
 ```
 
 ## getBlocks
-Returns a stream of blocks that is iterable. The following code will recieved blocks
+Returns a stream of blocks that is iterable. The following code will receive blocks
 as long as there is a connection to the node:
 
 ```js

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -1,27 +1,6 @@
 import * as fs from 'fs';
 import { Buffer } from 'buffer/';
 import { BoolResponse, JsonResponse } from '../grpc/concordium_p2p_rpc_pb';
-import createConcordiumClientV2 from '../src/clientV2';
-import ConcordiumNodeClientV2 from '@concordium/common-sdk/lib/GRPCClient';
-import { credentials, Metadata } from '@grpc/grpc-js/';
-
-/**
- * Creates a client to communicate with a local concordium-node
- * used for automatic tests.
- */
-export function getNodeClientV2(
-    address = 'node.testnet.concordium.com',
-    port = 20000
-): ConcordiumNodeClientV2 {
-    const metadata = new Metadata();
-    return createConcordiumClientV2(
-        address,
-        port,
-        credentials.createInsecure(),
-        metadata,
-        { timeout: 15000 }
-    );
-}
 
 export function intListToStringList(jsonStruct: string): string {
     return jsonStruct.replace(/(\-?[0-9]+)/g, '"$1"');

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -1,6 +1,27 @@
 import * as fs from 'fs';
 import { Buffer } from 'buffer/';
 import { BoolResponse, JsonResponse } from '../grpc/concordium_p2p_rpc_pb';
+import createConcordiumClientV2 from '../src/clientV2';
+import ConcordiumNodeClientV2 from '@concordium/common-sdk/lib/GRPCClient';
+import { credentials, Metadata } from '@grpc/grpc-js/';
+
+/**
+ * Creates a client to communicate with a local concordium-node
+ * used for automatic tests.
+ */
+export function getNodeClientV2(
+    address = 'node.testnet.concordium.com',
+    port = 20000
+): ConcordiumNodeClientV2 {
+    const metadata = new Metadata();
+    return createConcordiumClientV2(
+        address,
+        port,
+        credentials.createInsecure(),
+        metadata,
+        { timeout: 15000 }
+    );
+}
 
 export function intListToStringList(jsonStruct: string): string {
     return jsonStruct.replace(/(\-?[0-9]+)/g, '"$1"');

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -535,7 +535,7 @@ test.each([clientV2, clientWeb])('createAccount', async (client) => {
     ).rejects.toThrow('expired');
 });
 
-// For tests that take a long time to run, is skipped by default
+// Tests, which take a long time to run, are skipped by default
 describe.skip('Long run-time test suite', () => {
     const longTestTime = 45000;
 

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -1,7 +1,5 @@
-import { credentials, Metadata } from '@grpc/grpc-js/';
 import * as v1 from '@concordium/common-sdk';
 import * as v2 from '../../common/grpc/v2/concordium/types';
-import createConcordiumClientV2 from '../src/clientV2';
 import { testnetBulletproofGenerators } from './resources/bulletproofgenerators';
 import ConcordiumNodeClientV2, {
     getAccountIdentifierInput,
@@ -24,41 +22,24 @@ import {
 } from './testHelpers';
 import * as ed from '@noble/ed25519';
 import * as expected from './resources/expectedJsons';
+import { getNodeClientV2 } from '../src/util';
 import { serializeAccountTransaction } from '@concordium/common-sdk/lib/serialization';
 import { unwrap } from '@concordium/common-sdk/lib/util';
-import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 
 import { TextEncoder, TextDecoder } from 'util';
 import 'isomorphic-fetch';
+import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 global.TextEncoder = TextEncoder as any;
 global.TextDecoder = TextDecoder as any;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-/**
- * Creates a client to communicate with a local concordium-node
- * used for automatic tests.
- */
-function getNodeClientV2(
-    address = 'node.testnet.concordium.com',
-    port = 20000
-): ConcordiumNodeClientV2 {
-    const metadata = new Metadata();
-    return createConcordiumClientV2(
-        address,
-        port,
-        credentials.createInsecure(),
-        metadata,
-        { timeout: 15000 }
-    );
-}
-
 // TODO find nice way to move this to web/common
-function getNodeClientWeb(
+export function getNodeClientWeb(
     address = 'http://node.testnet.concordium.com',
     port = 20000
-) {
+): ConcordiumNodeClientV2 {
     const transport = new GrpcWebFetchTransport({
         baseUrl: `${address}:${port}`,
         timeout: 15000,

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -19,10 +19,10 @@ import {
     getModuleBuffer,
     getIdentityInput,
     getNodeClient as getNodeClientV1,
+    getNodeClientV2,
 } from './testHelpers';
 import * as ed from '@noble/ed25519';
 import * as expected from './resources/expectedJsons';
-import { getNodeClientV2 } from '../src/util';
 import { serializeAccountTransaction } from '@concordium/common-sdk/lib/serialization';
 import { unwrap } from '@concordium/common-sdk/lib/util';
 

--- a/packages/nodejs/test/manualTests.test.ts
+++ b/packages/nodejs/test/manualTests.test.ts
@@ -1,0 +1,60 @@
+import * as v1 from '@concordium/common-sdk';
+import {
+    buildBasicAccountSigner,
+    signTransaction,
+} from '@concordium/common-sdk';
+import { getNodeClientV2 } from '../src/util';
+
+const clientV2 = getNodeClientV2();
+
+const testAccount = new v1.AccountAddress(
+    '3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G'
+);
+const senderAccount = new v1.AccountAddress(
+    '39zbDo5ycLdugboskzUqjme8uNnDFfAYdyAYB9csegQJ2BqLoe'
+);
+
+const senderAccountPrivateKey =
+    'dcf347bda4fc45a4318c98e80b0939c83cb6a368e84e791f88f618cace4c3c41';
+
+describe.skip('Manual test suite', () => {
+    test('waitForTransactionFinalization', async () => {
+        const nonce = (await clientV2.getNextAccountNonce(senderAccount)).nonce;
+
+        // Create local transaction
+        const header: v1.AccountTransactionHeader = {
+            expiry: new v1.TransactionExpiry(new Date(Date.now() + 3600000)),
+            nonce: nonce,
+            sender: senderAccount,
+        };
+        const simpleTransfer: v1.SimpleTransferPayload = {
+            amount: new v1.CcdAmount(100n),
+            toAddress: testAccount,
+        };
+        const accountTransaction: v1.AccountTransaction = {
+            header: header,
+            payload: simpleTransfer,
+            type: v1.AccountTransactionType.Transfer,
+        };
+
+        // Sign transaction
+        const signer = buildBasicAccountSigner(senderAccountPrivateKey);
+        const signature: v1.AccountTransactionSignature = await signTransaction(
+            accountTransaction,
+            signer
+        );
+
+        const transactionHash = await clientV2.sendAccountTransaction(
+            accountTransaction,
+            signature
+        );
+
+        const blockHash = await clientV2.waitForTransactionFinalization(
+            transactionHash,
+            undefined
+        );
+
+        console.log('Blockhash:', blockHash);
+        console.log('TransactionHash:', transactionHash);
+    }, 750000);
+});

--- a/packages/nodejs/test/testHelpers.ts
+++ b/packages/nodejs/test/testHelpers.ts
@@ -4,6 +4,8 @@ import ConcordiumNodeClient from '../src/client';
 import { IdentityInput } from '@concordium/common-sdk';
 import { decryptMobileWalletExport, EncryptedData } from '../src/wallet/crypto';
 import { MobileWalletExport } from '../src/wallet/types';
+import createConcordiumClientV2 from '../src/clientV2';
+import ConcordiumNodeClientV2 from '@concordium/common-sdk/lib/GRPCClient';
 
 export { getModuleBuffer } from '../src/util';
 
@@ -23,6 +25,24 @@ export function getNodeClient(
         credentials.createInsecure(),
         metadata,
         15000
+    );
+}
+
+/**
+ * Creates a client to communicate with a local concordium-node
+ * used for automatic tests.
+ */
+export function getNodeClientV2(
+    address = 'node.testnet.concordium.com',
+    port = 20000
+): ConcordiumNodeClientV2 {
+    const metadata = new Metadata();
+    return createConcordiumClientV2(
+        address,
+        port,
+        credentials.createInsecure(),
+        metadata,
+        { timeout: 15000 }
     );
 }
 


### PR DESCRIPTION
## Purpose

See #102

## Changes

- Added `getFinalizedBlocks()` & `getBlocks()` GRPCv2 functions.
- Added public helper function `waitForTransactionFinalization()`
