### PR TITLE
Expose replacer and reviver for Web3 ID timestamps

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   `CIS4Contract` class for seemlessly interacting with contracts adhering to the CIS4 standard.
+-   Exposed `replaceDateWithTimeStampAttribute` and `reviveDateFromTimeStampAttribute`.
 
 ## 9.1.1
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -22,7 +22,11 @@ export { CcdAmount } from './types/ccdAmount';
 export { TransactionExpiry } from './types/transactionExpiry';
 export { DataBlob } from './types/DataBlob';
 export { ModuleReference } from './types/moduleReference';
-export { VerifiablePresentation } from './types/VerifiablePresentation';
+export {
+    VerifiablePresentation,
+    reviveDateFromTimeStampAttribute,
+    replaceDateWithTimeStampAttribute,
+} from './types/VerifiablePresentation';
 export * from './credentialDeploymentTransactions';
 export { isAlias, getAlias } from './alias';
 export {


### PR DESCRIPTION
## Purpose
The browser wallet needs access to the replacer and reviver for timestamps to correctly export credentials.

## Changes
- Export the replacer and reviver.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.