### PR TITLE
Include web in built package.

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -56,12 +56,20 @@ jobs:
         with:
           name: build-release
           path: |
-            ./node_modules/@concordium
             ./packages/rust-bindings/pkg
+            ./packages/rust-bindings/package.json
+            ./packages/rust-bindings/README.md
             ./packages/common/lib
-            ./packages/nodejs/lib
             ./packages/common/grpc
+            ./packages/common/package.json
+            ./packages/common/README.md
+            ./packages/nodejs/lib
             ./packages/nodejs/grpc
+            ./packages/nodejs/package.json
+            ./packages/nodejs/README.md
+            ./packages/web/lib
+            ./packages/web/package.json
+            ./packages/web/README.md
 
   build-typedoc:
     runs-on: ubuntu-22.04

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -50,9 +50,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn
+            ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Get dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: node_modules
-          key: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Generate typedoc documentation
         run: yarn typedoc

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -45,33 +45,32 @@ jobs:
         with:
           version: 'latest'
 
+      - name: Cache dependencies
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn
+
       - name: Get dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
       - name: Build release
         run: yarn build
 
       - name: Store build-release
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         with:
           name: build-release
           path: |
-            packages/rust-bindings/pkg
-            !packages/rust-bindings/pkg/**/.gitignore
-            !packages/rust-bindings/pkg/**/README.md
-            packages/rust-bindings/package.json
-            packages/rust-bindings/README.md
-            packages/common/lib
-            packages/common/grpc
-            packages/common/package.json
-            packages/common/README.md
-            packages/nodejs/lib
-            packages/nodejs/grpc
-            packages/nodejs/package.json
-            packages/nodejs/README.md
-            packages/web/lib
-            packages/web/package.json
-            packages/web/README.md
+            packages/*/lib
+            packages/*/grpc
+            packages/*/package.json
+            packages/*/README.md
+            packages/rust-bindings/pkg/*/concordium_rust_bindings*
 
   build-typedoc:
     runs-on: ubuntu-22.04
@@ -87,18 +86,21 @@ jobs:
           cache: yarn
 
       - name: Get build-output
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: build-release
 
-      - name: Get dependencies
-        run: yarn install --immutable
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn
 
       - name: Generate typedoc documentation
         run: yarn typedoc
 
       - name: Store typedoc
-        uses: actions/upload-artifact@v3
+        uses: ./.github/actions/upload-artifact
         with:
           name: typedoc-build
           path: typedoc
@@ -114,7 +116,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get typedoc
-        uses: actions/download-artifact@v3
+        uses: ./.github/actions/download-artifact
         with:
           name: typedoc-build
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -52,24 +52,26 @@ jobs:
         run: yarn build
 
       - name: Store build-release
-        uses: ./.github/actions/upload-artifact
+        uses: actions/upload-artifact@v3
         with:
           name: build-release
           path: |
-            ./packages/rust-bindings/pkg
-            ./packages/rust-bindings/package.json
-            ./packages/rust-bindings/README.md
-            ./packages/common/lib
-            ./packages/common/grpc
-            ./packages/common/package.json
-            ./packages/common/README.md
-            ./packages/nodejs/lib
-            ./packages/nodejs/grpc
-            ./packages/nodejs/package.json
-            ./packages/nodejs/README.md
-            ./packages/web/lib
-            ./packages/web/package.json
-            ./packages/web/README.md
+            packages/rust-bindings/pkg
+            !packages/rust-bindings/pkg/**/.gitignore
+            !packages/rust-bindings/pkg/**/README.md
+            packages/rust-bindings/package.json
+            packages/rust-bindings/README.md
+            packages/common/lib
+            packages/common/grpc
+            packages/common/package.json
+            packages/common/README.md
+            packages/nodejs/lib
+            packages/nodejs/grpc
+            packages/nodejs/package.json
+            packages/nodejs/README.md
+            packages/web/lib
+            packages/web/package.json
+            packages/web/README.md
 
   build-typedoc:
     runs-on: ubuntu-22.04
@@ -85,7 +87,7 @@ jobs:
           cache: yarn
 
       - name: Get build-output
-        uses: ./.github/actions/download-artifact
+        uses: actions/download-artifact@v3
         with:
           name: build-release
 
@@ -96,7 +98,7 @@ jobs:
         run: yarn typedoc
 
       - name: Store typedoc
-        uses: ./.github/actions/upload-artifact
+        uses: actions/upload-artifact@v3
         with:
           name: typedoc-build
           path: typedoc
@@ -112,7 +114,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get typedoc
-        uses: ./.github/actions/download-artifact
+        uses: actions/download-artifact@v3
         with:
           name: typedoc-build
 


### PR DESCRIPTION
## Purpose

Fixes #217 

## Changes

- Caches yarn dependencies
- Include all packages in `build-release`, slim down `rust-bindings` to only include needed files due to difficulties properly publishing with `pkg/*/.gitignore` present.
