### PR TITLE
Refactor schema types to match browser wallet

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `CIS4Contract` class for seemlessly interacting with contracts adhering to the CIS4 standard.
 
+### Fixed
+
+-   Aligned credential schema types with the tested types in the browser wallet.
+
 ## 9.1.1
 
 ### Fixes

--- a/packages/common/src/web3ProofTypes.ts
+++ b/packages/common/src/web3ProofTypes.ts
@@ -39,7 +39,7 @@ export type Web3IdProofInput = {
     commitmentInputs: CommitmentInput[];
 };
 
-export type TimestampPropertyDetails = {
+export type TimestampProperty = {
     title: string;
     type: 'object';
     properties: {
@@ -49,42 +49,46 @@ export type TimestampPropertyDetails = {
         };
         timestamp: {
             type: 'string';
+            format?: 'date-time';
         };
     };
+    required: ['type', 'timestamp'];
     description?: string;
 };
 
-export type SimplePropertyDetails = {
+export type SimpleProperty = {
     title: string;
     description?: string;
     type: 'string' | 'integer';
     format?: string;
 };
 
-export type PropertyDetails = SimplePropertyDetails | TimestampPropertyDetails;
+export type CredentialSchemaProperty = SimpleProperty | TimestampProperty;
 
-type IndexDetails = {
+type IdDetails = {
     title: string;
     description?: string;
     type: 'string';
 };
 
-export type VerifiableCredentialSubject = {
+type CredentialSchemaAttributes = {
+    title?: string;
+    description?: string;
+    type: 'object';
+    properties: Record<string, CredentialSchemaProperty | TimestampProperty>;
+    required: string[];
+};
+
+export type CredentialSchemaSubject = {
     type: 'object';
     properties: {
-        id: IndexDetails;
-        attributes: {
-            title?: string;
-            description?: string;
-            type: 'object';
-            properties: Record<string, PropertyDetails>;
-            required?: string[];
-        };
+        id: IdDetails;
+        attributes: CredentialSchemaAttributes;
     };
     required: string[];
 };
 
-export const IDENTITY_SUBJECT_SCHEMA: VerifiableCredentialSubject = {
+export const IDENTITY_SUBJECT_SCHEMA: CredentialSchemaSubject = {
     type: 'object',
     properties: {
         id: {
@@ -96,58 +100,59 @@ export const IDENTITY_SUBJECT_SCHEMA: VerifiableCredentialSubject = {
             type: 'object',
             properties: {
                 firstName: {
-                    title: 'first name',
+                    title: 'First name',
                     type: 'string',
                 },
                 lastName: {
-                    title: 'last name',
+                    title: 'Last name',
                     type: 'string',
                 },
                 sex: {
-                    title: 'sex',
+                    title: 'Sex',
                     type: 'string',
                 },
                 dob: {
-                    title: 'date of birth',
+                    title: 'Date of birth',
                     type: 'string',
                 },
                 countryOfResidence: {
-                    title: 'last name',
+                    title: 'Country of residence',
                     type: 'string',
                 },
                 nationality: {
-                    title: 'last name',
+                    title: 'Nationality',
                     type: 'string',
                 },
                 idDocType: {
-                    title: 'last name',
+                    title: 'ID Document Type',
                     type: 'string',
                 },
                 idDocNo: {
-                    title: 'last name',
+                    title: 'ID Document Number',
                     type: 'string',
                 },
                 idDocIssuer: {
-                    title: 'last name',
+                    title: 'ID Document Issuer',
                     type: 'string',
                 },
                 idDocIssuedAt: {
-                    title: 'last name',
+                    title: 'ID Document Issued At',
                     type: 'string',
                 },
                 idDocExpiresAt: {
-                    title: 'last name',
+                    title: 'ID Document Expires At',
                     type: 'string',
                 },
                 nationalIdNo: {
-                    title: 'last name',
+                    title: 'National ID Number',
                     type: 'string',
                 },
                 taxIdNo: {
-                    title: 'last name',
+                    title: 'Tax ID Number',
                     type: 'string',
                 },
             },
+            required: [],
         },
     },
     required: [],

--- a/packages/common/src/web3Proofs.ts
+++ b/packages/common/src/web3Proofs.ts
@@ -15,11 +15,11 @@ import {
     CredentialStatements,
     MembershipStatementV2,
     NonMembershipStatementV2,
-    PropertyDetails,
+    CredentialSchemaProperty,
     RangeStatementV2,
     StatementProverQualifier,
     VerifiableCredentialQualifier,
-    VerifiableCredentialSubject,
+    CredentialSchemaSubject,
     Web3IdProofInput,
     AccountCommitmentInput,
     Web3IssuerCommitmentInput,
@@ -72,7 +72,7 @@ const throwSetError = (title: string, property: string, mustBe: string) => {
     );
 };
 
-function isTimeStampAttribute(properties?: PropertyDetails) {
+function isTimeStampAttribute(properties?: CredentialSchemaProperty) {
     return (
         properties &&
         properties.type === 'object' &&
@@ -82,7 +82,7 @@ function isTimeStampAttribute(properties?: PropertyDetails) {
 
 function verifyRangeStatement(
     statement: RangeStatementV2,
-    properties?: PropertyDetails
+    properties?: CredentialSchemaProperty
 ) {
     if (statement.lower === undefined) {
         throw new Error('Range statements must contain a lower field');
@@ -143,7 +143,7 @@ function verifyRangeStatement(
 function verifySetStatement(
     statement: MembershipStatementV2 | NonMembershipStatementV2,
     statementTypeName: string,
-    properties?: PropertyDetails
+    properties?: CredentialSchemaProperty
 ) {
     if (statement.set === undefined) {
         throw new Error(
@@ -179,7 +179,7 @@ function verifySetStatement(
 
 function verifyAtomicStatement(
     statement: AtomicStatementV2,
-    schema?: VerifiableCredentialSubject
+    schema?: CredentialSchemaSubject
 ) {
     if (statement.type === undefined) {
         throw new Error('Statements must contain a type field');
@@ -224,7 +224,7 @@ function verifyAtomicStatement(
 function verifyAtomicStatementInContext(
     statement: AtomicStatementV2,
     existingStatements: AtomicStatementV2[],
-    schema?: VerifiableCredentialSubject
+    schema?: CredentialSchemaSubject
 ) {
     verifyAtomicStatement(statement, schema);
     if (
@@ -242,7 +242,7 @@ function verifyAtomicStatementInContext(
  */
 export function verifyAtomicStatements(
     statements: AtomicStatementV2[],
-    schema?: VerifiableCredentialSubject
+    schema?: CredentialSchemaSubject
 ): boolean {
     if (statements.length === 0) {
         throw new Error('Empty statements are not allowed');
@@ -275,9 +275,9 @@ function getAccountCredentialQualifier(
 
 export class AtomicStatementBuilder implements InternalBuilder {
     statements: AtomicStatementV2[];
-    schema: VerifiableCredentialSubject | undefined;
+    schema: CredentialSchemaSubject | undefined;
 
-    constructor(schema?: VerifiableCredentialSubject) {
+    constructor(schema?: CredentialSchemaSubject) {
         this.statements = [];
         this.schema = schema;
     }
@@ -462,7 +462,7 @@ export class Web3StatementBuilder {
     private add(
         idQualifier: StatementProverQualifier,
         builderCallback: (builder: InternalBuilder) => void,
-        schema?: VerifiableCredentialSubject
+        schema?: CredentialSchemaSubject
     ): this {
         const builder = new AtomicStatementBuilder(schema);
         builderCallback(builder);
@@ -476,7 +476,7 @@ export class Web3StatementBuilder {
     addForVerifiableCredentials(
         validContractAddresses: ContractAddress[],
         builderCallback: (builder: InternalBuilder) => void,
-        schema?: VerifiableCredentialSubject
+        schema?: CredentialSchemaSubject
     ): this {
         return this.add(
             getWeb3IdCredentialQualifier(validContractAddresses),

--- a/packages/common/test/web3Proofs.test.ts
+++ b/packages/common/test/web3Proofs.test.ts
@@ -15,7 +15,7 @@ import {
 import { expectedStatementMixed } from './resources/expectedStatements';
 import {
     CommitmentInput,
-    VerifiableCredentialSubject,
+    CredentialSchemaSubject,
 } from '../src/web3ProofTypes';
 import { TEST_SEED_1 } from './HdWallet.test';
 import fs from 'fs';
@@ -216,7 +216,7 @@ test('create Web3Id proof with Web3Id Credentials', () => {
     ).toEqual(expected.verifiableCredential[0].credentialSubject.statement);
 });
 
-const schemaWithTimeStamp: VerifiableCredentialSubject = {
+const schemaWithTimeStamp: CredentialSchemaSubject = {
     type: 'object',
     properties: {
         id: {
@@ -251,6 +251,7 @@ const schemaWithTimeStamp: VerifiableCredentialSubject = {
                             type: 'string',
                         },
                     },
+                    required: ['type', 'timestamp'],
                     description: 'Graduation date',
                 },
             },


### PR DESCRIPTION
## Purpose
Aligns the schema typing in the SDK with what is used by the browser wallet. The browser wallet will then use the types directly from the SDK instead of its local versions.

## Changes
- Update the types.
- Fixed titles in the faked identity schema.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.