### PR TITLE
Add function to display a type schema template

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint-staged": {
         "*.ts": "yarn lint-fix"
     },
+    "packageManager": "yarn@3.2.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/Concordium/concordium-node-sdk-js"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lint-staged": {
         "*.ts": "yarn lint-fix"
     },
-    "packageManager": "yarn@berry",
     "repository": {
         "type": "git",
         "url": "https://github.com/Concordium/concordium-node-sdk-js"

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 8.1.0
+
+### Added
+
+- `display_type_schema_template` function
+
 ## 8.0.0
 
 ### Breaking changes

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "8.0.0",
+    "version": "8.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"
@@ -51,7 +51,7 @@
         "build-dev": "tsc"
     },
     "dependencies": {
-        "@concordium/rust-bindings": "1.0.0",
+        "@concordium/rust-bindings": "1.1.0",
         "@grpc/grpc-js": "^1.3.4",
         "@noble/ed25519": "^1.7.1",
         "@protobuf-ts/runtime-rpc": "^2.8.2",

--- a/packages/common/src/schemaHelpers.ts
+++ b/packages/common/src/schemaHelpers.ts
@@ -42,3 +42,15 @@ export function getUpdateContractParameterSchema(
     );
     return Buffer.from(parameterSchema, 'hex');
 }
+
+/**
+ * @param rawSchema the schema for the type
+ * @returns JSON template of the schema
+ */
+export function displayTypeSchemaTemplate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+    rawSchema: Buffer
+): string {
+    const value = wasm.displayTypeSchemaTemplate(rawSchema.toString('hex'));
+    return value;
+}

--- a/packages/common/src/schemaHelpers.ts
+++ b/packages/common/src/schemaHelpers.ts
@@ -47,10 +47,6 @@ export function getUpdateContractParameterSchema(
  * @param rawSchema the schema for the type
  * @returns JSON template of the schema
  */
-export function displayTypeSchemaTemplate(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-    rawSchema: Buffer
-): string {
-    const value = wasm.displayTypeSchemaTemplate(rawSchema.toString('hex'));
-    return value;
+export function displayTypeSchemaTemplate(rawSchema: Buffer): string {
+    return wasm.displayTypeSchemaTemplate(rawSchema.toString('hex'));
 }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -60,7 +60,7 @@
         "build-dev": "tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "8.0.0",
+        "@concordium/common-sdk": "8.1.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "buffer": "^6.0.3",

--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `display_type_schema_template`
+- `display_type_schema_template` function
 
 ## 1.0.0
 

--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+### Added
+
+- `display_type_schema_template`
+
 ## 1.0.0
 
 ### Breaking changes

--- a/packages/rust-bindings/Cargo.lock
+++ b/packages/rust-bindings/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
 name = "concordium-contracts-common"
 version = "7.0.0"
 dependencies = [
+ "base64",
  "bs58",
  "chrono",
  "concordium-contracts-common-derive",

--- a/packages/rust-bindings/package.json
+++ b/packages/rust-bindings/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/rust-bindings",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/rust-bindings/src/aux_functions.rs
+++ b/packages/rust-bindings/src/aux_functions.rs
@@ -774,6 +774,12 @@ fn deserialize_type_value(
     }
 }
 
+pub fn display_type_schema_template_aux(schema: HexString) -> Result<JsonString> {
+    let value_type: Type = from_bytes(&hex::decode(schema)?)?;
+    let v = value_type.to_json_template();
+    Ok(to_string(&v)?)
+}
+
 #[derive(SerdeSerialize, SerdeDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdProofInput {

--- a/packages/rust-bindings/src/external_functions.rs
+++ b/packages/rust-bindings/src/external_functions.rs
@@ -403,3 +403,9 @@ pub fn deserialize_type_value_ext(
     )
     .map_err(|e| JsError::new(&format!("Unable to deserialize value due to: {}", e)))
 }
+
+#[wasm_bindgen(js_name = displayTypeSchemaTemplate)]
+pub fn display_type_schema_template(schema: HexString) -> JsResult {
+    display_type_schema_template_aux(schema)
+        .map_err(|e| JsError::new(&format!("Unable to get template of schema: {}", e)))
+}

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.1.0
+
+### Added
+
+- `display_type_schema_template` function
+
 ## 5.0.0
 
 ### Breaking changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,7 +48,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "8.0.0",
+        "@concordium/common-sdk": "8.1.0",
         "@concordium/rust-bindings": "1.1.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
@@ -49,7 +49,7 @@
     },
     "dependencies": {
         "@concordium/common-sdk": "8.0.0",
-        "@concordium/rust-bindings": "1.0.0",
+        "@concordium/rust-bindings": "1.1.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",
         "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,11 +1312,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@8.0.0, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@concordium/common-sdk@npm:8.0.0"
+  dependencies:
+    "@concordium/rust-bindings": 1.0.0
+    "@grpc/grpc-js": ^1.3.4
+    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    iso-3166-1: ^2.1.1
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: 2ee043af6fe32a6e78193876dc3dface9121f9ad6f88b4a70e3db3b1c94b8d9c636394c10e235b98234acfa31717c8f3f58b82af0300242a170ba8249d93fb94
+  languageName: node
+  linkType: hard
+
+"@concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
-    "@concordium/rust-bindings": 1.0.0
+    "@concordium/rust-bindings": 1.1.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/plugin": 2.8.1
@@ -1404,18 +1424,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/rust-bindings@1.0.0, @concordium/rust-bindings@workspace:packages/rust-bindings":
+"@concordium/rust-bindings@1.1.0, @concordium/rust-bindings@workspace:packages/rust-bindings":
   version: 0.0.0-use.local
   resolution: "@concordium/rust-bindings@workspace:packages/rust-bindings"
   languageName: unknown
   linkType: soft
+
+"@concordium/rust-bindings@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@concordium/rust-bindings@npm:1.0.0"
+  checksum: f13a9ff622d45974eb6b49261291ef726faba888867d9beeb4a754200d0666c8fba6c983db5481c45d1f6ff3256716e6fae65b7f572c826417a0595e384e828c
+  languageName: node
+  linkType: hard
 
 "@concordium/web-sdk@workspace:packages/web":
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
     "@concordium/common-sdk": 8.0.0
-    "@concordium/rust-bindings": 1.0.0
+    "@concordium/rust-bindings": 1.1.0
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2
     "@typescript-eslint/eslint-plugin": ^4.28.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,27 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@npm:8.0.0":
-  version: 8.0.0
-  resolution: "@concordium/common-sdk@npm:8.0.0"
-  dependencies:
-    "@concordium/rust-bindings": 1.0.0
-    "@grpc/grpc-js": ^1.3.4
-    "@noble/ed25519": ^1.7.1
-    "@protobuf-ts/runtime-rpc": ^2.8.2
-    "@scure/bip39": ^1.1.0
-    bs58check: ^2.1.2
-    buffer: ^6.0.3
-    cross-fetch: 3.1.5
-    hash.js: ^1.1.7
-    iso-3166-1: ^2.1.1
-    json-bigint: ^1.0.0
-    uuid: ^8.3.2
-  checksum: 2ee043af6fe32a6e78193876dc3dface9121f9ad6f88b4a70e3db3b1c94b8d9c636394c10e235b98234acfa31717c8f3f58b82af0300242a170ba8249d93fb94
-  languageName: node
-  linkType: hard
-
-"@concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@8.1.0, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
@@ -1395,7 +1375,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 8.0.0
+    "@concordium/common-sdk": 8.1.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/grpc-transport": ^2.8.2
@@ -1430,18 +1410,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/rust-bindings@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@concordium/rust-bindings@npm:1.0.0"
-  checksum: f13a9ff622d45974eb6b49261291ef726faba888867d9beeb4a754200d0666c8fba6c983db5481c45d1f6ff3256716e6fae65b7f572c826417a0595e384e828c
-  languageName: node
-  linkType: hard
-
 "@concordium/web-sdk@workspace:packages/web":
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 8.0.0
+    "@concordium/common-sdk": 8.1.0
     "@concordium/rust-bindings": 1.1.0
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2


### PR DESCRIPTION
## Purpose

Addresses https://github.com/Concordium/concordium-contracts-common/issues/96

`Contract-commons` had new functions added to display schema templates. Making this function/feature available for the front end as well.

## Changes

- Added rust-binding to the `to_json_template()` function that can be called on a `typeSchema`.