### PR TITLE
Fix contract parameter max length

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Fixes
+
+- The max smart contract parameter length was changed to 65535 bytes in protocol version 5 and onwards.
+  Functions which checks the parameter length will now reflect that.
+
 ## 9.1.0
 
 ### Added

--- a/packages/common/src/contractHelpers.ts
+++ b/packages/common/src/contractHelpers.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer/';
 import { ContractAddress, InstanceInfo } from './types';
 
-const CONTRACT_PARAM_MAX_LENGTH = 1024;
+const CONTRACT_PARAM_MAX_LENGTH = 65535;
 
 /**
  * Gets the contract name from an {@link InstanceInfo} object.


### PR DESCRIPTION
## Purpose

The max smart contract parameter length was changed in protocol version 5 and onwards.

## Changes

Change the max parameter length to the [new limit of 65535 bytes](https://proposals.concordium.software/updates/P5.html)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

