### PR TITLE
Add installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ All serialization and most utility functions are located in this package.
 
 Contains bindings for Rust code, which is used by the common package. This package is a utility package that should not be used directly, only through the usage of the common package.
 
+# Install/updating dependencies
+To install/update dependencies for the project, run
+```
+git submodule update --init --recursive
+```
+and
+```
+yarn
+```
+
+## MacOS arm64
+When installing/updating dependencies on a mac with an arm64 processor, it might be required to explicitly set the target architecture of dependencies to x64, as not all dependencies are available for the new mac processors. This is done by replacing the `yarn` command with
+```
+npm_config_target_arch=x64 yarn
+```
+
 # Build
 
 ## Building for a release


### PR DESCRIPTION
## Purpose

Had trouble installing and building on on my machine, which has an M2 processor. Was an issue with `grpc-tools` binary not being available/buildable. Installing dependencies for x64 architecture seems to solve the problem.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
