### PR TITLE
Prepare new release + Fix transaction type enum

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 8.1.0
+## 9.0.0
+
+### Breaking changes
+
+- Renamed `AccountTransactionType.TransferWithScheduleWithMemo` to `AccountTransactionType.TransferWithScheduleAndMemo`.
 
 ### Changed
 
@@ -8,7 +12,8 @@
 
 ### Added
 
-- `displayTypeSchemaTemplate` function
+- `getTransactionKindString` function.
+- `displayTypeSchemaTemplate` function.
 
 ## 8.0.0
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 8.1.0
 
+### Changed
+
+- Bumped @concordium/rust-bindings to 1.1.0 (adds `display_type_schema_template` function)
+
 ### Added
 
-- `display_type_schema_template` function
+- `displayTypeSchemaTemplate` function
 
 ## 8.0.0
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "8.1.0",
+    "version": "9.0.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1492,7 +1492,7 @@ export enum AccountTransactionType {
     RegisterData = 21,
     TransferWithMemo = 22,
     EncryptedAmountTransferWithMemo = 23,
-    TransferWithScheduleWithMemo = 24,
+    TransferWithScheduleAndMemo = 24,
     ConfigureBaker = 25,
     ConfigureDelegation = 26,
 }

--- a/packages/common/src/types/blockItemSummary.ts
+++ b/packages/common/src/types/blockItemSummary.ts
@@ -78,7 +78,9 @@ export enum TransactionKindString {
 /**
  * Given an AccountTransactionType number value, return the corresponding TransactionKindString value
  */
-export function getTransactionKindString(type: AccountTransactionType) {
+export function getTransactionKindString(
+    type: AccountTransactionType
+): TransactionKindString {
     return TransactionKindString[
         AccountTransactionType[type] as keyof typeof AccountTransactionType
     ];

--- a/packages/common/src/types/blockItemSummary.ts
+++ b/packages/common/src/types/blockItemSummary.ts
@@ -28,6 +28,7 @@ import {
     TransactionStatusEnum,
     ContractAddress,
     Base58String,
+    AccountTransactionType,
 } from '../types';
 import { RejectReason } from './rejectReason';
 import { isDefined } from '../util';
@@ -72,6 +73,15 @@ export enum TransactionKindString {
     ConfigureDelegation = 'configureDelegation',
     StakingReward = 'paydayAccountReward',
     Failed = 'failed',
+}
+
+/**
+ * Given an AccountTransactionType number value, return the corresponding TransactionKindString value
+ */
+export function getTransactionKindString(type: AccountTransactionType) {
+    return TransactionKindString[
+        AccountTransactionType[type] as keyof typeof AccountTransactionType
+    ];
 }
 
 export interface TransferSummary {

--- a/packages/common/test/schemaHelpers.test.ts
+++ b/packages/common/test/schemaHelpers.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import { Buffer } from 'buffer/';
+import {
+    displayTypeSchemaTemplate,
+    getUpdateContractParameterSchema,
+} from '../src/schemaHelpers';
+
+test('generate baker keys', () => {
+    const fullSchema = Buffer.from(
+        fs.readFileSync('./test/resources/cis2-nft-schema.bin')
+    );
+    const schemaVersion = 1;
+    const contractName = 'CIS2-NFT';
+    const functionName = 'transfer';
+    const template = displayTypeSchemaTemplate(
+        getUpdateContractParameterSchema(
+            fullSchema,
+            contractName,
+            functionName,
+            schemaVersion
+        )
+    );
+    expect(template).toBe(
+        '[{"amount":["<UInt8>","<UInt8>"],"data":["<UInt8>"],"from":{"Enum":[{"Account":["<AccountAddress>"]},{"Contract":[{"index":"<UInt64>","subindex":"<UInt64>"}]}]},"to":{"Enum":[{"Account":["<AccountAddress>"]},{"Contract":[{"index":"<UInt64>","subindex":"<UInt64>"},{"contract":"<String>","func":"<String>"}]}]},"token_id":["<UInt8>"]}]'
+    );
+});

--- a/packages/common/test/schemaHelpers.test.ts
+++ b/packages/common/test/schemaHelpers.test.ts
@@ -5,7 +5,7 @@ import {
     getUpdateContractParameterSchema,
 } from '../src/schemaHelpers';
 
-test('generate baker keys', () => {
+test('schema template display', () => {
     const fullSchema = Buffer.from(
         fs.readFileSync('./test/resources/cis2-nft-schema.bin')
     );

--- a/packages/common/test/types/blockItemSummary.test.ts
+++ b/packages/common/test/types/blockItemSummary.test.ts
@@ -18,6 +18,8 @@ import {
     ConfigureDelegationSummary,
     DelegationTargetType,
     getSummaryContractUpdateLogs,
+    getTransactionKindString,
+    AccountTransactionType,
 } from '../../src';
 
 const chainUpdate: UpdateSummary = {
@@ -347,4 +349,76 @@ describe('getSummaryContractUpdateLogs', () => {
             },
         ]);
     });
+});
+
+test('getTransactionKindString', () => {
+    expect(getTransactionKindString(AccountTransactionType.DeployModule)).toBe(
+        TransactionKindString.DeployModule
+    );
+    expect(getTransactionKindString(AccountTransactionType.InitContract)).toBe(
+        TransactionKindString.InitContract
+    );
+    expect(getTransactionKindString(AccountTransactionType.Update)).toBe(
+        TransactionKindString.Update
+    );
+    expect(getTransactionKindString(AccountTransactionType.Transfer)).toBe(
+        TransactionKindString.Transfer
+    );
+    expect(getTransactionKindString(AccountTransactionType.AddBaker)).toBe(
+        TransactionKindString.AddBaker
+    );
+    expect(getTransactionKindString(AccountTransactionType.RemoveBaker)).toBe(
+        TransactionKindString.RemoveBaker
+    );
+    expect(
+        getTransactionKindString(AccountTransactionType.UpdateBakerStake)
+    ).toBe(TransactionKindString.UpdateBakerStake);
+    expect(
+        getTransactionKindString(
+            AccountTransactionType.UpdateBakerRestakeEarnings
+        )
+    ).toBe(TransactionKindString.UpdateBakerRestakeEarnings);
+    expect(
+        getTransactionKindString(AccountTransactionType.UpdateBakerKeys)
+    ).toBe(TransactionKindString.UpdateBakerKeys);
+    expect(
+        getTransactionKindString(AccountTransactionType.UpdateCredentialKeys)
+    ).toBe(TransactionKindString.UpdateCredentialKeys);
+    expect(
+        getTransactionKindString(AccountTransactionType.EncryptedAmountTransfer)
+    ).toBe(TransactionKindString.EncryptedAmountTransfer);
+    expect(
+        getTransactionKindString(AccountTransactionType.TransferToEncrypted)
+    ).toBe(TransactionKindString.TransferToEncrypted);
+    expect(
+        getTransactionKindString(AccountTransactionType.TransferToPublic)
+    ).toBe(TransactionKindString.TransferToPublic);
+    expect(
+        getTransactionKindString(AccountTransactionType.TransferWithSchedule)
+    ).toBe(TransactionKindString.TransferWithSchedule);
+    expect(
+        getTransactionKindString(AccountTransactionType.UpdateCredentials)
+    ).toBe(TransactionKindString.UpdateCredentials);
+    expect(getTransactionKindString(AccountTransactionType.RegisterData)).toBe(
+        TransactionKindString.RegisterData
+    );
+    expect(
+        getTransactionKindString(AccountTransactionType.TransferWithMemo)
+    ).toBe(TransactionKindString.TransferWithMemo);
+    expect(
+        getTransactionKindString(
+            AccountTransactionType.EncryptedAmountTransferWithMemo
+        )
+    ).toBe(TransactionKindString.EncryptedAmountTransferWithMemo);
+    expect(
+        getTransactionKindString(
+            AccountTransactionType.TransferWithScheduleAndMemo
+        )
+    ).toBe(TransactionKindString.TransferWithScheduleAndMemo);
+    expect(
+        getTransactionKindString(AccountTransactionType.ConfigureBaker)
+    ).toBe(TransactionKindString.ConfigureBaker);
+    expect(
+        getTransactionKindString(AccountTransactionType.ConfigureDelegation)
+    ).toBe(TransactionKindString.ConfigureDelegation);
 });

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 8.1.0
+## 9.0.0
 
-### Changed
+### Breaking changes
 
-- Bumped @concordium/common-sdk to 8.1.0. (adds `display_type_schema_template` function)
+- Bumped @concordium/common-sdk to 9.0.0. (adds `displayTypeSchemaTemplate` and renames `AccountTransactionType.TransferWithScheduleWithMemo`)
 
 ## 8.0.0
 

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Bumped @concordium/common-sdk to 9.0.0. (adds `displayTypeSchemaTemplate` and renames `AccountTransactionType.TransferWithScheduleWithMemo`)
+- Bumped @concordium/common-sdk to 9.0.0. (adds `displayTypeSchemaTemplate/getTransactionKindString` and renames `AccountTransactionType.TransferWithScheduleWithMemo`)
 
 ## 8.0.0
 

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 8.1.0
+
+### Changed
+
+- Bumped @concordium/common-sdk to 8.1.0. (adds `display_type_schema_template` function)
+
 ## 8.0.0
 
 ### Breaking changes

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "8.0.0",
+    "version": "8.1.0",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "8.1.0",
+    "version": "9.0.0",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",
@@ -60,7 +60,7 @@
         "build-dev": "tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "8.1.0",
+        "@concordium/common-sdk": "9.0.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "buffer": "^6.0.3",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Bumped @concordium/rust-bindings to 1.1.0 and @concordium/common-sdk to 9.0.0. (adds `displayTypeSchemaTemplate` and renames `AccountTransactionType.TransferWithScheduleWithMemo`)
+- Bumped @concordium/rust-bindings to 1.1.0 and @concordium/common-sdk to 9.0.0. (adds `displayTypeSchemaTemplate/getTransactionKindString` and renames `AccountTransactionType.TransferWithScheduleWithMemo`)
 
 ## 5.0.0
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 5.1.0
 
-### Added
+### Changed
 
-- `display_type_schema_template` function
+- Bumped @concordium/rust-bindings to 1.1.0 and @concordium/common-sdk to 8.1.0. (adds `display_type_schema_template` function)
 
 ## 5.0.0
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 5.1.0
+## 6.0.0
 
-### Changed
+### Breaking changes
 
-- Bumped @concordium/rust-bindings to 1.1.0 and @concordium/common-sdk to 8.1.0. (adds `display_type_schema_template` function)
+- Bumped @concordium/rust-bindings to 1.1.0 and @concordium/common-sdk to 9.0.0. (adds `displayTypeSchemaTemplate` and renames `AccountTransactionType.TransferWithScheduleWithMemo`)
 
 ## 5.0.0
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "5.1.0",
+    "version": "6.0.0",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
@@ -48,7 +48,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "8.1.0",
+        "@concordium/common-sdk": "9.0.0",
         "@concordium/rust-bindings": "1.1.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@8.1.0, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@9.0.0, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
@@ -1375,7 +1375,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 8.1.0
+    "@concordium/common-sdk": 9.0.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/grpc-transport": ^2.8.2
@@ -1414,7 +1414,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 8.1.0
+    "@concordium/common-sdk": 9.0.0
     "@concordium/rust-bindings": 1.1.0
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2


### PR DESCRIPTION
## Purpose

Bump versions + fix stuff :upside_down_face: 

## Changes

- Bump major versions + update changelogs
- Rename `AccountTransactionType.TransferWithScheduleWithMemo` to `AccountTransactionType.TransferWithScheduleAndMemo`
- Add `getTransactionKindString`
- Add some tests

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

