### PR TITLE
Conversion helpers

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.0.1
+## Unreleased
 
 ### Added
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.0.1
+
+### Added
+
+- `toCcd` and `fromCcd` functions to the CcdAmount class, which lets users parse and convert to ccd amounts as strings.
+
 ## 9.0.0
 
 ### Breaking changes

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Added
 
-- `toCcd` and `fromCcd` functions to the CcdAmount class, which lets users parse and convert to ccd amounts as strings.
+Added a functions that handle conversions between CCD and micro CCD. The CCD amounts are handled as `Big`'s:
+- `toMicroCcd` returns the amount of micro CCD as a `Big`.
+- `toCcd`: returns the amount of CCD as a `Big`.
+- `fromCcd`: constructs a `CcdAmount` from an amount of CCD passed as a `Big`
+- `ccdToMicroCcd`: Converts CCD to micro CCD, both as `Big`'s
+- `microCcdToCcd`: Converts micro CCD to CCD, both as `Big`'s
+- The `CcdAmount` class constructor now also accepts a `BigSource` letting users create them from `Big`'s and strings
+
+All function parameters now also accepts strings, these strings can use comma as a decimal seperator.
 
 ## 9.0.0
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
     ],
     "devDependencies": {
         "@protobuf-ts/plugin": "2.8.1",
+        "@types/big.js": "^6.2.0",
         "@types/bs58check": "^2.1.0",
         "@types/jest": "^26.0.23",
         "@types/json-bigint": "^1.0.1",
@@ -56,7 +57,7 @@
         "@noble/ed25519": "^1.7.1",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
         "@scure/bip39": "^1.1.0",
-        "@types/big.js": "^6.2.0",
+        "big.js": "^6.2.0",
         "bs58check": "^2.1.2",
         "buffer": "^6.0.3",
         "cross-fetch": "3.1.5",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -56,6 +56,7 @@
         "@noble/ed25519": "^1.7.1",
         "@protobuf-ts/runtime-rpc": "^2.8.2",
         "@scure/bip39": "^1.1.0",
+        "@types/big.js": "^6.2.0",
         "bs58check": "^2.1.2",
         "buffer": "^6.0.3",
         "cross-fetch": "3.1.5",

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -55,7 +55,7 @@ export class CcdAmount {
                 throw Error('More than one decimal seperator found!');
             }
 
-            ccd = ccd.replace('.', ',');
+            ccd = ccd.replace(',', '.');
         }
 
         const microCcd = Big(ccd).mul(Big(1000000));

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -1,4 +1,6 @@
-import { Big } from 'big.js';
+import { Big, BigSource } from 'big.js';
+
+const MICRO_CCD_PER_CCD = 1000000;
 
 /**
  * Representation of a CCD amount.
@@ -8,7 +10,30 @@ import { Big } from 'big.js';
 export class CcdAmount {
     microCcdAmount: bigint;
 
-    constructor(microCcdAmount: bigint) {
+    /**
+     * Constructs a CcdAmount and checks that it is valid, can accept a number, string, big or bigint.
+     * Accepts strings with decimal seperators as both commas and decimals.
+     *
+     * @param microCcdAmount Theamount of micro CCD as a number, string, big or bigint.
+     * @throws If the number of commas in the input string exceeds 1
+     * @throws If a number is passed with several decimal seperators
+     * @throws If a negative amount of micro CCD is passed
+     * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
+     */
+    constructor(microCcdAmount: bigint | BigSource) {
+        // If the input is a "BigSource" assert that the number is whole
+        if (typeof microCcdAmount !== 'bigint') {
+            microCcdAmount = newBig(microCcdAmount);
+
+            if (!microCcdAmount.mod(Big(1)).eq(Big(0))) {
+                throw Error(
+                    'Can not create CcdAmount from a non-whole number!'
+                );
+            }
+
+            microCcdAmount = BigInt(microCcdAmount.toFixed());
+        }
+
         if (microCcdAmount < 0n) {
             throw new Error(
                 'A micro CCD amount must be a non-negative integer but was: ' +
@@ -25,44 +50,82 @@ export class CcdAmount {
     }
 
     /**
-     * Returns the amount of CCD as a string.
+     * Returns the amount of micro CCD as a Big.
      *
-     * @param useCommaDecimalSeperator Whether or not to use a comma as a decimal separator instead of the dot, defaults to false
-     * @returns The amount of CCD as a string
+     * @returns The amount of micro CCD as a Big
      */
-    toCcd(useCommaDecimalSeperator = false): string {
-        const ccd = Big(this.microCcdAmount.toString()).div(Big(1000000));
-
-        if (useCommaDecimalSeperator) {
-            return ccd.toString().replace('.', ',');
-        } else {
-            return ccd.toString();
-        }
+    toBig(): Big {
+        return Big(this.microCcdAmount.toString());
     }
 
     /**
-     * Parses an amount of CCD formatted as a string and creates a CcdAmount from it.
+     * Returns the amount of CCD as a Big.
      *
-     * @param ccd The amount of CCD to formatted as a string
-     * @param useCommaDecimalSeperator Whether or not to use comma as a decimal seperator, defaults to false
-     * @returns The CcdAmount object derived from the ccd input parameter
+     * @returns The amount of CCD as a Big
      */
-    static fromCcd(ccd: string, useCommaDecimalSeperator = false): CcdAmount {
-        if (useCommaDecimalSeperator) {
-            const numberOfDecimalSeperators = ccd.split(',').length - 1;
+    toCcd(): Big {
+        return this.toBig().div(Big(MICRO_CCD_PER_CCD));
+    }
 
-            if (numberOfDecimalSeperators > 1) {
-                throw Error('More than one decimal seperator found!');
-            }
-
-            ccd = ccd.replace(',', '.');
+    /**
+     * Creates a CcdAmount from a number, string, big or bigint.
+     *
+     * @param ccd The amount of CCD
+     * @returns The CcdAmount object derived from the ccd input parameter
+     * @throws If the number of commas in the input string exceeds 1
+     * @throws If a number is passed with several decimal seperators
+     * @throws If a negative amount of micro CCD is passed
+     * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
+     */
+    static fromCcd(ccd: BigSource | bigint): CcdAmount {
+        if (typeof ccd === 'bigint') {
+            ccd = ccd.toString();
         }
 
-        const microCcd = Big(ccd).mul(Big(1000000));
-        return new CcdAmount(BigInt(microCcd.toFixed()));
+        const microCcd = newBig(ccd).mul(Big(MICRO_CCD_PER_CCD));
+        return new CcdAmount(microCcd);
+    }
+
+    /**
+     * Converts an amount of CCD to micro CCD and asserts that the amount is a valid amount of CCD.
+     *
+     * @param ccd The amount of CCD
+     * @returns The amount of micro CCD as a Big
+     * @throws If the number of commas in the input string exceeds 1
+     * @throws If a number is passed with several decimal seperators
+     */
+    static ccdToMicroCcd(ccd: BigSource | bigint): Big {
+        return CcdAmount.fromCcd(ccd).toBig();
+    }
+
+    /**
+     * Converts an amount of micro CCD to CCD and asserts that the amount is a valid amount of CCD.
+     *
+     * @param microCcd The amount of micro CCD as a number, string, big or bigint.
+     * @returns The amount of CCD as a Big
+     * @throws If the number of commas in the input string exceeds 1
+     * @throws If a number is passed with several decimal seperators
+     * @throws If a negative amount of micro CCD is passed
+     * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
+     */
+    static microCcdToCcd(microCcd: BigSource | bigint): Big {
+        return new CcdAmount(microCcd).toCcd();
     }
 
     toJSON(): string {
         return this.microCcdAmount.toString();
     }
+}
+
+function newBig(bigSource: BigSource): Big {
+    if (typeof bigSource === 'string') {
+        const numberOfCommaSeperators = bigSource.split(',').length - 1;
+
+        if (numberOfCommaSeperators > 1) {
+            throw Error('More than one decimal seperator found!');
+        } else if (numberOfCommaSeperators === 1) {
+            return Big(bigSource.replace(',', '.'));
+        }
+    }
+    return Big(bigSource);
 }

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -27,7 +27,7 @@ export class CcdAmount {
     /**
      * Returns the amount of CCD as a string.
      *
-     * @param useCommaDecimalSeperator Whether or not to use comma as a decimal seperator, defaults to false
+     * @param useCommaDecimalSeperator Whether or not to use a comma as a decimal separator instead of the dot, defaults to false
      * @returns The amount of CCD as a string
      */
     toCcd(useCommaDecimalSeperator = false): string {

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -1,4 +1,4 @@
-import { Big } from 'big.js/';
+import { Big } from 'big.js';
 
 /**
  * Representation of a CCD amount.

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -15,9 +15,7 @@ export class CcdAmount {
      * It can accept a string as parameter with either a comma or a dot as the decimal separator.
      *
      * @param microCcdAmount The amount of micro CCD as a number, string, big, or bigint.
-     * @throws If a number is passed with several decimal seperators
-     * @throws If a negative amount of micro CCD is passed
-     * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
+     * @throws If an invalid micro CCD amount is passed, i.e. any value which is not an unsigned 64-bit integer
      */
     constructor(microCcdAmount: bigint | BigSource) {
         // If the input is a "BigSource" assert that the number is whole

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -119,13 +119,7 @@ export class CcdAmount {
 
 function newBig(bigSource: BigSource): Big {
     if (typeof bigSource === 'string') {
-        const numberOfCommaSeperators = bigSource.split(',').length - 1;
-
-        if (numberOfCommaSeperators > 1) {
-            throw Error('More than one decimal seperator found!');
-        } else if (numberOfCommaSeperators === 1) {
-            return Big(bigSource.replace(',', '.'));
-        }
+        return Big(bigSource.replace(',', '.'));
     }
     return Big(bigSource);
 }

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -15,7 +15,6 @@ export class CcdAmount {
      * It can accept a string as parameter with either a comma or a dot as the decimal separator.
      *
      * @param microCcdAmount The amount of micro CCD as a number, string, big, or bigint.
-     * @throws If the number of commas in the input string exceeds 1
      * @throws If a number is passed with several decimal seperators
      * @throws If a negative amount of micro CCD is passed
      * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
@@ -64,15 +63,14 @@ export class CcdAmount {
      * @returns The amount of CCD as a Big
      */
     toCcd(): Big {
-        return this.toBig().div(Big(MICRO_CCD_PER_CCD));
+        return this.toMicroCcd().div(Big(MICRO_CCD_PER_CCD));
     }
 
     /**
      * Creates a CcdAmount from a number, string, big, or bigint.
      *
-     * @param ccd The amount of CCD
+     * @param ccd The amount of micro CCD as a number, string, big or bigint.
      * @returns The CcdAmount object derived from the ccd input parameter
-     * @throws If the number of commas in the input string exceeds 1
      * @throws If a number is passed with several decimal seperators
      * @throws If a negative amount of micro CCD is passed
      * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
@@ -89,13 +87,14 @@ export class CcdAmount {
     /**
      * Converts an amount of CCD to micro CCD and asserts that the amount is a valid amount of CCD.
      *
-     * @param ccd The amount of CCD
+     * @param ccd The amount of CCD as a number, string, big or bigint.
      * @returns The amount of micro CCD as a Big
-     * @throws If the number of commas in the input string exceeds 1
      * @throws If a number is passed with several decimal seperators
+     * @throws If a negative amount of micro CCD is passed
+     * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer
      */
     static ccdToMicroCcd(ccd: BigSource | bigint): Big {
-        return CcdAmount.fromCcd(ccd).toBig();
+        return CcdAmount.fromCcd(ccd).toMicroCcd();
     }
 
     /**
@@ -103,7 +102,6 @@ export class CcdAmount {
      *
      * @param microCcd The amount of micro CCD as a number, string, big or bigint.
      * @returns The amount of CCD as a Big
-     * @throws If the number of commas in the input string exceeds 1
      * @throws If a number is passed with several decimal seperators
      * @throws If a negative amount of micro CCD is passed
      * @throws If the micro CCD passed is greater than what can be contained in a 64-bit integer

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -1,3 +1,5 @@
+import { Big } from 'big.js/';
+
 /**
  * Representation of a CCD amount.
  * The base unit of CCD is micro CCD, which is the representation
@@ -20,6 +22,44 @@ export class CcdAmount {
         }
 
         this.microCcdAmount = microCcdAmount;
+    }
+
+    /**
+     * Returns the amount of CCD as a string.
+     *
+     * @param useCommaDecimalSeperator Whether or not to use comma as a decimal seperator, defaults to false
+     * @returns The amount of CCD as a string
+     */
+    toCcd(useCommaDecimalSeperator = false): string {
+        const ccd = Big(this.microCcdAmount.toString()).div(Big(1000000));
+
+        if (useCommaDecimalSeperator) {
+            return ccd.toString().replace('.', ',');
+        } else {
+            return ccd.toString();
+        }
+    }
+
+    /**
+     * Parses an amount of CCD formatted as a string and creates a CcdAmount from it.
+     *
+     * @param ccd The amount of CCD to formatted as a string
+     * @param useCommaDecimalSeperator Whether or not to use comma as a decimal seperator, defaults to false
+     * @returns The CcdAmount object derived from the ccd input parameter
+     */
+    static fromCcd(ccd: string, useCommaDecimalSeperator = false): CcdAmount {
+        if (useCommaDecimalSeperator) {
+            const numberOfDecimalSeperators = ccd.split(',').length - 1;
+
+            if (numberOfDecimalSeperators > 1) {
+                throw Error('More than one decimal seperator found!');
+            }
+
+            ccd = ccd.replace('.', ',');
+        }
+
+        const microCcd = Big(ccd).mul(Big(1000000));
+        return new CcdAmount(BigInt(microCcd.toFixed()));
     }
 
     toJSON(): string {

--- a/packages/common/src/types/ccdAmount.ts
+++ b/packages/common/src/types/ccdAmount.ts
@@ -11,10 +11,10 @@ export class CcdAmount {
     microCcdAmount: bigint;
 
     /**
-     * Constructs a CcdAmount and checks that it is valid, can accept a number, string, big or bigint.
-     * Accepts strings with decimal seperators as both commas and decimals.
+     * Constructs a CcdAmount and checks that it is valid. It accepts a number, string, big, or bigint as parameter.
+     * It can accept a string as parameter with either a comma or a dot as the decimal separator.
      *
-     * @param microCcdAmount Theamount of micro CCD as a number, string, big or bigint.
+     * @param microCcdAmount The amount of micro CCD as a number, string, big, or bigint.
      * @throws If the number of commas in the input string exceeds 1
      * @throws If a number is passed with several decimal seperators
      * @throws If a negative amount of micro CCD is passed
@@ -54,7 +54,7 @@ export class CcdAmount {
      *
      * @returns The amount of micro CCD as a Big
      */
-    toBig(): Big {
+    toMicroCcd(): Big {
         return Big(this.microCcdAmount.toString());
     }
 
@@ -68,7 +68,7 @@ export class CcdAmount {
     }
 
     /**
-     * Creates a CcdAmount from a number, string, big or bigint.
+     * Creates a CcdAmount from a number, string, big, or bigint.
      *
      * @param ccd The amount of CCD
      * @returns The CcdAmount object derived from the ccd input parameter

--- a/packages/common/test/types/ccdAmount.test.ts
+++ b/packages/common/test/types/ccdAmount.test.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js';
 import { CcdAmount } from '../../src';
 
 describe('To and from ccd as strings', () => {
@@ -12,7 +13,9 @@ describe('To and from ccd as strings', () => {
     });
 
     test('CCD amounts that specifies more decimals than 6 throws', () => {
-        expect(() => CcdAmount.fromCcd('0.1234567')).toThrow();
+        expect(() => CcdAmount.fromCcd('0.1234567')).toThrow(
+            Error('Can not create CcdAmount from a non-whole number!')
+        );
     });
 
     test('CCD amounts that specifies 6 or less decimals is valid, test 1', () => {
@@ -27,21 +30,33 @@ describe('To and from ccd as strings', () => {
 
     test('Returns correct amount of CCD, test 1', () => {
         const ccd = new CcdAmount(1000n);
-        expect(ccd.toCcd()).toEqual('0.001');
+        expect(ccd.toCcd()).toEqual(Big('0.001'));
     });
 
     test('Returns correct amount of CCD, test 2', () => {
         const ccd = new CcdAmount(123456789n);
-        expect(ccd.toCcd()).toEqual('123.456789');
+        expect(ccd.toCcd()).toEqual(Big('123.456789'));
     });
 
-    test('Test comma seperator toCcd', () => {
-        const ccd = new CcdAmount(123456789n);
-        expect(ccd.toCcd(true)).toEqual('123,456789');
+    test('FromCcd correctly takes comma as a decimal seperator', () => {
+        expect(CcdAmount.fromCcd('10,000').toCcd()).toEqual(Big('10'));
     });
 
-    test('Test comma seperator fromCcd', () => {
-        const ccd = CcdAmount.fromCcd('1,002', true);
-        expect(ccd.microCcdAmount).toEqual(1002000n);
+    test('CcdAmount constructor correctly rejects multiple comma seperators', () => {
+        expect(() => CcdAmount.fromCcd('10,000,000')).toThrow(
+            Error('More than one decimal seperator found!')
+        );
+    });
+
+    test('fromCcd is equal to ccdToMicroCcd', () => {
+        const microCcd1 = Big(CcdAmount.fromCcd('1').microCcdAmount.toString());
+        const microCcd2 = CcdAmount.ccdToMicroCcd('1');
+        expect(microCcd1).toEqual(microCcd2);
+    });
+
+    test('toCcd is equal to microCcdToCcd', () => {
+        const ccd1 = new CcdAmount('1').toCcd();
+        const ccd2 = CcdAmount.microCcdToCcd('1');
+        expect(ccd1).toEqual(ccd2);
     });
 });

--- a/packages/common/test/types/ccdAmount.test.ts
+++ b/packages/common/test/types/ccdAmount.test.ts
@@ -34,4 +34,14 @@ describe('To and from ccd as strings', () => {
         const ccd = new CcdAmount(123456789n);
         expect(ccd.toCcd()).toEqual('123.456789');
     });
+
+    test('Test comma seperator toCcd', () => {
+        const ccd = new CcdAmount(123456789n);
+        expect(ccd.toCcd(true)).toEqual('123,456789');
+    });
+
+    test('Test comma seperator fromCcd', () => {
+        const ccd = CcdAmount.fromCcd('1,002', true);
+        expect(ccd.microCcdAmount).toEqual(1002000n);
+    });
 });

--- a/packages/common/test/types/ccdAmount.test.ts
+++ b/packages/common/test/types/ccdAmount.test.ts
@@ -1,0 +1,37 @@
+import { CcdAmount } from '../../src';
+
+describe('To and from ccd as strings', () => {
+    test('Parses one CCD correctly', () => {
+        const ccd = CcdAmount.fromCcd('1');
+        expect(ccd.microCcdAmount).toEqual(1000000n);
+    });
+
+    test('Parses decimals correctly', () => {
+        const ccd = CcdAmount.fromCcd('1.002');
+        expect(ccd.microCcdAmount).toEqual(1002000n);
+    });
+
+    test('CCD amounts that specifies more decimals than 6 throws', () => {
+        expect(() => CcdAmount.fromCcd('0.1234567')).toThrow();
+    });
+
+    test('CCD amounts that specifies 6 or less decimals is valid, test 1', () => {
+        const ccd = CcdAmount.fromCcd('0.123456');
+        expect(ccd.microCcdAmount).toEqual(123456n);
+    });
+
+    test('CCD amounts that specifies 6 or less decimals is valid, test 2', () => {
+        const ccd = CcdAmount.fromCcd('789.123456');
+        expect(ccd.microCcdAmount).toEqual(789123456n);
+    });
+
+    test('Returns correct amount of CCD, test 1', () => {
+        const ccd = new CcdAmount(1000n);
+        expect(ccd.toCcd()).toEqual('0.001');
+    });
+
+    test('Returns correct amount of CCD, test 2', () => {
+        const ccd = new CcdAmount(123456789n);
+        expect(ccd.toCcd()).toEqual('123.456789');
+    });
+});

--- a/packages/common/test/types/ccdAmount.test.ts
+++ b/packages/common/test/types/ccdAmount.test.ts
@@ -44,7 +44,7 @@ describe('To and from ccd as strings', () => {
 
     test('CcdAmount constructor correctly rejects multiple comma seperators', () => {
         expect(() => CcdAmount.fromCcd('10,000,000')).toThrow(
-            Error('More than one decimal seperator found!')
+            Error('[big.js] Invalid number')
         );
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1322,6 +1322,7 @@ __metadata:
     "@protobuf-ts/plugin": 2.8.1
     "@protobuf-ts/runtime-rpc": ^2.8.2
     "@scure/bip39": ^1.1.0
+    "@types/big.js": ^6.2.0
     "@types/bs58check": ^2.1.0
     "@types/jest": ^26.0.23
     "@types/json-bigint": ^1.0.1
@@ -2243,6 +2244,13 @@ __metadata:
   dependencies:
     "@babel/types": ^7.3.0
   checksum: 8992d8c1eaaf1c793e9184b930767883446939d2744c40ea4e9591086e79b631189dc519931ed8864f1e016742a189703c217db59b800aca84870b865009d8b4
+  languageName: node
+  linkType: hard
+
+"@types/big.js@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "@types/big.js@npm:6.2.0"
+  checksum: 69216051378559083453eb89ff63c70300928ebe3e5ccf2af98be39cdce1591d206a2206f1b3b97234b281646b54ded4c7bdf67fa4e383dccd278d129694af67
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.28.1
     "@typescript-eslint/parser": ^4.28.1
     babel-jest: ^27.0.6
+    big.js: ^6.2.0
     bs58check: ^2.1.2
     buffer: ^6.0.3
     cross-fetch: 3.1.5
@@ -3245,6 +3246,13 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: b89b6e8419b097a8fb4ed2399a1931a68c612bce3cfd5ca8c214b2d017531191070f990598de2fc6f3f993d91c0f08aa82697717f6b3b8732c9731866d233c9e
+  languageName: node
+  linkType: hard
+
+"big.js@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "big.js@npm:6.2.1"
+  checksum: 0b234a2fd56c52bed2798ed2020bcab6fef5e9523b99a05406ad071d1aed6ee97ada9fb8de9576092da74c68825c276e19015743b8d1baea269b60a5c666b0cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

Addresses #214 

## Changes

- `toCcd` and `fromCcd` functions to the CcdAmount class, which lets users parse and convert to ccd amounts as strings.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.