### PR TITLE
Validate type values in statements

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   `CIS4Contract` class for seemlessly interacting with contracts adhering to the CIS4 standard.
+-   Validation of type values when verifying statements.
 
 ## 9.1.1
 

--- a/packages/common/src/web3Proofs.ts
+++ b/packages/common/src/web3Proofs.ts
@@ -46,11 +46,24 @@ import {
     isStringAttributeInRange,
 } from './web3IdHelpers';
 
+export const MAX_STRING_BYTE_LENGTH = 31;
+export const MAX_U64 = 2n ** 64n - 1n;
+export const MIN_DATE_ISO = '-262144-01-01T00:00:00Z';
+export const MAX_DATE_ISO = '+262143-12-31T23:59:59.999999999Z';
+export const MIN_DATE_TIMESTAMP = Date.parse(MIN_DATE_ISO);
+export const MAX_DATE_TIMESTAMP = Date.parse(MAX_DATE_ISO);
+
+const TIMESTAMP_VALID_VALUES = MIN_DATE_ISO + 'to ' + MAX_DATE_ISO;
+const STRING_VALID_VALUES =
+    '0 to ' + MAX_STRING_BYTE_LENGTH + ' bytes as UTF-8';
+const INTEGER_VALID_VALUES = '0 to ' + MAX_U64;
+
 const throwRangeError = (
     title: string,
     property: string,
     end: string,
-    mustBe: string
+    mustBe: string,
+    validRange: string
 ) => {
     throw new Error(
         title +
@@ -59,16 +72,25 @@ const throwRangeError = (
             ' property and therefore the ' +
             end +
             ' end of a range statement must be a ' +
-            mustBe
+            mustBe +
+            ' in the range of ' +
+            validRange
     );
 };
-const throwSetError = (title: string, property: string, mustBe: string) => {
+const throwSetError = (
+    title: string,
+    property: string,
+    mustBe: string,
+    validRange: string
+) => {
     throw new Error(
         title +
             ' is a ' +
             property +
-            ' property and therefore the end members of a set statement must be ' +
-            mustBe
+            ' property and therefore the members of a set statement must be ' +
+            mustBe +
+            ' in the range of ' +
+            validRange
     );
 };
 
@@ -78,6 +100,35 @@ function isTimeStampAttribute(properties?: PropertyDetails) {
         properties.type === 'object' &&
         properties.properties.type.const === 'date-time'
     );
+}
+
+function isValidStringAttribute(attributeValue: string): boolean {
+    return (
+        Buffer.from(attributeValue, 'utf-8').length <= MAX_STRING_BYTE_LENGTH
+    );
+}
+
+function isValidIntegerAttribute(attributeValue: bigint) {
+    return attributeValue >= 0 && attributeValue <= MAX_U64;
+}
+
+function isValidTimestampAttribute(attributeValue: Date) {
+    return (
+        attributeValue.getTime() >= MIN_DATE_TIMESTAMP &&
+        attributeValue.getTime() <= MAX_DATE_TIMESTAMP
+    );
+}
+
+function validateTimestampAttribute(value: AttributeType) {
+    return value instanceof Date && isValidTimestampAttribute(value);
+}
+
+function validateStringAttribute(value: AttributeType) {
+    return typeof value === 'string' && isValidStringAttribute(value);
+}
+
+function validateIntegerAttribute(value: AttributeType) {
+    return typeof value === 'bigint' && isValidIntegerAttribute(value);
 }
 
 function verifyRangeStatement(
@@ -95,32 +146,50 @@ function verifyRangeStatement(
         const checkRange = (
             typeName: string,
             validate: (a: AttributeType) => boolean,
-            typeString: string
+            typeString: string,
+            validRange: string
         ) => {
             if (!validate(statement.lower)) {
                 throwRangeError(
                     properties.title,
                     typeName,
                     'lower',
-                    typeString
+                    typeString,
+                    validRange
                 );
             }
             if (!validate(statement.upper)) {
                 throwRangeError(
                     properties.title,
                     typeName,
-                    'lower',
-                    typeString
+                    'upper',
+                    typeString,
+                    validRange
                 );
             }
         };
 
         if (isTimeStampAttribute(properties)) {
-            checkRange('timestamp', (end) => end instanceof Date, 'Date');
+            checkRange(
+                'timestamp',
+                validateTimestampAttribute,
+                'Date',
+                TIMESTAMP_VALID_VALUES
+            );
         } else if (properties.type === 'string') {
-            checkRange('string', (end) => typeof end === 'string', 'string');
+            checkRange(
+                'string',
+                validateStringAttribute,
+                'string',
+                STRING_VALID_VALUES
+            );
         } else if (properties.type === 'integer') {
-            checkRange('integer', (end) => typeof end === 'bigint', 'bigint');
+            checkRange(
+                'integer',
+                validateIntegerAttribute,
+                'bigint',
+                INTEGER_VALID_VALUES
+            );
         }
     }
 
@@ -160,19 +229,40 @@ function verifySetStatement(
         const checkSet = (
             typeName: string,
             validate: (a: AttributeType) => boolean,
-            typeString: string
+            typeString: string,
+            validValues: string
         ) => {
             if (!statement.set.every(validate)) {
-                throwSetError(properties.title, typeName, typeString);
+                throwSetError(
+                    properties.title,
+                    typeName,
+                    typeString,
+                    validValues
+                );
             }
         };
 
         if (isTimeStampAttribute(properties)) {
-            checkSet('date-time', (value) => value instanceof Date, 'Date');
+            checkSet(
+                'date-time',
+                validateTimestampAttribute,
+                'Date',
+                TIMESTAMP_VALID_VALUES
+            );
         } else if (properties.type === 'string') {
-            checkSet('string', (value) => typeof value === 'string', 'string');
+            checkSet(
+                'string',
+                validateStringAttribute,
+                'string',
+                STRING_VALID_VALUES
+            );
         } else if (properties.type === 'integer') {
-            checkSet('integer', (value) => typeof value === 'bigint', 'bigint');
+            checkSet(
+                'integer',
+                validateIntegerAttribute,
+                'bigint',
+                INTEGER_VALID_VALUES
+            );
         }
     }
 }

--- a/packages/common/test/web3Proofs.test.ts
+++ b/packages/common/test/web3Proofs.test.ts
@@ -4,8 +4,13 @@ import {
     createAccountDID,
     createWeb3IdDID,
     getVerifiablePresentation,
+    MAX_DATE_TIMESTAMP,
+    MAX_U64,
+    MIN_DATE_TIMESTAMP,
     RequestStatement,
+    StatementTypes,
     VerifiablePresentation,
+    verifyAtomicStatements,
     Web3StatementBuilder,
 } from '../src';
 import {
@@ -19,6 +24,11 @@ import {
 } from '../src/web3ProofTypes';
 import { TEST_SEED_1 } from './HdWallet.test';
 import fs from 'fs';
+import {
+    GenericMembershipStatement,
+    GenericNonMembershipStatement,
+    GenericRangeStatement,
+} from '../src/commonProofTypes';
 
 test('Generate V2 statement', () => {
     const builder = new Web3StatementBuilder();
@@ -234,6 +244,11 @@ const schemaWithTimeStamp: VerifiableCredentialSubject = {
                     type: 'string',
                     description: 'Degree type',
                 },
+                age: {
+                    title: 'Age',
+                    type: 'integer',
+                    description: 'Age',
+                },
                 degreeName: {
                     title: 'Degree name',
                     type: 'string',
@@ -297,4 +312,345 @@ test('Generate statement with timestamp fails if not timestamp attribute', () =>
             schemaWithTimeStamp
         )
     ).toThrowError('string property');
+});
+
+test('A bigint range statement with an out of bounds lower limit fails', () => {
+    const statement: GenericRangeStatement<string, bigint> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'age',
+        lower: -1n,
+        upper: 10n,
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Age is a integer property and therefore the lower end of a range statement must be a bigint in the range of 0 to 18446744073709551615'
+    );
+});
+
+test('A bigint range statement with an out of bounds upper limit fails', () => {
+    const statement: GenericRangeStatement<string, bigint> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'age',
+        lower: 0n,
+        upper: 18446744073709551616n,
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Age is a integer property and therefore the upper end of a range statement must be a bigint in the range of 0 to 18446744073709551615'
+    );
+});
+
+test('A bigint range statement with valid bounds succeed verification', () => {
+    const statement: GenericRangeStatement<string, bigint> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'age',
+        lower: 0n,
+        upper: 18446744073709551615n,
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A string range statement with an out of bounds lower limit fails', () => {
+    const statement: GenericRangeStatement<string, string> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'degreeType',
+        lower: 'Concordium testing strings web33',
+        upper: 'Concordium testing strings web3',
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Degree Type is a string property and therefore the lower end of a range statement must be a string in the range of 0 to 31 bytes as UTF-8'
+    );
+});
+
+test('A string range statement with an out of bounds upper limit fails', () => {
+    const statement: GenericRangeStatement<string, string> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'degreeType',
+        lower: 'Concordium testing strings web3',
+        upper: 'Concordium testing strings web33',
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Degree Type is a string property and therefore the upper end of a range statement must be a string in the range of 0 to 31 bytes as UTF-8'
+    );
+});
+
+test('A string range statement with valid bounds succeed verification', () => {
+    const statement: GenericRangeStatement<string, string> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'degreeType',
+        lower: 'Concordium testing strings web3',
+        upper: 'Concordium testing strings web3',
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A timestamp range statement with an out of bounds lower limit fails', () => {
+    const statement: GenericRangeStatement<string, Date> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'graduationDate',
+        lower: new Date(MIN_DATE_TIMESTAMP - 1),
+        upper: new Date(MAX_DATE_TIMESTAMP),
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Graduation date is a timestamp property and therefore the lower end of a range statement must be a Date in the range of -262144-01-01T00:00:00Zto +262143-12-31T23:59:59.999999999Z'
+    );
+});
+
+test('A timestamp range statement with an out of bounds upper limit fails', () => {
+    const statement: GenericRangeStatement<string, Date> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'graduationDate',
+        lower: new Date(MIN_DATE_TIMESTAMP),
+        upper: new Date(MAX_DATE_TIMESTAMP + 1),
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Graduation date is a timestamp property and therefore the upper end of a range statement must be a Date in the range of -262144-01-01T00:00:00Zto +262143-12-31T23:59:59.999999999Z'
+    );
+});
+
+test('A timestamp range statement with valid bounds succeed verification', () => {
+    const statement: GenericRangeStatement<string, Date> = {
+        type: StatementTypes.AttributeInRange,
+        attributeTag: 'graduationDate',
+        lower: new Date(MIN_DATE_TIMESTAMP),
+        upper: new Date(MAX_DATE_TIMESTAMP),
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A bigint set statement with an out of bounds item fails', () => {
+    const statement: GenericMembershipStatement<string, bigint> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'age',
+        set: [MAX_U64 + 1n],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Age is a integer property and therefore the members of a set statement must be bigint in the range of 0 to 18446744073709551615'
+    );
+});
+
+test('A bigint set statement with a negative number item fails', () => {
+    const statement: GenericMembershipStatement<string, bigint> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'age',
+        set: [-1n],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Age is a integer property and therefore the members of a set statement must be bigint in the range of 0 to 18446744073709551615'
+    );
+});
+
+test('A bigint set statement with valid items succeeds', () => {
+    const statement: GenericMembershipStatement<string, bigint> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'age',
+        set: [0n, MAX_U64],
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A bigint not in set statement with an out of bounds item fails', () => {
+    const statement: GenericNonMembershipStatement<string, bigint> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'age',
+        set: [MAX_U64 + 1n],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Age is a integer property and therefore the members of a set statement must be bigint in the range of 0 to 18446744073709551615'
+    );
+});
+
+test('A bigint not in set statement with a negative number item fails', () => {
+    const statement: GenericNonMembershipStatement<string, bigint> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'age',
+        set: [-1n],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Age is a integer property and therefore the members of a set statement must be bigint in the range of 0 to 18446744073709551615'
+    );
+});
+
+test('A bigint not in set statement with valid items succeeds', () => {
+    const statement: GenericNonMembershipStatement<string, bigint> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'age',
+        set: [0n, MAX_U64],
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A string set statement with an out of bounds item fails', () => {
+    const statement: GenericMembershipStatement<string, string> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'degreeType',
+        set: ['Concordium testing strings web33'],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Degree Type is a string property and therefore the members of a set statement must be string in the range of 0 to 31 bytes as UTF-8'
+    );
+});
+
+test('A string set statement with valid items succeeds', () => {
+    const statement: GenericMembershipStatement<string, string> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'degreeType',
+        set: ['', 'Concordium testing strings web3'],
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A string not in set statement with an out of bounds item fails', () => {
+    const statement: GenericNonMembershipStatement<string, string> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'degreeType',
+        set: ['Concordium testing strings web33'],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Degree Type is a string property and therefore the members of a set statement must be string in the range of 0 to 31 bytes as UTF-8'
+    );
+});
+
+test('A string not in set statement with valid items succeeds', () => {
+    const statement: GenericNonMembershipStatement<string, string> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'degreeType',
+        set: ['', 'Concordium testing strings web3'],
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A timestamp set statement with an out of bounds item fails', () => {
+    const statement: GenericMembershipStatement<string, Date> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'graduationDate',
+        set: [new Date(MAX_DATE_TIMESTAMP + 1)],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Graduation date is a date-time property and therefore the members of a set statement must be Date in the range of -262144-01-01T00:00:00Zto +262143-12-31T23:59:59.999999999Z'
+    );
+});
+
+test('A timestamp set statement with a lower out of bounds item fails', () => {
+    const statement: GenericMembershipStatement<string, Date> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'graduationDate',
+        set: [new Date(MIN_DATE_TIMESTAMP - 1)],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Graduation date is a date-time property and therefore the members of a set statement must be Date in the range of -262144-01-01T00:00:00Zto +262143-12-31T23:59:59.999999999Z'
+    );
+});
+
+test('A timestamp set statement with valid items succeeds', () => {
+    const statement: GenericMembershipStatement<string, Date> = {
+        type: StatementTypes.AttributeInSet,
+        attributeTag: 'graduationDate',
+        set: [new Date(MIN_DATE_TIMESTAMP), new Date(MAX_DATE_TIMESTAMP)],
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
+});
+
+test('A timestamp not in set statement with an out of bounds item fails', () => {
+    const statement: GenericNonMembershipStatement<string, Date> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'graduationDate',
+        set: [new Date(MAX_DATE_TIMESTAMP + 1)],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Graduation date is a date-time property and therefore the members of a set statement must be Date in the range of -262144-01-01T00:00:00Zto +262143-12-31T23:59:59.999999999Z'
+    );
+});
+
+test('A timestamp not in set statement with a lower out of bounds item fails', () => {
+    const statement: GenericNonMembershipStatement<string, Date> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'graduationDate',
+        set: [new Date(MIN_DATE_TIMESTAMP - 1)],
+    };
+
+    expect(() =>
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toThrowError(
+        'Graduation date is a date-time property and therefore the members of a set statement must be Date in the range of -262144-01-01T00:00:00Zto +262143-12-31T23:59:59.999999999Z'
+    );
+});
+
+test('A timestamp not in set statement with valid items succeeds', () => {
+    const statement: GenericNonMembershipStatement<string, Date> = {
+        type: StatementTypes.AttributeNotInSet,
+        attributeTag: 'graduationDate',
+        set: [new Date(MIN_DATE_TIMESTAMP), new Date(MAX_DATE_TIMESTAMP)],
+    };
+
+    expect(
+        verifyAtomicStatements([statement], schemaWithTimeStamp)
+    ).toBeTruthy();
 });


### PR DESCRIPTION
## Purpose
Validate that the values in statements are within the bounds for each type (string, integer, timestamp).

## Changes
- Added validation when verifying atomic statements.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.