### PR TITLE
Web3 id fixes

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.1.1
+
+### Fixes
+ - `verifyWeb3IdCredentialSignature` now supports dates/timestamp attributes.
+ - `canProveAtomicStatement` now supports timestamp attributes, handles undefined attribute value correctly and handles strings correctly for range statements.
+
 ## 9.1.0
 
 ### Added

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "9.1.0",
+    "version": "9.1.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/common/src/web3IdHelpers.ts
+++ b/packages/common/src/web3IdHelpers.ts
@@ -21,7 +21,9 @@ export function verifyWeb3IdCredentialSignature(
     input: VerifyWeb3IdCredentialSignatureInput
 ): boolean {
     // Use json-bigint stringify to ensure we can handle bigints
-    return wasm.verifyWeb3IdCredentialSignature(stringify(input, replaceDateWithTimeStampAttribute));
+    return wasm.verifyWeb3IdCredentialSignature(
+        stringify(input, replaceDateWithTimeStampAttribute)
+    );
 }
 
 /**

--- a/packages/common/src/web3IdHelpers.ts
+++ b/packages/common/src/web3IdHelpers.ts
@@ -1,11 +1,13 @@
 import * as wasm from '@concordium/rust-bindings';
 import { stringify } from 'json-bigint';
 import { ContractAddress, CryptographicParameters } from './types';
+import { replaceDateWithTimeStampAttribute } from './types/VerifiablePresentation';
+import { AttributeType } from './web3ProofTypes';
 
 export type VerifyWeb3IdCredentialSignatureInput = {
     globalContext: CryptographicParameters;
     signature: string;
-    values: Record<string, string | bigint>;
+    values: Record<string, AttributeType>;
     randomness: Record<string, string>;
     holder: string;
     issuerPublicKey: string;
@@ -19,7 +21,7 @@ export function verifyWeb3IdCredentialSignature(
     input: VerifyWeb3IdCredentialSignatureInput
 ): boolean {
     // Use json-bigint stringify to ensure we can handle bigints
-    return wasm.verifyWeb3IdCredentialSignature(stringify(input));
+    return wasm.verifyWeb3IdCredentialSignature(stringify(input, replaceDateWithTimeStampAttribute));
 }
 
 /**

--- a/packages/common/src/web3Proofs.ts
+++ b/packages/common/src/web3Proofs.ts
@@ -41,7 +41,10 @@ import {
     replaceDateWithTimeStampAttribute,
     VerifiablePresentation,
 } from './types/VerifiablePresentation';
-import { compareStringAttributes, isStringAttributeInRange } from './web3IdHelpers';
+import {
+    compareStringAttributes,
+    isStringAttributeInRange,
+} from './web3IdHelpers';
 
 const throwRangeError = (
     title: string,
@@ -640,15 +643,34 @@ export function createWeb3CommitmentInputWithHdWallet(
 /**
  * Helper to check if an attribute value is in the given range.
  */
-function isInRange(value: AttributeType, lower: AttributeType, upper: AttributeType) {
-    if (typeof value === 'string' && typeof lower === 'string' && typeof upper === 'string') {
+function isInRange(
+    value: AttributeType,
+    lower: AttributeType,
+    upper: AttributeType
+) {
+    if (
+        typeof value === 'string' &&
+        typeof lower === 'string' &&
+        typeof upper === 'string'
+    ) {
         return isStringAttributeInRange(value, lower, upper);
     }
-    if (typeof value === 'bigint' && typeof lower === 'bigint' && typeof upper === 'bigint') {
+    if (
+        typeof value === 'bigint' &&
+        typeof lower === 'bigint' &&
+        typeof upper === 'bigint'
+    ) {
         return lower <= value && upper > value;
     }
-    if (value instanceof Date && lower instanceof Date && upper instanceof Date) {
-        return lower.getTime() <= value.getTime() && upper.getTime() > value.getTime();
+    if (
+        value instanceof Date &&
+        lower instanceof Date &&
+        upper instanceof Date
+    ) {
+        return (
+            lower.getTime() <= value.getTime() &&
+            upper.getTime() > value.getTime()
+        );
     }
     // Mismatch in types.
     return false;
@@ -662,7 +684,9 @@ function isInSet(value: AttributeType, set: AttributeType[]) {
         return set.includes(value);
     }
     if (value instanceof Date) {
-        return set.map((date) => date instanceof Date ? date.getTime() : undefined).includes(value.getTime());
+        return set
+            .map((date) => (date instanceof Date ? date.getTime() : undefined))
+            .includes(value.getTime());
     }
     return false;
 }

--- a/packages/common/test/web3IdHelpers.test.ts
+++ b/packages/common/test/web3IdHelpers.test.ts
@@ -92,6 +92,39 @@ test('verifyWeb3IdCredentialSignature can reject due to incorrect holder', async
     ).toBeFalsy();
 });
 
+test('verifyWeb3IdCredentialSignature with timestamps', async () => {
+    const signature =
+        'ec36951aa2795b20b3dee5aa3ddc6b2ce0749bb8b15b1197682614ef2a168ebea38d62711caac54b5097b79fcebf3734c47045c3bf92ad8b2e7d3b4c859a4904';
+    const randomness = {
+        degreeName: "6d89da997e8d6ebeb877413f447e2f6285dd1e885ef6570c0a2322aedb026f6c",
+        degreeType: "216ad9124a884d89b0f557abb03d4c5c1d639dd807a58972c0d21f47cff798cc",
+        graduationDate: "5e581a2c4ab96536b5d0918120cae2bb2f92642d4b9df4446890f5c519b2f3ca"
+}
+    const values = {
+        degreeName: 'Bachelor of Science and Arts',
+        degreeType: 'BachelorDegree',
+        graduationDate: new Date("2023-08-28T00:00:00.000Z"),
+    };
+
+    const holder =
+        '666b4811c26b36357186b6c286261930d12a8772776d70c485a9b16059881824';
+    const issuerPublicKey =
+        '00ee7c443e604fbe6defbbc08ee0bf25e76656037fc189c41e631ac3a0ab136d';
+    const issuerContract = { index: 6105n, subindex: 0n };
+
+    expect(
+        verifyWeb3IdCredentialSignature({
+            globalContext,
+            signature,
+            randomness,
+            values,
+            issuerContract,
+            issuerPublicKey,
+            holder,
+        })
+    ).toBeTruthy();
+});
+
 test('compareStringAttributes works with number strings', () => {
     expect(compareStringAttributes('1', '0')).toBe(1);
     expect(compareStringAttributes('1', '10')).toBe(-1);

--- a/packages/common/test/web3IdHelpers.test.ts
+++ b/packages/common/test/web3IdHelpers.test.ts
@@ -1,9 +1,9 @@
 import {
+    compareStringAttributes,
     isStringAttributeInRange,
     verifyWeb3IdCredentialSignature,
 } from '../src/web3IdHelpers';
 import fs from 'fs';
-import { compareStringAttributes } from '@concordium/rust-bindings';
 
 const globalContext = JSON.parse(
     fs.readFileSync('./test/resources/global.json').toString()
@@ -96,14 +96,17 @@ test('verifyWeb3IdCredentialSignature with timestamps', async () => {
     const signature =
         'ec36951aa2795b20b3dee5aa3ddc6b2ce0749bb8b15b1197682614ef2a168ebea38d62711caac54b5097b79fcebf3734c47045c3bf92ad8b2e7d3b4c859a4904';
     const randomness = {
-        degreeName: "6d89da997e8d6ebeb877413f447e2f6285dd1e885ef6570c0a2322aedb026f6c",
-        degreeType: "216ad9124a884d89b0f557abb03d4c5c1d639dd807a58972c0d21f47cff798cc",
-        graduationDate: "5e581a2c4ab96536b5d0918120cae2bb2f92642d4b9df4446890f5c519b2f3ca"
-}
+        degreeName:
+            '6d89da997e8d6ebeb877413f447e2f6285dd1e885ef6570c0a2322aedb026f6c',
+        degreeType:
+            '216ad9124a884d89b0f557abb03d4c5c1d639dd807a58972c0d21f47cff798cc',
+        graduationDate:
+            '5e581a2c4ab96536b5d0918120cae2bb2f92642d4b9df4446890f5c519b2f3ca',
+    };
     const values = {
         degreeName: 'Bachelor of Science and Arts',
         degreeType: 'BachelorDegree',
-        graduationDate: new Date("2023-08-28T00:00:00.000Z"),
+        graduationDate: new Date('2023-08-28T00:00:00.000Z'),
     };
 
     const holder =

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.1.1
+
+### Changed
+
+- Bumped @concordium/common-sdk to 9.1.1. (includes fixes for `verifyWeb3IdCredentialSignature` and `canProveAtomicStatement`)
+
 ## 9.1.0
 
 ### Changed

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "9.1.0",
+    "version": "9.1.1",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",
@@ -60,7 +60,7 @@
         "build-dev": "tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "9.1.0",
+        "@concordium/common-sdk": "9.1.1",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "buffer": "^6.0.3",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.1.1
+
+### Changed
+
+- Bumped @concordium/common-sdk to 9.1.1. (includes fixes for `verifyWeb3IdCredentialSignature` and `canProveAtomicStatement`)
+
 ## 6.1.0
 
 ### Changed

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
@@ -48,7 +48,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "9.1.0",
+        "@concordium/common-sdk": "9.1.1",
         "@concordium/rust-bindings": "1.2.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@9.1.0, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@9.1.1, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
@@ -1377,7 +1377,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 9.1.0
+    "@concordium/common-sdk": 9.1.1
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/grpc-transport": ^2.8.2
@@ -1416,7 +1416,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 9.1.0
+    "@concordium/common-sdk": 9.1.1
     "@concordium/rust-bindings": 1.2.0
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2


### PR DESCRIPTION
## Purpose

Some fixes for web3Id stuff, that were missed.

## Changes

 - `verifyWeb3IdCredentialSignature` now supports dates/timestamp attributes.
 - `canProveAtomicStatement` now supports timestamp attributes, handles undefined attribute value correctly and handles strings correctly for range statements.
 - bump package patch version.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG
