### PR TITLE
Grpcv2-PR6: `getPoolDelegators`, `getPoolDelegatorsRewardPeriod`, `getPassiveDelegators`, `getPassiveDelegatorsRewardPeriod`, `getBranches`

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -15,6 +15,7 @@
     - `getBakerList()`
     - `getPoolDelegators()`
     - `getPoolDelegatorsRewardPeriod()`
+    - `getPoolDelegatorsRewardPeriod()`
 
 ## 6.4.0
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -15,7 +15,9 @@
     - `getBakerList()`
     - `getPoolDelegators()`
     - `getPoolDelegatorsRewardPeriod()`
-    - `getPoolDelegatorsRewardPeriod()`
+    - `getPassiveDelegators()`
+    - `getPassiveDelegatorsRewardPeriod()`
+    - `getBranches()`
 
 ## 6.4.0
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -14,6 +14,7 @@
     - `getBlockInfo()`
     - `getBakerList()`
     - `getPoolDelegators()`
+    - `getPoolDelegatorsRewardPeriod()`
 
 ## 6.4.0
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -13,6 +13,7 @@
     - `getBlocksAtHeight()`
     - `getBlockInfo()`
     - `getBakerList()`
+    - `getPoolDelegators()`
 
 ## 6.4.0
 

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -690,7 +690,7 @@ export default class ConcordiumNodeClient {
      *
      * @returns a branch with a block hash and a list of branch-children
      */
-    async getBranches() {
+    async getBranches(): Promise<v1.Branch> {
         const branch = await this.client.getBranches(v2.Empty).response;
         return translate.branch(branch);
     }

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -587,7 +587,7 @@ export default class ConcordiumNodeClient {
      * The stream will end when all the delegators has been returned.
      *
      * @param baker The BakerId of the pool owner
-     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param blockHash an optional block hash to get the delegators at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of DelegatorInfo
      */
@@ -615,7 +615,7 @@ export default class ConcordiumNodeClient {
      * The stream will end when all the delegators has been returned.
      *
      * @param baker The BakerId of the pool owner
-     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param blockHash an optional block hash to get the delegators at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of DelegatorRewardPeriodInfo
      */
@@ -644,7 +644,7 @@ export default class ConcordiumNodeClient {
      * are immediately visible in this list.
      * The stream will end when all the delegators has been returned.
      *
-     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param blockHash an optional block hash to get the delegators at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of DelegatorInfo
      */
@@ -668,7 +668,7 @@ export default class ConcordiumNodeClient {
      * stake in the reward period containing the given block.
      * The stream will end when all the delegators has been returned.
      *
-     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param blockHash an optional block hash to get the delegators at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of DelegatorRewardPeriodInfo
      */

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -576,6 +576,30 @@ export default class ConcordiumNodeClient {
         const bakers = this.client.getBakerList(block, opts).responses;
         return mapAsyncIterable(bakers, (x) => x.value);
     }
+
+    /**
+     * Get the registered delegators of a given pool at the end of a given block.
+     * In contrast to the `GetPoolDelegatorsRewardPeriod` which returns delegators
+     * that are fixed for the reward period of the block, this endpoint returns the
+     * list of delegators that are registered in the block. Any changes to delegators
+     * are immediately visible in this list.
+     * The stream will end when all the delegators has been returned.
+     *
+     * @param baker The BakerId of the pool owner
+     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @returns a stream of DelegatorInfo
+     */
+    getPoolDelegators(
+        baker: v1.BakerId,
+        blockHash?: HexString
+    ): AsyncIterable<v1.DelegatorInfo> {
+        const request: v2.GetPoolDelegatorsRequest = {
+            blockHash: getBlockHashInput(blockHash),
+            baker: { value: baker },
+        };
+        const delegatorInfo = this.client.getPoolDelegators(request).responses;
+        return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
+    }
 }
 
 export function getBlockHashInput(blockHash?: HexString): v2.BlockHashInput {

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -617,13 +617,13 @@ export default class ConcordiumNodeClient {
      * @param baker The BakerId of the pool owner
      * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
-     * @returns a stream of DelegatorInfo
+     * @returns a stream of DelegatorRewardPeriodInfo
      */
     getPoolDelegatorsRewardPeriod(
         baker: v1.BakerId,
         blockHash?: HexString,
         abortSignal?: AbortSignal
-    ): AsyncIterable<v1.DelegatorInfo> {
+    ): AsyncIterable<v1.DelegatorRewardPeriodInfo> {
         const opts = { abort: abortSignal };
         const request: v2.GetPoolDelegatorsRequest = {
             blockHash: getBlockHashInput(blockHash),
@@ -659,6 +659,40 @@ export default class ConcordiumNodeClient {
             opts
         ).responses;
         return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
+    }
+
+    /**
+     * Get the fixed passive delegators for the reward period of the given block.
+     * In contracts to the `GetPassiveDelegators` which returns delegators registered
+     * for the given block, this endpoint returns the fixed delegators contributing
+     * stake in the reward period containing the given block.
+     * The stream will end when all the delegators has been returned.
+     *
+     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param abortSignal an optional AbortSignal to close the stream.
+     * @returns a stream of DelegatorRewardPeriodInfo
+     */
+    getPassiveDelegatorsRewardPeriod(
+        blockHash?: HexString,
+        abortSignal?: AbortSignal
+    ): AsyncIterable<v1.DelegatorRewardPeriodInfo> {
+        const opts = { abort: abortSignal };
+        const blockHashInput = getBlockHashInput(blockHash);
+        const delegatorInfo = this.client.getPassiveDelegatorsRewardPeriod(
+            blockHashInput,
+            opts
+        ).responses;
+        return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
+    }
+
+    /**
+     * Get the current branches of blocks starting from and including the last finalized block.
+     *
+     * @returns a branch with a block hash and a list of branch-children
+     */
+    async getBranches() {
+        const branch = await this.client.getBranches(v2.Empty).response;
+        return translate.branch(branch);
     }
 }
 

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -591,13 +591,40 @@ export default class ConcordiumNodeClient {
      */
     getPoolDelegators(
         baker: v1.BakerId,
-        blockHash?: HexString
+        blockHash?: HexString,
+        abortSignal?: AbortSignal
     ): AsyncIterable<v1.DelegatorInfo> {
+        const opts = { abort: abortSignal };
         const request: v2.GetPoolDelegatorsRequest = {
             blockHash: getBlockHashInput(blockHash),
             baker: { value: baker },
         };
         const delegatorInfo = this.client.getPoolDelegators(request).responses;
+        return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
+    }
+    /**
+     * Get the fixed delegators of a given pool for the reward period of the given block.
+     * In contracts to the `GetPoolDelegators` which returns delegators registered
+     * for the given block, this endpoint returns the fixed delegators contributing
+     * stake in the reward period containing the given block.
+     * The stream will end when all the delegators has been returned.
+     *
+     * @param baker The BakerId of the pool owner
+     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @returns a stream of DelegatorInfo
+     */
+    getPoolDelegatorsRewardPeriod(
+        baker: v1.BakerId,
+        blockHash?: HexString,
+        abortSignal?: AbortSignal
+    ) {
+        const opts = { abort: abortSignal };
+        const request: v2.GetPoolDelegatorsRequest = {
+            blockHash: getBlockHashInput(blockHash),
+            baker: { value: baker },
+        };
+        const delegatorInfo =
+            this.client.getPoolDelegatorsRewardPeriod(request).responses;
         return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
     }
 }

--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -565,6 +565,7 @@ export default class ConcordiumNodeClient {
      * Get all the bakers at the end of the given block.
      *
      * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param abortSignal an optional AbortSignal to close the stream.
      * @returns an async iterable of BakerIds.
      */
     getBakerList(
@@ -587,6 +588,7 @@ export default class ConcordiumNodeClient {
      *
      * @param baker The BakerId of the pool owner
      * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of DelegatorInfo
      */
     getPoolDelegators(
@@ -599,7 +601,10 @@ export default class ConcordiumNodeClient {
             blockHash: getBlockHashInput(blockHash),
             baker: { value: baker },
         };
-        const delegatorInfo = this.client.getPoolDelegators(request).responses;
+        const delegatorInfo = this.client.getPoolDelegators(
+            request,
+            opts
+        ).responses;
         return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
     }
     /**
@@ -611,20 +616,48 @@ export default class ConcordiumNodeClient {
      *
      * @param baker The BakerId of the pool owner
      * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of DelegatorInfo
      */
     getPoolDelegatorsRewardPeriod(
         baker: v1.BakerId,
         blockHash?: HexString,
         abortSignal?: AbortSignal
-    ) {
+    ): AsyncIterable<v1.DelegatorInfo> {
         const opts = { abort: abortSignal };
         const request: v2.GetPoolDelegatorsRequest = {
             blockHash: getBlockHashInput(blockHash),
             baker: { value: baker },
         };
-        const delegatorInfo =
-            this.client.getPoolDelegatorsRewardPeriod(request).responses;
+        const delegatorInfo = this.client.getPoolDelegatorsRewardPeriod(
+            request,
+            opts
+        ).responses;
+        return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
+    }
+
+    /**
+     * Get the registered passive delegators at the end of a given block.
+     * In contrast to the `GetPassiveDelegatorsRewardPeriod` which returns delegators
+     * that are fixed for the reward period of the block, this endpoint returns the
+     * list of delegators that are registered in the block. Any changes to delegators
+     * are immediately visible in this list.
+     * The stream will end when all the delegators has been returned.
+     *
+     * @param blockHash an optional block hash to get the instance states at, otherwise retrieves from last finalized block.
+     * @param abortSignal an optional AbortSignal to close the stream.
+     * @returns a stream of DelegatorInfo
+     */
+    getPassiveDelegators(
+        blockHash?: HexString,
+        abortSignal?: AbortSignal
+    ): AsyncIterable<v1.DelegatorInfo> {
+        const opts = { abort: abortSignal };
+        const blockHashInput = getBlockHashInput(blockHash);
+        const delegatorInfo = this.client.getPassiveDelegators(
+            blockHashInput,
+            opts
+        ).responses;
         return mapAsyncIterable(delegatorInfo, translate.delegatorInfo);
     }
 }

--- a/packages/common/src/GRPCTypeTranslation.ts
+++ b/packages/common/src/GRPCTypeTranslation.ts
@@ -1704,6 +1704,18 @@ export function blockInfo(blockInfo: v2.BlockInfo): v1.BlockInfo {
     };
 }
 
+export function delegatorInfo(
+    delegatorInfo: v2.DelegatorInfo
+): v1.DelegatorInfo {
+    return {
+        account: unwrapToBase58(delegatorInfo.account),
+        stake: unwrap(delegatorInfo.stake?.value),
+        ...(delegatorInfo.pendingChange && {
+            pendingChange: trPendingChange(delegatorInfo.pendingChange),
+        }),
+    };
+}
+
 // ---------------------------- //
 // --- V1 => V2 translation --- //
 // ---------------------------- //

--- a/packages/common/src/GRPCTypeTranslation.ts
+++ b/packages/common/src/GRPCTypeTranslation.ts
@@ -1716,6 +1716,13 @@ export function delegatorInfo(
     };
 }
 
+export function branch(branchV2: v2.Branch): v1.Branch {
+    return {
+        blockHash: unwrapValToHex(branchV2.blockHash),
+        children: branchV2.children.map(branch),
+    };
+}
+
 // ---------------------------- //
 // --- V1 => V2 translation --- //
 // ---------------------------- //

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -992,10 +992,19 @@ export interface ArInfo {
     arPublicKey: string;
 }
 
-export interface DelegatorInfo {
+interface DelegatorInfoCommon {
     account: Base58String;
     stake: Amount;
+}
+export interface DelegatorInfo extends DelegatorInfoCommon {
     pendingChange?: StakePendingChange;
+}
+
+export type DelegatorRewardPeriodInfo = DelegatorInfoCommon;
+
+export interface Branch {
+    blockHash: HexString;
+    children: Branch[];
 }
 
 export enum BlockItemKind {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -992,6 +992,12 @@ export interface ArInfo {
     arPublicKey: string;
 }
 
+export interface DelegatorInfo {
+    account: Base58String;
+    stake: Amount;
+    pendingChange?: StakePendingChange;
+}
+
 export enum BlockItemKind {
     AccountTransactionKind = 0,
     CredentialDeploymentKind = 1,

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -513,10 +513,38 @@ The stream will end when all the delegators has been returned.
 If a blockhash is not supplied it will pick the latest finalized block. An optional abort signal can also be provided that closes the stream.
 ```js
 const blockHash = "fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e";
-const delegatorInfoList = await client.getPoolDelegatorsRewardPeriod(blockHash);
+const delegatorInfoList = await client.getPassiveDelegators(blockHash);
 
 for await (const delegatorInfo of delegatorInfoList) {
     console.log(delegatorInfo);
 }
+...
+```
+
+## getPassiveDelegatorsRewardPeriod
+Get the fixed passive delegators for the reward period of the given block.
+In contracts to the `GetPassiveDelegators` which returns delegators registered
+for the given block, this endpoint returns the fixed delegators contributing
+stake in the reward period containing the given block.
+The stream will end when all the delegators has been returned.
+
+If a blockhash is not supplied it will pick the latest finalized block. An optional abort signal can also be provided that closes the stream.
+```js
+const blockHash = "fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e";
+const delegatorInfoList = await client.getPassiveDelegatorsRewardPeriod(blockHash);
+
+for await (const delegatorInfo of delegatorInfoList) {
+    console.log(delegatorInfo);
+}
+...
+```
+
+## getBranches
+Get the current branches of blocks starting from and including the last finalized block.
+```js
+const branch = await client.getBranches();
+
+console.log(branch.blockhash);
+console.log(branch.children);
 ...
 ```

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -464,3 +464,17 @@ for await (const id of bakerIds) {
 }
 ...
 ```
+
+## getPoolDelegators
+Get the registered delegators of a given pool at the end of a given block.
+
+If a blockhash is not supplied it will pick the latest finalized block. An optional abort signal can also be provided that closes the stream.
+```js
+const blockHash = "fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e";
+const delegatorInfoList = await client.getPoolDelegators(15n, blockHash);
+
+for await (const delegatorInfo of delegatorInfoList) {
+    console.log(delegatorInfo);
+}
+...
+```

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -467,11 +467,34 @@ for await (const id of bakerIds) {
 
 ## getPoolDelegators
 Get the registered delegators of a given pool at the end of a given block.
+In contrast to the `GetPoolDelegatorsRewardPeriod` which returns delegators
+that are fixed for the reward period of the block, this endpoint returns the
+list of delegators that are registered in the block. Any changes to delegators
+are immediately visible in this list.
+The stream will end when all the delegators has been returned.
 
 If a blockhash is not supplied it will pick the latest finalized block. An optional abort signal can also be provided that closes the stream.
 ```js
 const blockHash = "fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e";
 const delegatorInfoList = await client.getPoolDelegators(15n, blockHash);
+
+for await (const delegatorInfo of delegatorInfoList) {
+    console.log(delegatorInfo);
+}
+...
+```
+
+## getPoolDelegatorsRewardPeriod
+Get the fixed delegators of a given pool for the reward period of the given block.
+In contracts to the `GetPoolDelegators` which returns delegators registered
+for the given block, this endpoint returns the fixed delegators contributing
+stake in the reward period containing the given block.
+The stream will end when all the delegators has been returned.
+
+If a blockhash is not supplied it will pick the latest finalized block. An optional abort signal can also be provided that closes the stream.
+```js
+const blockHash = "fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e";
+const delegatorInfoList = await client.getPoolDelegatorsRewardPeriod(15n, blockHash);
 
 for await (const delegatorInfo of delegatorInfoList) {
     console.log(delegatorInfo);

--- a/packages/nodejs/READMEV2.md
+++ b/packages/nodejs/READMEV2.md
@@ -501,3 +501,22 @@ for await (const delegatorInfo of delegatorInfoList) {
 }
 ...
 ```
+
+## getPassiveDelegators
+Get the registered passive delegators at the end of a given block.
+In contrast to the `GetPassiveDelegatorsRewardPeriod` which returns delegators
+that are fixed for the reward period of the block, this endpoint returns the
+list of delegators that are registered in the block. Any changes to delegators
+are immediately visible in this list.
+The stream will end when all the delegators has been returned.
+
+If a blockhash is not supplied it will pick the latest finalized block. An optional abort signal can also be provided that closes the stream.
+```js
+const blockHash = "fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e";
+const delegatorInfoList = await client.getPoolDelegatorsRewardPeriod(blockHash);
+
+for await (const delegatorInfo of delegatorInfoList) {
+    console.log(delegatorInfo);
+}
+...
+```

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -641,12 +641,36 @@ test.each([clientV2, clientWeb])(
 );
 test.each([clientV2, clientWeb])('getPassiveDelegators', async (client) => {
     const blocks = await client.getBlocksAtHeight(10000n);
-    console.log(blocks[0]);
-    const delegatorInfoStream = client.getPassiveDelegators(blocks[0]);
-    const delegatorInfoList = await asyncIterableToList(delegatorInfoStream);
+    const passiveDelegatorInfoStream = client.getPassiveDelegators(blocks[0]);
+    const passiveDelegatorInfoList = await asyncIterableToList(
+        passiveDelegatorInfoStream
+    );
 
-    console.log(delegatorInfoList);
-    expect(delegatorInfoList).toEqual(expected.passiveDelegatorInfoList);
+    expect(passiveDelegatorInfoList).toEqual(expected.passiveDelegatorInfoList);
+});
+
+test.each([clientV2, clientWeb])(
+    'getPassiveDelegatorsRewardPeriod',
+    async (client) => {
+        const blocks = await client.getBlocksAtHeight(10000n);
+        const passiveDelegatorRewardInfoStream =
+            client.getPassiveDelegatorsRewardPeriod(blocks[0]);
+        const passiveDelegatorRewardInfoList = await asyncIterableToList(
+            passiveDelegatorRewardInfoStream
+        );
+
+        expect(passiveDelegatorRewardInfoList).toEqual(
+            expected.passiveDelegatorRewardInfoList
+        );
+    }
+);
+
+test.each([clientV2, clientWeb])('getBranches', async (client) => {
+    const branch = await client.getBranches();
+
+    expect(branch).toBeDefined();
+    expect(branch.blockHash).toBeDefined();
+    expect(branch.children).toBeDefined();
 });
 
 // For tests that take a long time to run, is skipped by default

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -618,6 +618,13 @@ test.each([clientV2, clientWeb])('getBakerList', async (client) => {
     expect(bakersV2).toEqual(bakersV1);
 });
 
+test.each([clientV2, clientWeb])('getPoolDelegators', async (client) => {
+    const delegatorInfoStream = client.getPoolDelegators(15n, testBlockHash);
+    const delegatorInfoList = await asyncIterableToList(delegatorInfoStream);
+
+    expect(delegatorInfoList).toEqual(expected.delegatorInfoList);
+});
+
 // For tests that take a long time to run, is skipped by default
 describe.skip('Long run-time test suite', () => {
     const longTestTime = 45000;

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -625,6 +625,22 @@ test.each([clientV2, clientWeb])('getPoolDelegators', async (client) => {
     expect(delegatorInfoList).toEqual(expected.delegatorInfoList);
 });
 
+test.each([clientV2, clientWeb])(
+    'getPoolDelegatorsRewardPeriod',
+    async (client) => {
+        const delegatorInfoStream = client.getPoolDelegatorsRewardPeriod(
+            15n,
+            testBlockHash
+        );
+        const delegatorInfoList = await asyncIterableToList(
+            delegatorInfoStream
+        );
+
+        console.log(delegatorInfoList);
+        expect(delegatorInfoList).toEqual(expected.delegatorInfoList);
+    }
+);
+
 // For tests that take a long time to run, is skipped by default
 describe.skip('Long run-time test suite', () => {
     const longTestTime = 45000;

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -636,10 +636,18 @@ test.each([clientV2, clientWeb])(
             delegatorInfoStream
         );
 
-        console.log(delegatorInfoList);
         expect(delegatorInfoList).toEqual(expected.delegatorInfoList);
     }
 );
+test.each([clientV2, clientWeb])('getPassiveDelegators', async (client) => {
+    const blocks = await client.getBlocksAtHeight(10000n);
+    console.log(blocks[0]);
+    const delegatorInfoStream = client.getPassiveDelegators(blocks[0]);
+    const delegatorInfoList = await asyncIterableToList(delegatorInfoStream);
+
+    console.log(delegatorInfoList);
+    expect(delegatorInfoList).toEqual(expected.passiveDelegatorInfoList);
+});
 
 // For tests that take a long time to run, is skipped by default
 describe.skip('Long run-time test suite', () => {

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -329,3 +329,26 @@ export const arList = [
             'b14cbfe44a02c6b1f78711176d5f437295367aa4f2a8c2551ee10d25a03adc69d61a332a058971919dad7312e1fc94c5a791a28a6d3e7ca0857c0f996f94e65da78b8d9b5de5e32164e291e553ed103bf14d6fab1f21749d59664e34813afe77',
     },
 ];
+
+export const delegatorInfoList = [
+    {
+        account: '3uX8g2uzQwBjVSJ6ZDU5cQCKhgsET6kMuRoraQH2ANB9Xa84YR',
+        stake: 40000000000n,
+    },
+    {
+        account: '4mAs6xcFw26fb6u8odkJWoe3fAK8bCJ91BwScUc36DFhh3thwD',
+        stake: 10000000n,
+    },
+    {
+        account: '3NvUNvVm5puDT2EYbo7hCF3d5AwzzCqKE18Ms6BYkKY9UShdf3',
+        stake: 3000000000n,
+    },
+    {
+        account: '3ivPxmqdRk5TX5mKpFshKzrA44bYUW2tg6EwDPvALszNoBGTK9',
+        stake: 33000000n,
+    },
+    {
+        account: '37tU96v4MQSaEgVP68M3TBRHMwZpgYSGnMer3ta3FJ8wkXtjDQ',
+        stake: 94000000n,
+    },
+];

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -352,3 +352,22 @@ export const delegatorInfoList = [
         stake: 94000000n,
     },
 ];
+
+export const passiveDelegatorInfoList = [
+    {
+        account: '4gCvJ91EeYzsTzwiC7Kr4AcFzSuDmf5wxev7FRzU3uw49WamBm',
+        stake: 1900000000n,
+    },
+    {
+        account: '4mQweXtq3zHwS7CtK5fjWkpJDUvtUSKycNa8xaEbe6kErGeXcL',
+        stake: 1000000000n,
+    },
+    {
+        account: '3irV7FF3BZbz9ejGTm7EHLUi6CQHdJUELDfyhwkHcLqXmQyUfR',
+        stake: 100000000n,
+        pendingChange: {
+            effectiveTime: new Date('2022-06-28T11:47:37.750Z'),
+            change: 'RemoveStake',
+        },
+    },
+];

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -371,3 +371,14 @@ export const passiveDelegatorInfoList = [
         },
     },
 ];
+
+export const passiveDelegatorRewardInfoList = [
+    {
+        account: '4gCvJ91EeYzsTzwiC7Kr4AcFzSuDmf5wxev7FRzU3uw49WamBm',
+        stake: 1900000000n,
+    },
+    {
+        account: '4mQweXtq3zHwS7CtK5fjWkpJDUvtUSKycNa8xaEbe6kErGeXcL',
+        stake: 1000000000n,
+    },
+];


### PR DESCRIPTION
## Purpose

See #102

## Changes
 - `getPoolDelegators()`
 - `getPoolDelegatorsRewardPeriod()`
 - `getPassiveDelegators()`
 - `getPassiveDelegatorsRewardPeriod()`
 - `getBranches()`
