### PR TITLE
Fix GRPCClient waitForTransactionFinalization

### DIFF
--- a/packages/common/src/GRPCClient.ts
+++ b/packages/common/src/GRPCClient.ts
@@ -528,17 +528,19 @@ export class ConcordiumGRPCClient {
                 }, timeoutTime);
             }
 
-            const blockStream = this.getFinalizedBlocks(abortController.signal);
-
-            const response = await this.getBlockItemStatus(transactionHash);
-            if (response.status === 'finalized') {
-                // Simply doing `abortController.abort()` causes an error.
-                // See: https://github.com/grpc/grpc-node/issues/1652
-                setTimeout(() => abortController.abort(), 0);
-                return resolve(response.outcome);
-            }
-
             try {
+                const blockStream = this.getFinalizedBlocks(
+                    abortController.signal
+                );
+
+                const response = await this.getBlockItemStatus(transactionHash);
+                if (response.status === 'finalized') {
+                    // Simply doing `abortController.abort()` causes an error.
+                    // See: https://github.com/grpc/grpc-node/issues/1652
+                    setTimeout(() => abortController.abort(), 0);
+                    return resolve(response.outcome);
+                }
+
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 for await (const _ of blockStream) {
                     const response = await this.getBlockItemStatus(


### PR DESCRIPTION
## Purpose

The `waitForTransactionFinalization` method on `ConcordiumGRPCClient` has a bug, where some errors such as waiting for an unknown transaction do not cause the promise to reject. This is for example a problem if a transaction is submitted to one node and `waitForTransactionFinalization` is called connected to a different node. In this case, the correct solution is to wait and retry on a GRPC `NOT_FOUND` error, but as it is now, this is not possible because the promise does not reject.

## Changes

A `try` block has been expanded to catch all errors, which will then cause the promise to reject as it should.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
