### PR TITLE
Add private keys to generateBakerKeys output + bump versions

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+## 6.4.2 2023-04-21
+
+### Changed
+
+- `generateBakerKeys` now also returns the private baker keys.
+
 ## 6.4.1 2023-03-31
+
+### Changed
 
 - Replace use of `setImmediate` with `setTimeout` since the former is not
   supported in browsers.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "6.4.1",
+    "version": "6.4.2",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"
@@ -51,7 +51,7 @@
         "build-dev": "tsc"
     },
     "dependencies": {
-        "@concordium/rust-bindings": "0.11.0",
+        "@concordium/rust-bindings": "0.11.1",
         "@grpc/grpc-js": "^1.3.4",
         "@noble/ed25519": "^1.7.1",
         "@protobuf-ts/runtime-rpc": "^2.8.2",

--- a/packages/common/src/accountHelpers.ts
+++ b/packages/common/src/accountHelpers.ts
@@ -11,7 +11,7 @@ import {
     AccountInfoBakerV1,
     AccountInfoDelegator,
     StakePendingChangeV0,
-    BakerKeysWithProofs,
+    GenerateBakerKeysOutput,
 } from './types';
 
 export const isDelegatorAccount = (
@@ -50,11 +50,11 @@ export const isRemovalPendingChange = (
 /**
  * Generates random baker keys for the specified account, that can be used with the configureBaker transaction
  * @param account the address of the account that the keys should be added to.
- * @returns baker keys and their associated proofs
+ * @returns an object with a `keyPayload` field containing the public baker keys and their associated proofs, which should be used for the transaction payload. The object also has a `key` field containing the public baker keys and their associated private keys.
  */
 export function generateBakerKeys(
     account: AccountAddress
-): BakerKeysWithProofs {
+): GenerateBakerKeysOutput {
     const rawKeys = wasm.generateBakerKeys(account.address);
     try {
         return JSON.parse(rawKeys);

--- a/packages/common/src/accountHelpers.ts
+++ b/packages/common/src/accountHelpers.ts
@@ -50,7 +50,7 @@ export const isRemovalPendingChange = (
 /**
  * Generates random baker keys for the specified account, that can be used with the configureBaker transaction
  * @param account the address of the account that the keys should be added to.
- * @returns an object with a `keyPayload` field containing the public baker keys and their associated proofs, which should be used for the transaction payload. The object also has a `key` field containing the public baker keys and their associated private keys.
+ * @returns an object containing the public baker keys, their associated proofs and their associated private keys.
  */
 export function generateBakerKeys(
     account: AccountAddress

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1267,14 +1267,29 @@ export interface UpdateCredentialsPayload {
     currentNumberOfCredentials: bigint;
 }
 
-export interface BakerKeysWithProofs {
+export interface PublicBakerKeys {
     signatureVerifyKey: HexString;
     electionVerifyKey: HexString;
     aggregationVerifyKey: HexString;
+}
+
+export interface PrivateBakerKeys {
+    aggregationSignKey: HexString;
+    signatureSignKey: HexString;
+    electionPrivateKey: HexString;
+}
+
+export interface BakerKeyProofs {
     proofAggregation: HexString;
     proofSig: HexString;
     proofElection: HexString;
 }
+
+export type BakerKeysWithProofs = PublicBakerKeys & BakerKeyProofs;
+
+export type GenerateBakerKeysOutput = PublicBakerKeys &
+    PrivateBakerKeys &
+    BakerKeyProofs;
 
 export interface ConfigureBakerPayload {
     /* stake to bake. if set to 0, this removes the account as a baker */

--- a/packages/common/test/accountHelpers.test.ts
+++ b/packages/common/test/accountHelpers.test.ts
@@ -1,12 +1,15 @@
 import { AccountAddress } from '../src';
 import { generateBakerKeys } from '../src/accountHelpers';
 
-test('generate baker keys', async () => {
+test('generate baker keys', () => {
     const accountAddress = '3eP94feEdmhYiPC1333F9VoV31KGMswonuHk5tqmZrzf761zK5';
-    const keys = await generateBakerKeys(new AccountAddress(accountAddress));
+    const keys = generateBakerKeys(new AccountAddress(accountAddress));
     expect(typeof keys.signatureVerifyKey).toBe('string');
     expect(typeof keys.electionVerifyKey).toBe('string');
     expect(typeof keys.aggregationVerifyKey).toBe('string');
+    expect(typeof keys.signatureSignKey).toBe('string');
+    expect(typeof keys.electionPrivateKey).toBe('string');
+    expect(typeof keys.aggregationSignKey).toBe('string');
     expect(typeof keys.proofAggregation).toBe('string');
     expect(typeof keys.proofSig).toBe('string');
     expect(typeof keys.proofElection).toBe('string');

--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1 2023-4-21
+
+### Changes
+
+- `generateBakerKeys` now also returns the private keys.
+
 ## 0.11.0 2023-3-22
 
 ### Added

--- a/packages/rust-bindings/package.json
+++ b/packages/rust-bindings/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/rust-bindings",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/rust-bindings/src/aux_functions.rs
+++ b/packages/rust-bindings/src/aux_functions.rs
@@ -1,7 +1,7 @@
 use crate::{helpers::*, types::*};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use concordium_base::{
-    base::{BakerKeyPairs, BakerSignatureSignKey, BakerElectionSignKey, BakerAggregationSignKey},
+    base::{BakerAggregationSignKey, BakerElectionSignKey, BakerKeyPairs, BakerSignatureSignKey},
     common::{
         types::{KeyIndex, KeyPair, TransactionTime},
         *,
@@ -889,15 +889,14 @@ pub fn create_unsigned_credential_v1_aux(input: UnsignedCredentialInput) -> Resu
 #[serde(rename_all = "camelCase")]
 pub struct BakerKeys {
     #[serde(flatten)]
-    keys_payload: ConfigureBakerKeysPayload,
+    keys_payload:         ConfigureBakerKeysPayload,
     #[serde(serialize_with = "base16_encode", rename = "electionPrivateKey")]
     election_private_key: BakerElectionSignKey,
-    #[serde(serialize_with = "base16_encode", rename = "signatureSignKey" )]
-    signature_sign_key: BakerSignatureSignKey,
+    #[serde(serialize_with = "base16_encode", rename = "signatureSignKey")]
+    signature_sign_key:   BakerSignatureSignKey,
     #[serde(serialize_with = "base16_encode", rename = "aggregationSignKey")]
     aggregation_sign_key: BakerAggregationSignKey,
 }
-
 
 pub fn generate_baker_keys(sender: AccountAddress) -> Result<JsonString> {
     let mut csprng = thread_rng();

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.4.2 2023-4-21
+
+### Changed
+
+- Bumped @concordium/common-sdk to 6.4.2. (`generateBakerKeys` include private baker keys in output)
+
 ## 3.4.1 2023-3-31
 
 ### Changed

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
@@ -48,8 +48,8 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "6.4.1",
-        "@concordium/rust-bindings": "0.11.0",
+        "@concordium/common-sdk": "6.4.2",
+        "@concordium/rust-bindings": "0.11.1",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",
         "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,11 +1312,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@6.4.1, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@6.4.2, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
-    "@concordium/rust-bindings": 0.11.0
+    "@concordium/rust-bindings": 0.11.1
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/plugin": 2.8.1
@@ -1370,6 +1370,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/common-sdk@npm:6.4.1":
+  version: 6.4.1
+  resolution: "@concordium/common-sdk@npm:6.4.1"
+  dependencies:
+    "@concordium/rust-bindings": 0.11.0
+    "@grpc/grpc-js": ^1.3.4
+    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    iso-3166-1: ^2.1.1
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: 26cce68b496f9799359666d7ddf430c659c0250e16a96c8bfe1956162f737517896a9ab9e0c9a7a3a17117ee6d763a91cbcde20891c76d87444f67299a37c8c6
+  languageName: node
+  linkType: hard
+
 "@concordium/node-sdk@6.3.0, @concordium/node-sdk@workspace:packages/nodejs":
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
@@ -1403,18 +1423,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/rust-bindings@0.11.0, @concordium/rust-bindings@workspace:packages/rust-bindings":
+"@concordium/rust-bindings@0.11.1, @concordium/rust-bindings@workspace:packages/rust-bindings":
   version: 0.0.0-use.local
   resolution: "@concordium/rust-bindings@workspace:packages/rust-bindings"
   languageName: unknown
   linkType: soft
 
+"@concordium/rust-bindings@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@concordium/rust-bindings@npm:0.11.0"
+  checksum: a6c437cb782b7b2e9f217215dd4dbed9ffb8b3ef46fa307952aca3ae8f166cb96687de64efd18490aec7e86d58712dccb7d1a8bf63c151e3ed2a0170f066cd6d
+  languageName: node
+  linkType: hard
+
 "@concordium/web-sdk@workspace:packages/web":
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 6.4.1
-    "@concordium/rust-bindings": 0.11.0
+    "@concordium/common-sdk": 6.4.2
+    "@concordium/rust-bindings": 0.11.1
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     "@typescript-eslint/eslint-plugin": ^4.28.1


### PR DESCRIPTION
## Purpose

Have `generateBakerKeys` return the private baker keys when generating them.  

## Changes

- Added baker private keys to `generateBakerKeys` return value.
- Bumped package versions. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
