### PR TITLE
Ensure types remain compatible with gRPC v1 API

### DIFF
--- a/examples/client/getBlockChainParameters.ts
+++ b/examples/client/getBlockChainParameters.ts
@@ -62,10 +62,7 @@ const client = createConcordiumClient(
     if (isChainParametersV2(cp)) {
         console.log('Minimum block time', cp.consensusParameters.minBlockTime);
     } else if (isChainParametersV1(cp)) {
-        console.log(
-            'Minimum equity capital:',
-            cp.poolParameters.minimumEquityCapital
-        );
+        console.log('Minimum equity capital:', cp.minimumEquityCapital);
     } else {
         console.log(
             'Chain parameters is V0 and does not contain information on minimum equity capital'

--- a/examples/client/getBlockChainParameters.ts
+++ b/examples/client/getBlockChainParameters.ts
@@ -60,7 +60,7 @@ const client = createConcordiumClient(
 
     // Check version of chain parameters
     if (isChainParametersV2(cp)) {
-        console.log('Minimum block time', cp.consensusParameters.minBlockTime);
+        console.log('Minimum block time', cp.minBlockTime);
     } else if (isChainParametersV1(cp)) {
         console.log('Minimum equity capital:', cp.minimumEquityCapital);
     } else {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -7,16 +7,9 @@
 - Bumped @concordium/rust-bindings to 1.0.0. (Throws proper `Error`s when execution fails for any WASM entrypoint, with improved error messages)
 - Updated `types.ts` to conform to updated GRPC API, which includes adding more variants to existing types (all new variants take effect from protocol version 6):
   - `ChainParametersV2` added to `ChainParameters`
-  - `ChainParameters` field `microGTUPerEuro` is now called `microCCDPerEuro`.
-  - The following parameters on `ChainParametersV1` have been moved into objects to align with GRPC api:
-    - `passiveFinalizationCommission`, `passiveBakingCommission`, `passiveTransactionCommission`, `finalizationCommissionRange`, `bakingCommissionRange`, `transactionCommissionRange`, `minimumEquityCapital`, `capitalBound`, `leverageBound` have been moved to `poolParameters`
-    - `poolOwnerCooldown`, `delegatorCooldown` have been moved to `cooldownParameters` 
-    - `rewardPeriodLength`, `mintPerPayday` have been moved to `timeParameters` 
   - `BlockInfo` changed to `BlockInfoV0 | BlockInfoV1`
   - `ConsensusStatus` changed to `ConsensusStatusV0 | ConsensusStatusV1`
   - `ElectionInfo` changed to `ElectionInfoV0 | ElectionInfoV1`
-- Renamed type `MicroGtuPerEuroUpdate` to `MicroCCDPerEuroUpdate`
-- Renamed enum member `UpdateType.MicroGtuPerEuro` to `UpdateType.MicroCCDPerEuro`, along with it's corresponding string value from `"microGtuPerEuro"` to `"microCCDPerEuro"`.
 
 ### Fixed
 

--- a/packages/common/src/GRPCTypeTranslation.ts
+++ b/packages/common/src/GRPCTypeTranslation.ts
@@ -255,7 +255,7 @@ function translateChainParametersCommon(
 ): v1.ChainParametersCommon {
     return {
         euroPerEnergy: unwrap(params.euroPerEnergy?.value),
-        microCCDPerEuro: unwrap(params.microCcdPerEuro?.value),
+        microGTUPerEuro: unwrap(params.microCcdPerEuro?.value),
         accountCreationLimit: unwrap(params.accountCreationLimit?.value),
         foundationAccount: unwrapToBase58(params.foundationAccount),
     };
@@ -404,24 +404,30 @@ function trChainParametersV0(v0: v2.ChainParametersV0): v1.ChainParametersV0 {
     const commonRewardParameters = translateRewardParametersCommon(v0);
     return {
         ...common,
-        ...commonRewardParameters,
         electionDifficulty: trAmountFraction(v0.electionDifficulty?.value),
         bakerCooldownEpochs: unwrap(v0.bakerCooldownEpochs?.value),
         minimumThresholdForBaking: unwrap(v0.minimumThresholdForBaking?.value),
-        gasRewards: {
-            baker: trAmountFraction(v0.gasRewards?.baker),
-            finalizationProof: trAmountFraction(
-                v0.gasRewards?.finalizationProof
-            ),
-            accountCreation: trAmountFraction(v0.gasRewards?.accountCreation),
-            chainUpdate: trAmountFraction(v0.gasRewards?.chainUpdate),
-        },
-        mintDistribution: {
-            bakingReward: trAmountFraction(v0.mintDistribution?.bakingReward),
-            finalizationReward: trAmountFraction(
-                v0.mintDistribution?.finalizationReward
-            ),
-            mintPerSlot: trMintRate(v0.mintDistribution?.mintPerSlot),
+        rewardParameters: {
+            ...commonRewardParameters,
+            gASRewards: {
+                baker: trAmountFraction(v0.gasRewards?.baker),
+                finalizationProof: trAmountFraction(
+                    v0.gasRewards?.finalizationProof
+                ),
+                accountCreation: trAmountFraction(
+                    v0.gasRewards?.accountCreation
+                ),
+                chainUpdate: trAmountFraction(v0.gasRewards?.chainUpdate),
+            },
+            mintDistribution: {
+                bakingReward: trAmountFraction(
+                    v0.mintDistribution?.bakingReward
+                ),
+                finalizationReward: trAmountFraction(
+                    v0.mintDistribution?.finalizationReward
+                ),
+                mintPerSlot: trMintRate(v0.mintDistribution?.mintPerSlot),
+            },
         },
     };
 }
@@ -433,66 +439,62 @@ function trChainParametersV1(
     const commonRewardParameters = translateRewardParametersCommon(params);
     return {
         ...common,
-        ...commonRewardParameters,
         electionDifficulty: trAmountFraction(params.electionDifficulty?.value),
-        timeParameters: {
-            rewardPeriodLength: unwrap(
-                params.timeParameters?.rewardPeriodLength?.value?.value
-            ),
-            mintPerPayday: trMintRate(params.timeParameters?.mintPerPayday),
-        },
-        cooldownParameters: {
-            delegatorCooldown: unwrap(
-                params.cooldownParameters?.delegatorCooldown?.value
-            ),
-            poolOwnerCooldown: unwrap(
-                params.cooldownParameters?.poolOwnerCooldown?.value
-            ),
-        },
-        poolParameters: {
-            passiveFinalizationCommission: trAmountFraction(
-                params.poolParameters?.passiveFinalizationCommission
-            ),
-            passiveBakingCommission: trAmountFraction(
-                params.poolParameters?.passiveBakingCommission
-            ),
-            passiveTransactionCommission: trAmountFraction(
-                params.poolParameters?.passiveTransactionCommission
-            ),
-            finalizationCommissionRange: translateCommissionRange(
-                params.poolParameters?.commissionBounds?.finalization
-            ),
-            bakingCommissionRange: translateCommissionRange(
-                params.poolParameters?.commissionBounds?.baking
-            ),
-            transactionCommissionRange: translateCommissionRange(
-                params.poolParameters?.commissionBounds?.transaction
-            ),
-            minimumEquityCapital: unwrap(
-                params.poolParameters?.minimumEquityCapital?.value
-            ),
-            capitalBound: trAmountFraction(
-                params.poolParameters?.capitalBound?.value
-            ),
-            leverageBound: unwrap(params.poolParameters?.leverageBound?.value),
-        },
-        gasRewards: {
-            baker: trAmountFraction(params.gasRewards?.baker),
-            finalizationProof: trAmountFraction(
-                params.gasRewards?.finalizationProof
-            ),
-            accountCreation: trAmountFraction(
-                params.gasRewards?.accountCreation
-            ),
-            chainUpdate: trAmountFraction(params.gasRewards?.chainUpdate),
-        },
-        mintDistribution: {
-            bakingReward: trAmountFraction(
-                params.mintDistribution?.bakingReward
-            ),
-            finalizationReward: trAmountFraction(
-                params.mintDistribution?.finalizationReward
-            ),
+        rewardPeriodLength: unwrap(
+            params.timeParameters?.rewardPeriodLength?.value?.value
+        ),
+        mintPerPayday: trMintRate(params.timeParameters?.mintPerPayday),
+        delegatorCooldown: unwrap(
+            params.cooldownParameters?.delegatorCooldown?.value
+        ),
+        poolOwnerCooldown: unwrap(
+            params.cooldownParameters?.poolOwnerCooldown?.value
+        ),
+        passiveFinalizationCommission: trAmountFraction(
+            params.poolParameters?.passiveFinalizationCommission
+        ),
+        passiveBakingCommission: trAmountFraction(
+            params.poolParameters?.passiveBakingCommission
+        ),
+        passiveTransactionCommission: trAmountFraction(
+            params.poolParameters?.passiveTransactionCommission
+        ),
+        finalizationCommissionRange: translateCommissionRange(
+            params.poolParameters?.commissionBounds?.finalization
+        ),
+        bakingCommissionRange: translateCommissionRange(
+            params.poolParameters?.commissionBounds?.baking
+        ),
+        transactionCommissionRange: translateCommissionRange(
+            params.poolParameters?.commissionBounds?.transaction
+        ),
+        minimumEquityCapital: unwrap(
+            params.poolParameters?.minimumEquityCapital?.value
+        ),
+        capitalBound: trAmountFraction(
+            params.poolParameters?.capitalBound?.value
+        ),
+        leverageBound: unwrap(params.poolParameters?.leverageBound?.value),
+        rewardParameters: {
+            ...commonRewardParameters,
+            gASRewards: {
+                baker: trAmountFraction(params.gasRewards?.baker),
+                finalizationProof: trAmountFraction(
+                    params.gasRewards?.finalizationProof
+                ),
+                accountCreation: trAmountFraction(
+                    params.gasRewards?.accountCreation
+                ),
+                chainUpdate: trAmountFraction(params.gasRewards?.chainUpdate),
+            },
+            mintDistribution: {
+                bakingReward: trAmountFraction(
+                    params.mintDistribution?.bakingReward
+                ),
+                finalizationReward: trAmountFraction(
+                    params.mintDistribution?.finalizationReward
+                ),
+            },
         },
     };
 }
@@ -505,97 +507,82 @@ function trChainParametersV2(
 
     return {
         ...common,
-        ...commonRewardParameters,
-        timeParameters: {
-            rewardPeriodLength: unwrap(
-                params.timeParameters?.rewardPeriodLength?.value?.value
-            ),
-            mintPerPayday: trMintRate(params.timeParameters?.mintPerPayday),
-        },
-        cooldownParameters: {
-            delegatorCooldown: unwrap(
-                params.cooldownParameters?.delegatorCooldown?.value
-            ),
-            poolOwnerCooldown: unwrap(
-                params.cooldownParameters?.poolOwnerCooldown?.value
-            ),
-        },
-        poolParameters: {
-            passiveFinalizationCommission: trAmountFraction(
-                params.poolParameters?.passiveFinalizationCommission
-            ),
-            passiveBakingCommission: trAmountFraction(
-                params.poolParameters?.passiveBakingCommission
-            ),
-            passiveTransactionCommission: trAmountFraction(
-                params.poolParameters?.passiveTransactionCommission
-            ),
-            finalizationCommissionRange: translateCommissionRange(
-                params.poolParameters?.commissionBounds?.finalization
-            ),
-            bakingCommissionRange: translateCommissionRange(
-                params.poolParameters?.commissionBounds?.baking
-            ),
-            transactionCommissionRange: translateCommissionRange(
-                params.poolParameters?.commissionBounds?.transaction
-            ),
-            minimumEquityCapital: unwrap(
-                params.poolParameters?.minimumEquityCapital?.value
-            ),
-            capitalBound: trAmountFraction(
-                params.poolParameters?.capitalBound?.value
-            ),
-            leverageBound: unwrap(params.poolParameters?.leverageBound?.value),
-        },
-        gasRewards: {
-            baker: trAmountFraction(params.gasRewards?.baker),
-            accountCreation: trAmountFraction(
-                params.gasRewards?.accountCreation
-            ),
-            chainUpdate: trAmountFraction(params.gasRewards?.chainUpdate),
-        },
-        mintDistribution: {
-            bakingReward: trAmountFraction(
-                params.mintDistribution?.bakingReward
-            ),
-            finalizationReward: trAmountFraction(
-                params.mintDistribution?.finalizationReward
-            ),
-        },
-        consensusParameters: {
-            timeoutParameters: {
-                timeoutBase: unwrap(
-                    params.consensusParameters?.timeoutParameters?.timeoutBase
-                        ?.value
+        rewardPeriodLength: unwrap(
+            params.timeParameters?.rewardPeriodLength?.value?.value
+        ),
+        mintPerPayday: trMintRate(params.timeParameters?.mintPerPayday),
+        delegatorCooldown: unwrap(
+            params.cooldownParameters?.delegatorCooldown?.value
+        ),
+        poolOwnerCooldown: unwrap(
+            params.cooldownParameters?.poolOwnerCooldown?.value
+        ),
+        passiveFinalizationCommission: trAmountFraction(
+            params.poolParameters?.passiveFinalizationCommission
+        ),
+        passiveBakingCommission: trAmountFraction(
+            params.poolParameters?.passiveBakingCommission
+        ),
+        passiveTransactionCommission: trAmountFraction(
+            params.poolParameters?.passiveTransactionCommission
+        ),
+        finalizationCommissionRange: translateCommissionRange(
+            params.poolParameters?.commissionBounds?.finalization
+        ),
+        bakingCommissionRange: translateCommissionRange(
+            params.poolParameters?.commissionBounds?.baking
+        ),
+        transactionCommissionRange: translateCommissionRange(
+            params.poolParameters?.commissionBounds?.transaction
+        ),
+        minimumEquityCapital: unwrap(
+            params.poolParameters?.minimumEquityCapital?.value
+        ),
+        capitalBound: trAmountFraction(
+            params.poolParameters?.capitalBound?.value
+        ),
+        leverageBound: unwrap(params.poolParameters?.leverageBound?.value),
+        rewardParameters: {
+            ...commonRewardParameters,
+            gASRewards: {
+                baker: trAmountFraction(params.gasRewards?.baker),
+                accountCreation: trAmountFraction(
+                    params.gasRewards?.accountCreation
                 ),
-                timeoutDecrease: unwrap(
-                    params.consensusParameters?.timeoutParameters
-                        ?.timeoutDecrease
+                chainUpdate: trAmountFraction(params.gasRewards?.chainUpdate),
+            },
+            mintDistribution: {
+                bakingReward: trAmountFraction(
+                    params.mintDistribution?.bakingReward
                 ),
-                timeoutIncrease: unwrap(
-                    params.consensusParameters?.timeoutParameters
-                        ?.timeoutIncrease
+                finalizationReward: trAmountFraction(
+                    params.mintDistribution?.finalizationReward
                 ),
             },
-            minBlockTime: unwrap(
-                params.consensusParameters?.minBlockTime?.value
-            ),
-            blockEnergyLimit: unwrap(
-                params.consensusParameters?.blockEnergyLimit?.value
-            ),
         },
-        finalizationCommiteeParameters: {
-            finalizerRelativeStakeThreshold: trAmountFraction(
-                params.finalizationCommitteeParameters
-                    ?.finalizerRelativeStakeThreshold
-            ),
-            minimumFinalizers: unwrap(
-                params.finalizationCommitteeParameters?.minimumFinalizers
-            ),
-            maximumFinalizers: unwrap(
-                params.finalizationCommitteeParameters?.maximumFinalizers
-            ),
-        },
+        timeoutBase: unwrap(
+            params.consensusParameters?.timeoutParameters?.timeoutBase?.value
+        ),
+        timeoutDecrease: unwrap(
+            params.consensusParameters?.timeoutParameters?.timeoutDecrease
+        ),
+        timeoutIncrease: unwrap(
+            params.consensusParameters?.timeoutParameters?.timeoutIncrease
+        ),
+        minBlockTime: unwrap(params.consensusParameters?.minBlockTime?.value),
+        blockEnergyLimit: unwrap(
+            params.consensusParameters?.blockEnergyLimit?.value
+        ),
+        finalizerRelativeStakeThreshold: trAmountFraction(
+            params.finalizationCommitteeParameters
+                ?.finalizerRelativeStakeThreshold
+        ),
+        minimumFinalizers: unwrap(
+            params.finalizationCommitteeParameters?.minimumFinalizers
+        ),
+        maximumFinalizers: unwrap(
+            params.finalizationCommitteeParameters?.maximumFinalizers
+        ),
     };
 }
 
@@ -757,10 +744,12 @@ export function consensusInfo(ci: v2.ConsensusInfo): v1.ConsensusStatus {
 
     const ci1: v1.ConsensusStatusV1 = {
         ...common,
-        currentTimeoutDuration: unwrap(ci.currentTimeoutDuration?.value),
-        currentRound: unwrap(ci.currentRound?.value),
-        currentEpoch: unwrap(ci.currentEpoch?.value),
-        triggerBlockTime: trTimestamp(ci.triggerBlockTime),
+        concordiumBFTStatus: {
+            currentTimeoutDuration: unwrap(ci.currentTimeoutDuration?.value),
+            currentRound: unwrap(ci.currentRound?.value),
+            currentEpoch: unwrap(ci.currentEpoch?.value),
+            triggerBlockTime: trTimestamp(ci.triggerBlockTime),
+        },
     };
 
     return ci1;
@@ -1276,9 +1265,9 @@ function trEuroPerEnergyUpdate(
 }
 function trMicroCcdPerEuroUpdate(
     exchangeRate: v2.ExchangeRate
-): v1.MicroCCDPerEuroUpdate {
+): v1.MicroGtuPerEuroUpdate {
     return {
-        updateType: v1.UpdateType.MicroCCDPerEuro,
+        updateType: v1.UpdateType.MicroGtuPerEuro,
         update: unwrap(exchangeRate.value),
     };
 }
@@ -1738,10 +1727,10 @@ function trAuthorizationsV0(auths: v2.AuthorizationsV0): v1.AuthorizationsV0 {
         addIdentityProvider: trAccessStructure(auths.addIdentityProvider),
         addAnonymityRevoker: trAccessStructure(auths.addAnonymityRevoker),
         emergency: trAccessStructure(auths.emergency),
-        consensus: trAccessStructure(auths.parameterConsensus),
+        electionDifficulty: trAccessStructure(auths.parameterConsensus),
         euroPerEnergy: trAccessStructure(auths.parameterEuroPerEnergy),
         foundationAccount: trAccessStructure(auths.parameterFoundationAccount),
-        microCCDPerEuro: trAccessStructure(auths.parameterMicroCCDPerEuro),
+        microGTUPerEuro: trAccessStructure(auths.parameterMicroCCDPerEuro),
         paramGASRewards: trAccessStructure(auths.parameterGasRewards),
         mintDistribution: trAccessStructure(auths.parameterMintDistribution),
         transactionFeeDistribution: trAccessStructure(

--- a/packages/common/src/JsonRpcClient.ts
+++ b/packages/common/src/JsonRpcClient.ts
@@ -4,6 +4,7 @@ import {
     AccountTransaction,
     AccountTransactionSignature,
     buildInvoker,
+    ConcordiumBftStatus,
     ConsensusStatus,
     ConsensusStatusV0,
     ConsensusStatusV1,
@@ -137,14 +138,17 @@ export class JsonRpcClient {
         type CS = ConsensusStatusV0 & ConsensusStatusV1;
 
         // TODO Avoid code duplication with nodejs client
-        const datePropertyKeys: (keyof CS)[] = [
+        const datePropertyKeys: (keyof CS | keyof ConcordiumBftStatus)[] = [
             'blockLastReceivedTime',
             'blockLastArrivedTime',
             'genesisTime',
             'currentEraGenesisTime',
             'lastFinalizedTime',
+
+            // v1
+            'triggerBlockTime',
         ];
-        const bigIntPropertyKeys: (keyof CS)[] = [
+        const bigIntPropertyKeys: (keyof CS | keyof ConcordiumBftStatus)[] = [
             'epochDuration',
             'slotDuration',
             'bestBlockHeight',
@@ -153,10 +157,11 @@ export class JsonRpcClient {
             'blocksVerifiedCount',
             'blocksReceivedCount',
             'protocolVersion',
+
+            // v1
             'currentTimeoutDuration',
             'currentRound',
             'currentEpoch',
-            'triggerBlockTime',
         ];
 
         const res = transformJsonResponse<ConsensusStatus>(

--- a/packages/common/src/blockSummaryHelpers.ts
+++ b/packages/common/src/blockSummaryHelpers.ts
@@ -23,7 +23,7 @@ export const isUpdateQueuesV1 = (uq: UpdateQueues): uq is UpdateQueuesV1 =>
 
 /** Whether {@link UpdateQueues} parameter given is of type {@link UpdateQueuesV2} */
 export const isUpdateQueuesV2 = (uq: UpdateQueues): uq is UpdateQueuesV2 =>
-    (uq as UpdateQueuesV2).timeoutParameters !== undefined;
+    (uq as UpdateQueuesV2).consensus2TimingParameters !== undefined;
 
 export const isUpdatesV0 = (u: Updates): u is UpdatesV0 =>
     isUpdateQueuesV0(u.updateQueues);
@@ -38,7 +38,9 @@ export const isBlockSummaryV0 = (bs: BlockSummary): bs is BlockSummaryV0 =>
     bs.protocolVersion === undefined || bs.protocolVersion <= 3n;
 
 export const isBlockSummaryV1 = (bs: BlockSummary): bs is BlockSummaryV1 =>
-    bs.protocolVersion !== undefined && bs.protocolVersion > 3n;
+    bs.protocolVersion !== undefined &&
+    bs.protocolVersion > 3n &&
+    bs.protocolVersion <= 5n;
 
 export const isBlockSummaryV2 = (bs: BlockSummary): bs is BlockSummaryV2 =>
     bs.protocolVersion !== undefined && bs.protocolVersion > 5n;

--- a/packages/common/src/energyCost.ts
+++ b/packages/common/src/energyCost.ts
@@ -64,13 +64,13 @@ export function getEnergyCost(
  */
 export function getExchangeRate({
     euroPerEnergy,
-    microCCDPerEuro,
+    microGTUPerEuro,
 }: ChainParameters): Ratio {
     const denominator = BigInt(
-        euroPerEnergy.denominator * microCCDPerEuro.denominator
+        euroPerEnergy.denominator * microGTUPerEuro.denominator
     );
     const numerator = BigInt(
-        euroPerEnergy.numerator * microCCDPerEuro.numerator
+        euroPerEnergy.numerator * microGTUPerEuro.numerator
     );
     return { numerator, denominator };
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -322,7 +322,7 @@ export interface RewardParametersV0 extends RewardParametersCommon {
     /** The current mint distribution */
     mintDistribution: MintDistributionV0;
     /** The current gas rewards parameters */
-    gasRewards: GasRewardsV0;
+    gASRewards: GasRewardsV0;
 }
 
 /** Reward parameters used in protocol versions 4 and 5 ({@link ChainParametersV1}). */
@@ -330,7 +330,7 @@ export interface RewardParametersV1 extends RewardParametersCommon {
     /** The current mint distribution */
     mintDistribution: MintDistributionV1;
     /** The current gas rewards parameters */
-    gasRewards: GasRewardsV0;
+    gASRewards: GasRewardsV0;
 }
 
 /** Reward parameters used from protocol version 6 ({@link ChainParametersV2}). */
@@ -338,7 +338,7 @@ export interface RewardParametersV2 extends RewardParametersCommon {
     /** The current mint distribution */
     mintDistribution: MintDistributionV1;
     /** The current gas rewards parameters */
-    gasRewards: GasRewardsV1;
+    gASRewards: GasRewardsV1;
 }
 
 /** Cooldown parameters used from protocol version 1-3 */
@@ -413,8 +413,6 @@ export interface TimeoutParameters {
 
 /** Consensus parameters, used from protocol version 6 */
 export interface ConsensusParameters {
-    /** Parameters controlling round timeouts. */
-    timeoutParameters: TimeoutParameters;
     /** Minimum time interval between blocks. */
     minBlockTime: Duration;
     /** Maximum energy allowed per block. */
@@ -442,60 +440,46 @@ export interface ChainParametersCommon {
     /** Rate of euros per energy */
     euroPerEnergy: ExchangeRate;
     /** Rate of micro CCD per euro */
-    microCCDPerEuro: ExchangeRate;
+    microGTUPerEuro: ExchangeRate;
     /** Limit for the number of account creations in a block */
     accountCreationLimit: number;
     /** The chain foundation account */
     foundationAccount: Base58String;
+    /** The chain foundation account index */
+    foundationAccountIndex?: bigint;
 }
 
 /** Chain parameters used from protocol version 1-3 */
 export type ChainParametersV0 = ChainParametersCommon &
     CooldownParametersV0 &
-    PoolParametersV0 &
-    RewardParametersV0 & {
+    PoolParametersV0 & {
         /** The election difficulty for consensus lottery */
         electionDifficulty: number;
+        /** The election difficulty for consensus lottery */
+        rewardParameters: RewardParametersV0;
     };
 
 /** Chain parameters used in protocol versions 4 and 5 */
 export type ChainParametersV1 = ChainParametersCommon &
-    RewardParametersV1 & {
-        /**
-         * The extra number of epochs before reduction in stake
-         * or baker deregistration is completed.
-         */
-        cooldownParameters: CooldownParametersV1;
-        /**
-         * The time parameters, indicating the mint rate and
-         * the reward period length, i.e. the tiem between paydays
-         */
-        timeParameters: TimeParametersV1;
-        /** Parameters governing baking pools and their commissions. */
-        poolParameters: PoolParametersV1;
+    CooldownParametersV1 &
+    TimeParametersV1 &
+    PoolParametersV1 & {
         /** The election difficulty for consensus lottery */
         electionDifficulty: number;
+        /** The election difficulty for consensus lottery */
+        rewardParameters: RewardParametersV1;
     };
 
 /** Chain parameters used from protocol version 6 */
 export type ChainParametersV2 = ChainParametersCommon &
-    RewardParametersV2 & {
-        /** The consensus parameters. */
-        consensusParameters: ConsensusParameters;
-        /**
-         * The extra number of epochs before reduction in stake
-         * or baker deregistration is completed.
-         */
-        cooldownParameters: CooldownParametersV1;
-        /**
-         * The time parameters, indicating the mint rate and
-         * the reward period length, i.e. the tiem between paydays
-         */
-        timeParameters: TimeParametersV1;
-        /** Parameters governing baking pools and their commissions. */
-        poolParameters: PoolParametersV1;
-        /** The finalization committee parameters */
-        finalizationCommiteeParameters: FinalizationCommitteeParameters;
+    CooldownParametersV1 &
+    TimeParametersV1 &
+    PoolParametersV1 &
+    FinalizationCommitteeParameters &
+    TimeoutParameters &
+    ConsensusParameters & {
+        /** The election difficulty for consensus lottery */
+        rewardParameters: RewardParametersV2;
     };
 
 /** Union of all chain parameters across all protocol versions */
@@ -511,7 +495,7 @@ export interface Authorization {
 
 interface AuthorizationsCommon {
     emergency: Authorization;
-    microCCDPerEuro: Authorization;
+    microGTUPerEuro: Authorization;
     euroPerEnergy: Authorization;
     transactionFeeDistribution: Authorization;
     foundationAccount: Authorization;
@@ -522,7 +506,10 @@ interface AuthorizationsCommon {
      * For protocol version 3 and earlier, this controls the authorization of the bakerStakeThreshold update.
      */
     poolParameters: Authorization;
-    consensus: Authorization;
+    /**
+     * For protocol version 6 and later, this controls the authorization of consensus related updates.
+     */
+    electionDifficulty: Authorization;
     addAnonymityRevoker: Authorization;
     addIdentityProvider: Authorization;
     keys: VerifyKey[];
@@ -579,15 +566,14 @@ export interface UpdateQueueQueue {
 
 export interface UpdateQueue {
     nextSequenceNumber: bigint;
-    queue: UpdateQueueQueue;
+    queue: UpdateQueueQueue[];
 }
 
 interface UpdateQueuesCommon {
-    microCCDPerEuro: UpdateQueue;
+    microGTUPerEuro: UpdateQueue;
     euroPerEnergy: UpdateQueue;
     transactionFeeDistribution: UpdateQueue;
     foundationAccount: UpdateQueue;
-    electionDifficulty: UpdateQueue;
     mintDistribution: UpdateQueue;
     protocol: UpdateQueue;
     gasRewards: UpdateQueue;
@@ -602,6 +588,7 @@ interface UpdateQueuesCommon {
  * Used from protocol version 1-3
  */
 export interface UpdateQueuesV0 extends UpdateQueuesCommon {
+    electionDifficulty: UpdateQueue;
     bakerStakeThreshold: UpdateQueue;
 }
 
@@ -609,6 +596,7 @@ export interface UpdateQueuesV0 extends UpdateQueuesCommon {
  * Used in protocol version 4 and 5
  */
 export interface UpdateQueuesV1 extends UpdateQueuesCommon {
+    electionDifficulty: UpdateQueue;
     cooldownParameters: UpdateQueue;
     timeParameters: UpdateQueue;
     poolParameters: UpdateQueue;
@@ -618,10 +606,7 @@ export interface UpdateQueuesV1 extends UpdateQueuesCommon {
  * Used from protocol version 6
  */
 export interface UpdateQueuesV2 extends UpdateQueuesV1 {
-    timeoutParameters: UpdateQueue;
-    minBlockTime: UpdateQueue;
-    blockEnergyLimit: UpdateQueue;
-    finalizationCommiteeParameters: UpdateQueue;
+    consensus2TimingParameters: UpdateQueue;
 }
 
 export type UpdateQueues = UpdateQueuesV0 | UpdateQueuesV1 | UpdateQueuesV2;
@@ -901,8 +886,7 @@ export interface ConsensusStatusV0 extends ConsensusStatusCommon {
     slotDuration: Duration;
 }
 
-/** Consensus status used from protocol version 6 */
-export type ConsensusStatusV1 = ConsensusStatusCommon & {
+export interface ConcordiumBftStatus {
     /** Current duration before a round times out, in milliseconds */
     currentTimeoutDuration: Duration;
     /** Current round */
@@ -914,6 +898,11 @@ export type ConsensusStatusV1 = ConsensusStatusCommon & {
      * the trigger block for the epoch transition.
      */
     triggerBlockTime: Date;
+}
+
+/** Consensus status used from protocol version 6 */
+export type ConsensusStatusV1 = ConsensusStatusCommon & {
+    concordiumBFTStatus: ConcordiumBftStatus;
 };
 
 /** Union of consensus status types used across all protocol versions */

--- a/packages/common/src/types/chainUpdate.ts
+++ b/packages/common/src/types/chainUpdate.ts
@@ -54,8 +54,8 @@ export type EuroPerEnergyUpdate = ChainUpdate<
 >;
 
 /** An update to the micro CCD per euro exchange rate */
-export type MicroCCDPerEuroUpdate = ChainUpdate<
-    UpdateType.MicroCCDPerEuro,
+export type MicroGtuPerEuroUpdate = ChainUpdate<
+    UpdateType.MicroGtuPerEuro,
     ExchangeRate
 >;
 
@@ -160,7 +160,7 @@ export type PendingAuthorizationKeysUpdate = ChainUpdate<
 
 /** A union of chain updates, barring key updates */
 export type CommonUpdate =
-    | MicroCCDPerEuroUpdate
+    | MicroGtuPerEuroUpdate
     | EuroPerEnergyUpdate
     | TransactionFeeDistributionUpdate
     | FoundationAccountUpdate
@@ -198,7 +198,7 @@ export enum UpdateType {
     Protocol = 'protocol',
     ElectionDifficulty = 'electionDifficulty',
     EuroPerEnergy = 'euroPerEnergy',
-    MicroCCDPerEuro = 'microCCDPerEuro',
+    MicroGtuPerEuro = 'microGtuPerEuro',
     FoundationAccount = 'foundationAccount',
     MintDistribution = 'mintDistribution',
     TransactionFeeDistribution = 'transactionFeeDistribution',

--- a/packages/common/src/versionedTypeHelpers.ts
+++ b/packages/common/src/versionedTypeHelpers.ts
@@ -61,14 +61,14 @@ export const isChainParametersV0 = (
 export const isChainParametersV1 = (
     cp: ChainParameters
 ): cp is ChainParametersV1 =>
-    (cp as ChainParametersV1).timeParameters !== undefined &&
+    (cp as ChainParametersV1).mintPerPayday !== undefined &&
     !isChainParametersV2(cp);
 
 /** Whether {@link ChainParameters} parameter given is of type {@link ChainParametersV2} */
 export const isChainParametersV2 = (
     cp: ChainParameters
 ): cp is ChainParametersV2 =>
-    (cp as ChainParametersV2).consensusParameters !== undefined;
+    (cp as ChainParametersV2).maximumFinalizers !== undefined;
 
 /** Whether {@link Keys} parameter given is of type {@link KeysV0} */
 export const isKeysV0 = (ks: Keys): ks is KeysV0 =>
@@ -89,14 +89,13 @@ export const isBlockInfoV1 = (bi: BlockInfo): bi is BlockInfoV1 =>
 /** Whether {@link ConensusStatus} parameter given is of type {@link ConsensusStatusV0} */
 export const isConsensusStatusV0 = (
     cs: ConsensusStatus
-): cs is ConsensusStatusV0 =>
-    (cs as ConsensusStatusV0).slotDuration !== undefined;
+): cs is ConsensusStatusV0 => (cs as ConsensusStatusV0).slotDuration != null;
 
 /** Whether {@link ConensusStatus} parameter given is of type {@link ConsensusStatusV1} */
 export const isConsensusStatusV1 = (
     cs: ConsensusStatus
 ): cs is ConsensusStatusV1 =>
-    (cs as ConsensusStatusV1).currentRound !== undefined;
+    (cs as ConsensusStatusV1).concordiumBFTStatus !== undefined;
 
 /** Whether {@link ElectionInfo} parameter given is of type {@link ElectionInfoV0} */
 export const isElectionInfoV0 = (ei: ElectionInfo): ei is ElectionInfoV0 =>

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -80,6 +80,7 @@ import {
     ConsensusParameters,
     TimeoutParameters,
     Ratio,
+    ConcordiumBftStatus,
 } from '@concordium/common-sdk';
 import {
     buildJsonResponseReviver,
@@ -390,6 +391,7 @@ export default class ConcordiumNodeClient {
             'index',
             'subindex',
             'protocolVersion',
+            'foundationAccountIndex',
 
             // v0 keys
             'bakerCooldownEpochs',
@@ -491,14 +493,17 @@ export default class ConcordiumNodeClient {
             new Empty()
         );
 
-        const datePropertyKeys: (keyof CS)[] = [
+        const datePropertyKeys: (keyof CS | keyof ConcordiumBftStatus)[] = [
             'blockLastReceivedTime',
             'blockLastArrivedTime',
             'genesisTime',
             'currentEraGenesisTime',
             'lastFinalizedTime',
+
+            //v1
+            'triggerBlockTime',
         ];
-        const bigIntPropertyKeys: (keyof CS)[] = [
+        const bigIntPropertyKeys: (keyof CS | keyof ConcordiumBftStatus)[] = [
             'epochDuration',
             'slotDuration',
             'bestBlockHeight',
@@ -507,10 +512,11 @@ export default class ConcordiumNodeClient {
             'blocksVerifiedCount',
             'blocksReceivedCount',
             'protocolVersion',
+
+            // v1
             'currentTimeoutDuration',
             'currentRound',
             'currentEpoch',
-            'triggerBlockTime',
         ];
 
         const consensusStatus = unwrapJsonResponse<ConsensusStatus>(

--- a/packages/nodejs/test/CIS2Contract.test.ts
+++ b/packages/nodejs/test/CIS2Contract.test.ts
@@ -6,7 +6,7 @@ import {
     serializeTypeValue,
     TransactionEventTag,
 } from '@concordium/common-sdk';
-import { getNodeClient } from './testHelpers';
+import { getNodeClientV2 as getNodeClient } from './testHelpers';
 
 const CIS2_FT_ADDRESS: ContractAddress = {
     index: 3496n,

--- a/packages/nodejs/test/cis0.test.ts
+++ b/packages/nodejs/test/cis0.test.ts
@@ -1,5 +1,5 @@
 import { CIS0, cis0Supports } from '@concordium/common-sdk';
-import { getNodeClient } from './testHelpers';
+import { getNodeClientV2 as getNodeClient } from './testHelpers';
 
 const client = getNodeClient();
 

--- a/packages/nodejs/test/client.test.ts
+++ b/packages/nodejs/test/client.test.ts
@@ -13,7 +13,7 @@ import { getNodeClient } from './testHelpers';
  * remove the v1 API entirely.
  */
 
-const address = '127.0.0.1';
+const address = 'concordiumwalletnode.com';
 const port = 10000;
 
 const client = getNodeClient(address, port);
@@ -21,22 +21,16 @@ const client = getNodeClient(address, port);
 // eslint-disable-next-line prefer-const
 let CHAIN_GENESIS_BLOCK: string | undefined = undefined;
 // eslint-disable-next-line prefer-const
-let PV1_BLOCK: string | undefined = undefined;
-// eslint-disable-next-line prefer-const
 let PV4_BLOCK: string | undefined = undefined;
 // eslint-disable-next-line prefer-const
 let PV6_BLOCK: string | undefined = undefined;
-
-// Stagenet blocks.
-// PV4_BLOCK = 'f97d975f0e92297c51e24c3b0d8fd39dfe8e1b148d993eba6e9389d4083f7a64';
-// PV6_BLOCK = 'a3e46b2cf01d611c7507a2c2a3597da681f7b7b503b7a1f1372e661e040790f3';
 
 // Mainnet blocks.
 CHAIN_GENESIS_BLOCK =
     '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
 PV4_BLOCK = '568589c9f5b3a3989c24d4c916bc2417a64c6dff6ec987595349c551a829d332';
 
-test.each([CHAIN_GENESIS_BLOCK, PV1_BLOCK, PV4_BLOCK, PV6_BLOCK])(
+test.each([CHAIN_GENESIS_BLOCK, PV4_BLOCK, PV6_BLOCK])(
     'blockSummary format as expected',
     async (block) => {
         if (block === undefined) {
@@ -164,7 +158,7 @@ test.each([CHAIN_GENESIS_BLOCK, PV1_BLOCK, PV4_BLOCK, PV6_BLOCK])(
                 .finalizationReward
         ).toBeDefined();
         expect(bs.updates.chainParameters.euroPerEnergy).toBeDefined();
-        // expect(bs.updates.chainParameters.foundationAccountIndex).toBeDefined();
+        expect(bs.updates.chainParameters.foundationAccountIndex).toBeDefined();
         expect(bs.updates.chainParameters.accountCreationLimit).toBeDefined();
 
         if (isBlockSummaryV0(bs)) {

--- a/packages/nodejs/test/client.test.ts
+++ b/packages/nodejs/test/client.test.ts
@@ -13,24 +13,21 @@ import { getNodeClient } from './testHelpers';
  * remove the v1 API entirely.
  */
 
-const address = 'concordiumwalletnode.com';
-const port = 10000;
-
-const client = getNodeClient(address, port);
+const client = getNodeClient();
 
 // eslint-disable-next-line prefer-const
 let CHAIN_GENESIS_BLOCK: string | undefined = undefined;
 // eslint-disable-next-line prefer-const
-let PV4_BLOCK: string | undefined = undefined;
+let PV5_BLOCK: string | undefined = undefined;
 // eslint-disable-next-line prefer-const
 let PV6_BLOCK: string | undefined = undefined;
 
-// Mainnet blocks.
+// Testnet blocks.
 CHAIN_GENESIS_BLOCK =
-    '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
-PV4_BLOCK = '568589c9f5b3a3989c24d4c916bc2417a64c6dff6ec987595349c551a829d332';
+    '4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796';
+PV5_BLOCK = '58daebb41ca195442593e10c1a67279bb839a8195c8ea7442ea7116d87114fbb';
 
-test.each([CHAIN_GENESIS_BLOCK, PV4_BLOCK, PV6_BLOCK])(
+test.each([CHAIN_GENESIS_BLOCK, PV5_BLOCK, PV6_BLOCK])(
     'blockSummary format as expected',
     async (block) => {
         if (block === undefined) {

--- a/packages/nodejs/test/client.test.ts
+++ b/packages/nodejs/test/client.test.ts
@@ -1,0 +1,291 @@
+import {
+    isBlockSummaryV0,
+    isBlockSummaryV1,
+    isBlockSummaryV2,
+    isConsensusStatusV0,
+    isConsensusStatusV1,
+} from '@concordium/common-sdk';
+import { getNodeClient } from './testHelpers';
+
+/**
+ * These tests mostly serve the purpose of making sure that the types exposed follow the format returned by the API,
+ * i.e. we don't change the types to conform to the v2 API, but rather translate the v2 types to the v1 types until we can
+ * remove the v1 API entirely.
+ */
+
+const address = '127.0.0.1';
+const port = 10000;
+
+const client = getNodeClient(address, port);
+
+// eslint-disable-next-line prefer-const
+let CHAIN_GENESIS_BLOCK: string | undefined = undefined;
+// eslint-disable-next-line prefer-const
+let PV1_BLOCK: string | undefined = undefined;
+// eslint-disable-next-line prefer-const
+let PV4_BLOCK: string | undefined = undefined;
+// eslint-disable-next-line prefer-const
+let PV6_BLOCK: string | undefined = undefined;
+
+// Stagenet blocks.
+// PV4_BLOCK = 'f97d975f0e92297c51e24c3b0d8fd39dfe8e1b148d993eba6e9389d4083f7a64';
+// PV6_BLOCK = 'a3e46b2cf01d611c7507a2c2a3597da681f7b7b503b7a1f1372e661e040790f3';
+
+// Mainnet blocks.
+CHAIN_GENESIS_BLOCK =
+    '9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478';
+PV4_BLOCK = '568589c9f5b3a3989c24d4c916bc2417a64c6dff6ec987595349c551a829d332';
+
+test.each([CHAIN_GENESIS_BLOCK, PV1_BLOCK, PV4_BLOCK, PV6_BLOCK])(
+    'blockSummary format as expected',
+    async (block) => {
+        if (block === undefined) {
+            return;
+        }
+
+        const bs = await client.getBlockSummary(block);
+
+        if (!bs) {
+            throw new Error('could not find block');
+        }
+
+        console.log(bs.protocolVersion);
+
+        // BlockSummary
+        expect(typeof bs.protocolVersion).toEqual('bigint');
+
+        // UpdateQueues
+        expect(
+            typeof bs.updates.updateQueues.foundationAccount.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            Array.isArray(bs.updates.updateQueues.foundationAccount.queue)
+        ).toBeTruthy();
+        expect(
+            typeof bs.updates.updateQueues.euroPerEnergy.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.mintDistribution.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.microGTUPerEuro.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.protocol.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.rootKeys.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.gasRewards.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.level1Keys.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.level2Keys.nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.addAnonymityRevoker
+                .nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.addIdentityProvider
+                .nextSequenceNumber
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.updateQueues.transactionFeeDistribution
+                .nextSequenceNumber
+        ).toEqual('bigint');
+
+        // Keys
+        expect(bs.updates.keys.rootKeys.keys).toBeDefined();
+        expect(bs.updates.keys.rootKeys.threshold).toBeDefined();
+        expect(bs.updates.keys.level1Keys.keys).toBeDefined();
+        expect(bs.updates.keys.level2Keys.keys).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.addAnonymityRevoker.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.poolParameters.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.transactionFeeDistribution.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.addIdentityProvider.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.protocol.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.microGTUPerEuro.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.mintDistribution.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.euroPerEnergy.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.foundationAccount.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.electionDifficulty.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.emergency.authorizedKeys
+        ).toBeDefined();
+        expect(
+            bs.updates.keys.level2Keys.paramGASRewards.authorizedKeys
+        ).toBeDefined();
+
+        // Test format of chain parameters holds
+        expect(
+            typeof bs.updates.chainParameters.microGTUPerEuro.numerator
+        ).toEqual('bigint');
+        expect(
+            typeof bs.updates.chainParameters.microGTUPerEuro.denominator
+        ).toEqual('bigint');
+        expect(
+            bs.updates.chainParameters.rewardParameters.gASRewards.baker
+        ).toBeDefined();
+        expect(
+            bs.updates.chainParameters.rewardParameters.gASRewards.chainUpdate
+        ).toBeDefined();
+        expect(
+            bs.updates.chainParameters.rewardParameters.gASRewards
+                .accountCreation
+        ).toBeDefined();
+        expect(
+            bs.updates.chainParameters.rewardParameters.mintDistribution
+                .bakingReward
+        ).toBeDefined();
+        expect(
+            bs.updates.chainParameters.rewardParameters.mintDistribution
+                .finalizationReward
+        ).toBeDefined();
+        expect(bs.updates.chainParameters.euroPerEnergy).toBeDefined();
+        // expect(bs.updates.chainParameters.foundationAccountIndex).toBeDefined();
+        expect(bs.updates.chainParameters.accountCreationLimit).toBeDefined();
+
+        if (isBlockSummaryV0(bs)) {
+            expect(
+                typeof bs.updates.updateQueues.electionDifficulty
+                    .nextSequenceNumber
+            ).toEqual('bigint');
+            expect(
+                typeof bs.updates.updateQueues.bakerStakeThreshold
+                    .nextSequenceNumber
+            ).toEqual('bigint');
+
+            expect(
+                typeof bs.updates.chainParameters.bakerCooldownEpochs
+            ).toEqual('bigint');
+        } else if (isBlockSummaryV1(bs)) {
+            expect(
+                typeof bs.updates.updateQueues.electionDifficulty
+                    .nextSequenceNumber
+            ).toEqual('bigint');
+            expect(
+                typeof bs.updates.updateQueues.poolParameters.nextSequenceNumber
+            ).toEqual('bigint');
+            expect(
+                typeof bs.updates.updateQueues.timeParameters.nextSequenceNumber
+            ).toEqual('bigint');
+            expect(
+                typeof bs.updates.updateQueues.cooldownParameters
+                    .nextSequenceNumber
+            ).toEqual('bigint');
+
+            expect(
+                bs.updates.keys.level2Keys.cooldownParameters.authorizedKeys
+            ).toBeDefined();
+            expect(
+                bs.updates.keys.level2Keys.timeParameters.authorizedKeys
+            ).toBeDefined();
+
+            expect(bs.updates.chainParameters.electionDifficulty).toBeDefined();
+            expect(
+                bs.updates.chainParameters.rewardParameters.gASRewards
+                    .finalizationProof
+            );
+            expect(bs.updates.chainParameters.mintPerPayday).toBeDefined();
+            expect(bs.updates.chainParameters.capitalBound).toBeDefined();
+            expect(bs.updates.chainParameters.leverageBound).toBeDefined();
+            expect(
+                bs.updates.chainParameters.finalizationCommissionRange.min
+            ).toBeDefined();
+        } else if (isBlockSummaryV2(bs)) {
+            expect(
+                typeof bs.updates.updateQueues.consensus2TimingParameters
+                    .nextSequenceNumber
+            ).toEqual('bigint');
+
+            expect(
+                bs.updates.keys.level2Keys.cooldownParameters.authorizedKeys
+            ).toBeDefined();
+            expect(
+                bs.updates.keys.level2Keys.timeParameters.authorizedKeys
+            ).toBeDefined();
+
+            expect(bs.updates.chainParameters.minimumFinalizers).toBeDefined();
+            expect(bs.updates.chainParameters.maximumFinalizers).toBeDefined();
+            expect(typeof bs.updates.chainParameters.blockEnergyLimit).toEqual(
+                'bigint'
+            );
+            expect(typeof bs.updates.chainParameters.minBlockTime).toEqual(
+                'bigint'
+            );
+            expect(typeof bs.updates.chainParameters.timeoutBase).toEqual(
+                'bigint'
+            );
+            expect(
+                typeof bs.updates.chainParameters.timeoutDecrease.numerator
+            ).toEqual('bigint');
+            expect(
+                typeof bs.updates.chainParameters.timeoutIncrease.denominator
+            ).toEqual('bigint');
+            expect(
+                bs.updates.chainParameters.finalizerRelativeStakeThreshold
+            ).toBeDefined();
+        }
+    }
+);
+
+test('consensusStatus format as expected', async () => {
+    const cs = await client.getConsensusStatus();
+
+    expect(typeof cs.protocolVersion).toEqual('bigint');
+    expect(cs.bestBlock).toBeDefined();
+    expect(cs.genesisTime instanceof Date).toBeTruthy();
+    expect(cs.genesisBlock).toBeDefined();
+    expect(cs.genesisIndex).toBeDefined();
+    expect(typeof cs.epochDuration).toEqual('bigint');
+    expect(typeof cs.bestBlockHeight).toEqual('bigint');
+    expect(typeof cs.finalizationCount).toEqual('bigint');
+    expect(cs.lastFinalizedBlock).toBeDefined();
+    expect(typeof cs.blocksReceivedCount).toEqual('bigint');
+    expect(typeof cs.blocksVerifiedCount).toEqual('bigint');
+    expect(cs.blockArriveLatencyEMA).toBeDefined();
+    expect(cs.blockLastArrivedTime instanceof Date).toBeTruthy();
+    expect(cs.currentEraGenesisTime instanceof Date).toBeTruthy();
+    expect(cs.blockArriveLatencyEMSD).toBeDefined();
+    expect(cs.currentEraGenesisBlock).toBeDefined();
+    expect(cs.transactionsPerBlockEMA).toBeDefined();
+    expect(typeof cs.lastFinalizedBlockHeight).toEqual('bigint');
+    expect(cs.transactionsPerBlockEMSD).toBeDefined();
+
+    if (isConsensusStatusV0(cs)) {
+        expect(typeof cs.slotDuration).toEqual('bigint');
+    } else if (isConsensusStatusV1(cs)) {
+        expect(typeof cs.concordiumBFTStatus.currentTimeoutDuration).toEqual(
+            'bigint'
+        );
+        expect(typeof cs.concordiumBFTStatus.currentEpoch).toEqual('bigint');
+        expect(typeof cs.concordiumBFTStatus.currentRound).toEqual('bigint');
+        expect(
+            cs.concordiumBFTStatus.triggerBlockTime instanceof Date
+        ).toBeTruthy();
+    }
+});

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -20,7 +20,7 @@ import {
 import {
     getModuleBuffer,
     getIdentityInput,
-    getNodeClient,
+    getNodeClientV2,
     getNodeClientWeb,
 } from './testHelpers';
 import * as ed from '@noble/ed25519';
@@ -36,7 +36,7 @@ global.TextEncoder = TextEncoder as any;
 global.TextDecoder = TextDecoder as any;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-const clientV2 = getNodeClient();
+const clientV2 = getNodeClientV2();
 const clientWeb = getNodeClientWeb();
 
 const testAccount = new v1.AccountAddress(

--- a/packages/nodejs/test/events.test.ts
+++ b/packages/nodejs/test/events.test.ts
@@ -1,6 +1,6 @@
 import * as expected from './resources/expectedJsons';
 import { streamToList } from '@concordium/common-sdk';
-import { getNodeClient } from './testHelpers';
+import { getNodeClientV2 as getNodeClient } from './testHelpers';
 
 const client = getNodeClient();
 

--- a/packages/nodejs/test/getConsensusStatus.test.ts
+++ b/packages/nodejs/test/getConsensusStatus.test.ts
@@ -1,5 +1,5 @@
 import { ConsensusStatus, isHex } from '@concordium/common-sdk';
-import { getNodeClient } from './testHelpers';
+import { getNodeClientV2 as getNodeClient } from './testHelpers';
 
 const client = getNodeClient();
 test('retrieves the consensus status from the node with correct types', async () => {

--- a/packages/nodejs/test/manualTests.test.ts
+++ b/packages/nodejs/test/manualTests.test.ts
@@ -4,7 +4,7 @@ import {
     buildBasicAccountSigner,
     signTransaction,
 } from '@concordium/common-sdk';
-import { getNodeClient } from '../test/testHelpers';
+import { getNodeClientV2 as getNodeClient } from '../test/testHelpers';
 
 const client = getNodeClient();
 

--- a/packages/nodejs/test/rejectReasons.test.ts
+++ b/packages/nodejs/test/rejectReasons.test.ts
@@ -1,6 +1,6 @@
 import * as expected from './resources/expectedJsons';
 import { streamToList } from '@concordium/common-sdk';
-import { getNodeClient } from './testHelpers';
+import { getNodeClientV2 as getNodeClient } from './testHelpers';
 
 const client = getNodeClient();
 

--- a/packages/nodejs/test/resources/expectedJsons.ts
+++ b/packages/nodejs/test/resources/expectedJsons.ts
@@ -149,7 +149,7 @@ export const blockItemStatusUpdate = {
             type: 'updateTransaction',
             effectiveTime: 0n,
             payload: {
-                updateType: 'microCCDPerEuro',
+                updateType: 'microGtuPerEuro',
                 update: {
                     numerator: 17592435270983729152n,
                     denominator: 163844642115n,
@@ -459,7 +459,7 @@ export const transactionEventList = [
         hash: '49d7b5c3234dc17bd904af0b63712dc0a6680b96ad556c5ac1103d8cdd128891',
         effectiveTime: 0n,
         payload: {
-            updateType: 'microCCDPerEuro',
+            updateType: 'microGtuPerEuro',
             update: {
                 denominator: 126230907181n,
                 numerator: 9397474320418127872n,
@@ -1613,60 +1613,58 @@ export const regularAccountInfo = {
 export const chainParameters: ChainParametersV1 = {
     electionDifficulty: 0.025,
     euroPerEnergy: { numerator: 1n, denominator: 50000n },
-    microCCDPerEuro: {
+    microGTUPerEuro: {
         numerator: 697170112016908288n,
         denominator: 7989497115n,
     },
     accountCreationLimit: 10,
     foundationAccount: '3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G',
-    timeParameters: {
-        mintPerPayday: 0.000261157877,
-        rewardPeriodLength: 24n,
+    mintPerPayday: 0.000261157877,
+    rewardPeriodLength: 24n,
+    delegatorCooldown: 1209600n,
+    poolOwnerCooldown: 1814400n,
+    passiveFinalizationCommission: 1,
+    passiveBakingCommission: 0.12,
+    passiveTransactionCommission: 0.12,
+    finalizationCommissionRange: { min: 1, max: 1 },
+    bakingCommissionRange: { min: 0.1, max: 0.1 },
+    transactionCommissionRange: { min: 0.1, max: 0.1 },
+    minimumEquityCapital: 14000000000n,
+    capitalBound: 0.1,
+    leverageBound: { numerator: 3n, denominator: 1n },
+    rewardParameters: {
+        transactionFeeDistribution: { baker: 0.45, gasAccount: 0.45 },
+        gASRewards: {
+            baker: 0.25,
+            finalizationProof: 0.005,
+            accountCreation: 0.02,
+            chainUpdate: 0.005,
+        },
+        mintDistribution: { bakingReward: 0.6, finalizationReward: 0.3 },
     },
-    cooldownParameters: {
-        delegatorCooldown: 1209600n,
-        poolOwnerCooldown: 1814400n,
-    },
-    poolParameters: {
-        passiveFinalizationCommission: 1,
-        passiveBakingCommission: 0.12,
-        passiveTransactionCommission: 0.12,
-        finalizationCommissionRange: { min: 1, max: 1 },
-        bakingCommissionRange: { min: 0.1, max: 0.1 },
-        transactionCommissionRange: { min: 0.1, max: 0.1 },
-        minimumEquityCapital: 14000000000n,
-        capitalBound: 0.1,
-        leverageBound: { numerator: 3n, denominator: 1n },
-    },
-    transactionFeeDistribution: { baker: 0.45, gasAccount: 0.45 },
-    gasRewards: {
-        baker: 0.25,
-        finalizationProof: 0.005,
-        accountCreation: 0.02,
-        chainUpdate: 0.005,
-    },
-    mintDistribution: { bakingReward: 0.6, finalizationReward: 0.3 },
 };
 
 export const oldChainParameters: ChainParametersV0 = {
     electionDifficulty: 0.025,
     euroPerEnergy: { numerator: 1n, denominator: 50000n },
-    microCCDPerEuro: { numerator: 50000000n, denominator: 1n },
+    microGTUPerEuro: { numerator: 50000000n, denominator: 1n },
     accountCreationLimit: 10,
     foundationAccount: '3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G',
     bakerCooldownEpochs: 166n,
     minimumThresholdForBaking: 15000000000n,
-    transactionFeeDistribution: { baker: 0.45, gasAccount: 0.45 },
-    gasRewards: {
-        baker: 0.25,
-        finalizationProof: 0.005,
-        accountCreation: 0.02,
-        chainUpdate: 0.005,
-    },
-    mintDistribution: {
-        bakingReward: 0.6,
-        finalizationReward: 0.3,
-        mintPerSlot: 7.555665e-10,
+    rewardParameters: {
+        transactionFeeDistribution: { baker: 0.45, gasAccount: 0.45 },
+        gASRewards: {
+            baker: 0.25,
+            finalizationProof: 0.005,
+            accountCreation: 0.02,
+            chainUpdate: 0.005,
+        },
+        mintDistribution: {
+            bakingReward: 0.6,
+            finalizationReward: 0.3,
+            mintPerSlot: 7.555665e-10,
+        },
     },
 };
 

--- a/packages/nodejs/test/specialEvents.test.ts
+++ b/packages/nodejs/test/specialEvents.test.ts
@@ -1,6 +1,6 @@
 import * as expected from './resources/expectedJsons';
 import { streamToList } from '@concordium/common-sdk';
-import { getNodeClient } from './testHelpers';
+import { getNodeClientV2 as getNodeClient } from './testHelpers';
 
 const client = getNodeClient();
 

--- a/packages/nodejs/test/testHelpers.ts
+++ b/packages/nodejs/test/testHelpers.ts
@@ -13,13 +13,17 @@ import 'isomorphic-fetch';
 
 export { getModuleBuffer } from '../src/util';
 
+const TESTNET_NODE = 'node.testnet.concordium.com';
+const GRPCV1_PORT = 10000;
+const GRPCV2_PORT = 20000;
+
 /**
  * Creates a gRPC v1 client (for nodeJS) to communicate with a local concordium-node
  * used for automatic tests.
  */
 export function getNodeClient(
-    address = '127.0.0.1',
-    port = 10000
+    address = TESTNET_NODE,
+    port = GRPCV1_PORT
 ): ConcordiumNodeClient {
     const metadata = new Metadata();
     metadata.add('authentication', 'rpcadmin');
@@ -37,8 +41,8 @@ export function getNodeClient(
  * used for automatic tests.
  */
 export function getNodeClientV2(
-    address = 'node.testnet.concordium.com',
-    port = 20000
+    address = TESTNET_NODE,
+    port = GRPCV2_PORT
 ): ConcordiumGRPCClient {
     return createConcordiumClient(address, port, credentials.createInsecure(), {
         timeout: 15000,
@@ -52,7 +56,7 @@ export function getNodeClientV2(
  */
 export function getNodeClientWeb(
     address = 'http://node.testnet.concordium.com',
-    port = 20000
+    port = GRPCV2_PORT
 ): ConcordiumGRPCClient {
     const transport = new GrpcWebFetchTransport({
         baseUrl: `${address}:${port}`,

--- a/packages/nodejs/test/testHelpers.ts
+++ b/packages/nodejs/test/testHelpers.ts
@@ -1,10 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import * as fs from 'fs';
-import { credentials } from '@grpc/grpc-js/';
+import { credentials, Metadata } from '@grpc/grpc-js/';
 import { ConcordiumGRPCClient, IdentityInput } from '@concordium/common-sdk';
 import { decryptMobileWalletExport, EncryptedData } from '../src/wallet/crypto';
 import { MobileWalletExport } from '../src/wallet/types';
 import { createConcordiumClient } from '../src/clientV2';
+import ConcordiumNodeClient from '../src/client';
 import ConcordiumNodeClientV2 from '@concordium/common-sdk/lib/GRPCClient';
 import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 
@@ -14,10 +15,29 @@ import 'isomorphic-fetch';
 export { getModuleBuffer } from '../src/util';
 
 /**
- * Creates a client to communicate with a local concordium-node
+ * Creates a gRPC v1 client (for nodeJS) to communicate with a local concordium-node
  * used for automatic tests.
  */
 export function getNodeClient(
+    address = '127.0.0.1',
+    port = 10000
+): ConcordiumNodeClient {
+    const metadata = new Metadata();
+    metadata.add('authentication', 'rpcadmin');
+    return new ConcordiumNodeClient(
+        address,
+        port,
+        credentials.createInsecure(),
+        metadata,
+        15000
+    );
+}
+
+/**
+ * Creates a gRPC v2 client (for nodeJS) to communicate with a local concordium-node
+ * used for automatic tests.
+ */
+export function getNodeClientV2(
     address = 'node.testnet.concordium.com',
     port = 20000
 ): ConcordiumNodeClientV2 {
@@ -25,7 +45,12 @@ export function getNodeClient(
         timeout: 15000,
     });
 }
+
 // TODO find nice way to move this to web/common
+/**
+ * Creates a gRPC v2 client (for web) to communicate with a local concordium-node
+ * used for automatic tests.
+ */
 export function getNodeClientWeb(
     address = 'http://node.testnet.concordium.com',
     port = 20000

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -30,6 +30,7 @@ for more information
 <!--toc:end-->
 
 ## ConcordiumGRPCClient
+
 The SDK provides a gRPC client, which can interact with the [Concordium
 Node](https://github.com/Concordium/concordium-node) using gRPC-web.
 


### PR DESCRIPTION
## Purpose

Forgot to take the deprecated JSON RPC client into account and the format returned from that when refactoring the types versioned by the different protocol versions. This PR reverts some changes, and makes bases the new versions on the types returned by the v1 api rather than the v2.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
