### PR TITLE
Fixed bug where `getBlockInfo` throws error on genesis blocks.

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Changed
+### Breaking changes
 - Updated `blockInfo` so that the `bakerId` field is optional, since it will be undefined for genesis blocks.
 
 ## 6.5.0 2023-5-03

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- Updated `blockInfo` so that the `bakerId` field is optional, since it will be undefined for genesis blocks.
+
 ## 6.5.0 2023-5-03
 
 ### Added

--- a/packages/common/src/GRPCTypeTranslation.ts
+++ b/packages/common/src/GRPCTypeTranslation.ts
@@ -2078,7 +2078,7 @@ export function blockInfo(blockInfo: v2.BlockInfo): v1.BlockInfo {
         blockStateHash: unwrapValToHex(blockInfo.stateHash),
         blockLastFinalized: unwrapValToHex(blockInfo.lastFinalizedBlock),
         blockHeight: unwrap(blockInfo.height?.value),
-        blockBaker: unwrap(blockInfo.baker?.value),
+        blockBaker: blockInfo.baker?.value,
         blockSlot: unwrap(blockInfo.slotNumber?.value),
         blockArriveTime: trTimestamp(blockInfo.arriveTime),
         blockReceiveTime: trTimestamp(blockInfo.receiveTime),

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -583,7 +583,7 @@ export interface BlockInfo {
     blockLastFinalized: HexString;
 
     blockHeight: bigint;
-    blockBaker: BakerId;
+    blockBaker?: BakerId;
     blockSlot: bigint;
 
     blockArriveTime: Date;


### PR DESCRIPTION
## Changes

- Updated `blockInfo` so that the `bakerId` field is optional, since it will be undefined for genesis blocks.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
