### PR TITLE
signMessage and verifyMessageSignature now supports a binary message

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Bumped @concordium/rust-bindings to 0.11.0. (Includes a fix to serialization of negative numbers for smart contract values)
+- `signMessage` and `verifyMessageSignature` can now handle the message being a buffer/Uint8Array instead of only a utf8 string.
 
 ## 6.3.0 2023-02-27
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -670,6 +670,8 @@ if (!verifyMessageSignature(message, signature, accountInfo)) {
 }
 ```
 
+The message can either be a utf8 encoded string or a Uint8Array directly containing the message bytes.
+
 ## Deserialize smart contract types with only the specific type's schema
 The SDK exposes a general function to deserialize smart contract values from binary format to their JSON representation. In the previous sections the schema used was assumed to be the schema for an entire module, this function can be used with the schema containing only the specific type of the parameter, return value, event or error.
 

--- a/packages/common/src/signHelpers.ts
+++ b/packages/common/src/signHelpers.ts
@@ -55,24 +55,28 @@ export function signTransaction(
 
 /**
  * @param account the address of the account that will sign this message.
- * @param message the message to sign, assumed to be utf8 encoded.
+ * @param message the message to sign, assumed to be utf8 encoded string or a Uint8Array/buffer.
  */
-function getMessageDigest(account: AccountAddress, message: string): Buffer {
+function getMessageDigest(
+    account: AccountAddress,
+    message: string | Uint8Array
+): Buffer {
     const prepend = Buffer.alloc(8, 0);
-    const rawMessage = Buffer.from(message, 'utf8');
+    const rawMessage =
+        typeof message === 'string' ? Buffer.from(message, 'utf8') : message;
     return sha256([account.decodedAddress, prepend, rawMessage]);
 }
 
 /**
  * Helper function to sign a message.
- * Note that this function prepends the string "MyGoodPrepend" to ensure that the message is not a transaction.
+ * Note that this function prepends 8 zero-bytes to ensure that the message is not a transaction.
  * Note that the current prepend is temporary and will later be replaced.
- * @param message the message to sign, assumed to be utf8 encoded.
+ * @param message the message to sign, assumed to be utf8 encoded string or a Uint8Array/buffer.
  * @param signer An object that handles the keys of the account, and performs the actual signing.
  */
 export function signMessage(
     account: AccountAddress,
-    message: string,
+    message: string | Uint8Array,
     signer: AccountSigner
 ): Promise<AccountTransactionSignature> {
     return signer.sign(getMessageDigest(account, message));
@@ -80,12 +84,12 @@ export function signMessage(
 
 /**
  * Helper function to verify a signed message.
- * @param message the message to sign, assumed to be utf8 encoded.
+ * @param message the message to sign, assumed to be utf8 encoded string or a Uint8Array/buffer.
  * @param signature the signature of a message, from a specific account.
  * @param accountInfo the address and credentials of the account
  */
 export async function verifyMessageSignature(
-    message: string,
+    message: string | Uint8Array,
     signature: AccountTransactionSignature,
     accountInfo: Pick<
         AccountInfo,

--- a/packages/common/test/signHelpers.test.ts
+++ b/packages/common/test/signHelpers.test.ts
@@ -24,11 +24,12 @@ const TEST_CREDENTIALS = {
     },
 };
 
-test('test signMessage', async () => {
+const testEachMessageType = test.each(['test', Buffer.from('test', 'utf8')]);
+
+testEachMessageType('[%o] test signMessage', async (message) => {
     const account = new AccountAddress(
         '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5'
     );
-    const message = 'test';
     const signature = await signMessage(
         account,
         message,
@@ -41,24 +42,26 @@ test('test signMessage', async () => {
     );
 });
 
-test('verifyMessageSignature returns true on the correct address/signature', async () => {
-    const message = 'test';
-    const signature = await verifyMessageSignature(
-        message,
-        {
-            0: {
-                0: '445197d79ca90d8cc8440328dac9f307932ade0c03cc7aa575b59b746e26e5f1bca13ade5ff7a56e918ba5a32450fdf52b034cd2580929b21213263e81f7f809',
+testEachMessageType(
+    '[%o] verifyMessageSignature returns true on the correct address/signature',
+    async (message) => {
+        const signature = await verifyMessageSignature(
+            message,
+            {
+                0: {
+                    0: '445197d79ca90d8cc8440328dac9f307932ade0c03cc7aa575b59b746e26e5f1bca13ade5ff7a56e918ba5a32450fdf52b034cd2580929b21213263e81f7f809',
+                },
             },
-        },
-        {
-            accountAddress:
-                '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5',
-            accountThreshold: 1,
-            accountCredentials: TEST_CREDENTIALS,
-        } as unknown as AccountInfo
-    );
-    expect(signature).toBeTruthy();
-});
+            {
+                accountAddress:
+                    '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5',
+                accountThreshold: 1,
+                accountCredentials: TEST_CREDENTIALS,
+            } as unknown as AccountInfo
+        );
+        expect(signature).toBeTruthy();
+    }
+);
 
 test('verifyMessageSignature returns false on the incorrect address', async () => {
     const message = 'test';


### PR DESCRIPTION
## Purpose

Support messages as Buffers (/Uint8Arrays) in signHelper's `signMessage` and `verifyMessageSignature`.

## Changes

Expand the supported message type in `signMessage` and `verifyMessageSignature` to include Uint8Arrays.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.