### PR TITLE
Remove Date from AttributeType and add TimestampAttribute

### DIFF
--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 9.3.0
 
 ### Added
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - `sendRawAccountTransaction` to the gRPC Client.
 
+### Changed
+
+- Stopped using `replaceDateWithTimeStampAttribute` and `reviveDateFromTimeStampAttribute` for serializing and parsing verifiable presentation.
+- AttributeType no longer contains `Date`, but now instead has `TimestampAttribute`. The statement builders have their types extended to keep allowing for both `Date` and `TimestampAttribute`.
+
 ## 9.2.1
 
 ### Fixed

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/common-sdk",
-    "version": "9.2.1",
+    "version": "9.3.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=14.16.0"

--- a/packages/common/src/types/VerifiablePresentation.ts
+++ b/packages/common/src/types/VerifiablePresentation.ts
@@ -93,7 +93,7 @@ export class VerifiablePresentation {
         return JSONBigInt({
             alwaysParseAsBig: true,
             useNativeBigInt: true,
-        }).stringify(this, replaceDateWithTimeStampAttribute);
+        }).stringify(this);
     }
 
     static fromString(json: string): VerifiablePresentation {
@@ -101,7 +101,7 @@ export class VerifiablePresentation {
         const parsed: VerifiablePresentation = JSONBigInt({
             alwaysParseAsBig: true,
             useNativeBigInt: true,
-        }).parse(json, reviveDateFromTimeStampAttribute);
+        }).parse(json);
         return new VerifiablePresentation(
             parsed.presentationContext,
             parsed.proof,

--- a/packages/common/src/web3ProofTypes.ts
+++ b/packages/common/src/web3ProofTypes.ts
@@ -7,7 +7,21 @@ import {
 } from './commonProofTypes';
 import { ContractAddress, CryptographicParameters } from './types';
 
-export type AttributeType = string | bigint | Date;
+export type TimestampAttribute = {
+    type: 'date-time';
+    timestamp: string;
+};
+export type AttributeType = string | bigint | TimestampAttribute;
+export type StatementAttributeType = AttributeType | Date;
+
+export function isTimestampAttribute(
+    attribute: AttributeType
+): attribute is TimestampAttribute {
+    return (
+        (attribute as TimestampAttribute).type === 'date-time' &&
+        typeof (attribute as TimestampAttribute).timestamp === 'string'
+    );
+}
 
 export type AccountCommitmentInput = {
     type: 'account';

--- a/packages/common/test/web3IdHelpers.test.ts
+++ b/packages/common/test/web3IdHelpers.test.ts
@@ -1,6 +1,13 @@
 import {
+    AttributeType,
+    StatementAttributeType,
+    TimestampAttribute,
+    statementAttributeTypeToAttributeType,
+} from '../src';
+import {
     compareStringAttributes,
     isStringAttributeInRange,
+    timestampToDate,
     verifyWeb3IdCredentialSignature,
 } from '../src/web3IdHelpers';
 import fs from 'fs';
@@ -103,10 +110,13 @@ test('verifyWeb3IdCredentialSignature with timestamps', async () => {
         graduationDate:
             '5e581a2c4ab96536b5d0918120cae2bb2f92642d4b9df4446890f5c519b2f3ca',
     };
-    const values = {
+    const values: Record<string, AttributeType> = {
         degreeName: 'Bachelor of Science and Arts',
         degreeType: 'BachelorDegree',
-        graduationDate: new Date('2023-08-28T00:00:00.000Z'),
+        graduationDate: {
+            type: 'date-time',
+            timestamp: '2023-08-28T00:00:00.000Z',
+        },
     };
 
     const holder =
@@ -157,4 +167,31 @@ test('isStringAttributeInRange handles value === upper correctly', () => {
 test('isStringAttributeInRange handles value === lower === upper correctly', () => {
     expect(isStringAttributeInRange('2', '2', '2')).toBeFalsy();
     expect(isStringAttributeInRange('299910', '299910', '299910')).toBeFalsy();
+});
+
+test('mapping statement date attribute to timestamp attribute', () => {
+    const statementAttribute: StatementAttributeType = new Date(0);
+    expect(statementAttributeTypeToAttributeType(statementAttribute)).toEqual({
+        type: 'date-time',
+        timestamp: '1970-01-01T00:00:00.000Z',
+    });
+});
+
+test('mapping timestamp attribute to date', () => {
+    const timestampAttribute: TimestampAttribute = {
+        type: 'date-time',
+        timestamp: '1975-01-01T00:00:00.000Z',
+    };
+
+    expect(timestampToDate(timestampAttribute)).toEqual(new Date(157766400000));
+});
+
+test('mapping statement date attribute to timestamp attribute and back again', () => {
+    const statementAttribute: StatementAttributeType = new Date(50000);
+    const timestampAttribute =
+        statementAttributeTypeToAttributeType(statementAttribute);
+
+    expect(timestampToDate(timestampAttribute as TimestampAttribute)).toEqual(
+        statementAttribute
+    );
 });

--- a/packages/common/test/web3Proofs.test.ts
+++ b/packages/common/test/web3Proofs.test.ts
@@ -3,6 +3,7 @@ import {
     ConcordiumHdWallet,
     createAccountDID,
     createWeb3IdDID,
+    dateToTimestampAttribute,
     getVerifiablePresentation,
     MAX_DATE_TIMESTAMP,
     MAX_U64,
@@ -21,6 +22,7 @@ import { expectedStatementMixed } from './resources/expectedStatements';
 import {
     CommitmentInput,
     CredentialSchemaSubject,
+    TimestampAttribute,
 } from '../src/web3ProofTypes';
 import { TEST_SEED_1 } from './HdWallet.test';
 import fs from 'fs';
@@ -292,8 +294,8 @@ test('Generate statement with timestamp', () => {
     const atomic = statement[0].statement[0];
     expect(atomic.type).toBe('AttributeInRange');
     if (atomic.type === 'AttributeInRange') {
-        expect(atomic.lower).toBe(lower);
-        expect(atomic.upper).toBe(upper);
+        expect(atomic.lower).toEqual(dateToTimestampAttribute(lower));
+        expect(atomic.upper).toEqual(dateToTimestampAttribute(upper));
     }
 });
 
@@ -402,11 +404,11 @@ test('A string range statement with valid bounds succeed verification', () => {
 });
 
 test('A timestamp range statement with an out of bounds lower limit fails', () => {
-    const statement: GenericRangeStatement<string, Date> = {
+    const statement: GenericRangeStatement<string, TimestampAttribute> = {
         type: StatementTypes.AttributeInRange,
         attributeTag: 'graduationDate',
-        lower: new Date(MIN_DATE_TIMESTAMP - 1),
-        upper: new Date(MAX_DATE_TIMESTAMP),
+        lower: dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP - 1)),
+        upper: dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP)),
     };
 
     expect(() =>
@@ -417,11 +419,11 @@ test('A timestamp range statement with an out of bounds lower limit fails', () =
 });
 
 test('A timestamp range statement with an out of bounds upper limit fails', () => {
-    const statement: GenericRangeStatement<string, Date> = {
+    const statement: GenericRangeStatement<string, TimestampAttribute> = {
         type: StatementTypes.AttributeInRange,
         attributeTag: 'graduationDate',
-        lower: new Date(MIN_DATE_TIMESTAMP),
-        upper: new Date(MAX_DATE_TIMESTAMP + 1),
+        lower: dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP)),
+        upper: dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP + 1)),
     };
 
     expect(() =>
@@ -432,11 +434,11 @@ test('A timestamp range statement with an out of bounds upper limit fails', () =
 });
 
 test('A timestamp range statement with valid bounds succeed verification', () => {
-    const statement: GenericRangeStatement<string, Date> = {
+    const statement: GenericRangeStatement<string, TimestampAttribute> = {
         type: StatementTypes.AttributeInRange,
         attributeTag: 'graduationDate',
-        lower: new Date(MIN_DATE_TIMESTAMP),
-        upper: new Date(MAX_DATE_TIMESTAMP),
+        lower: dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP)),
+        upper: dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP)),
     };
 
     expect(
@@ -577,10 +579,10 @@ test('A string not in set statement with valid items succeeds', () => {
 });
 
 test('A timestamp set statement with an out of bounds item fails', () => {
-    const statement: GenericMembershipStatement<string, Date> = {
+    const statement: GenericMembershipStatement<string, TimestampAttribute> = {
         type: StatementTypes.AttributeInSet,
         attributeTag: 'graduationDate',
-        set: [new Date(MAX_DATE_TIMESTAMP + 1)],
+        set: [dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP + 1))],
     };
 
     expect(() =>
@@ -591,10 +593,10 @@ test('A timestamp set statement with an out of bounds item fails', () => {
 });
 
 test('A timestamp set statement with a lower out of bounds item fails', () => {
-    const statement: GenericMembershipStatement<string, Date> = {
+    const statement: GenericMembershipStatement<string, TimestampAttribute> = {
         type: StatementTypes.AttributeInSet,
         attributeTag: 'graduationDate',
-        set: [new Date(MIN_DATE_TIMESTAMP - 1)],
+        set: [dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP - 1))],
     };
 
     expect(() =>
@@ -605,10 +607,13 @@ test('A timestamp set statement with a lower out of bounds item fails', () => {
 });
 
 test('A timestamp set statement with valid items succeeds', () => {
-    const statement: GenericMembershipStatement<string, Date> = {
+    const statement: GenericMembershipStatement<string, TimestampAttribute> = {
         type: StatementTypes.AttributeInSet,
         attributeTag: 'graduationDate',
-        set: [new Date(MIN_DATE_TIMESTAMP), new Date(MAX_DATE_TIMESTAMP)],
+        set: [
+            dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP)),
+            dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP)),
+        ],
     };
 
     expect(
@@ -617,11 +622,12 @@ test('A timestamp set statement with valid items succeeds', () => {
 });
 
 test('A timestamp not in set statement with an out of bounds item fails', () => {
-    const statement: GenericNonMembershipStatement<string, Date> = {
-        type: StatementTypes.AttributeNotInSet,
-        attributeTag: 'graduationDate',
-        set: [new Date(MAX_DATE_TIMESTAMP + 1)],
-    };
+    const statement: GenericNonMembershipStatement<string, TimestampAttribute> =
+        {
+            type: StatementTypes.AttributeNotInSet,
+            attributeTag: 'graduationDate',
+            set: [dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP + 1))],
+        };
 
     expect(() =>
         verifyAtomicStatements([statement], schemaWithTimeStamp)
@@ -631,11 +637,12 @@ test('A timestamp not in set statement with an out of bounds item fails', () => 
 });
 
 test('A timestamp not in set statement with a lower out of bounds item fails', () => {
-    const statement: GenericNonMembershipStatement<string, Date> = {
-        type: StatementTypes.AttributeNotInSet,
-        attributeTag: 'graduationDate',
-        set: [new Date(MIN_DATE_TIMESTAMP - 1)],
-    };
+    const statement: GenericNonMembershipStatement<string, TimestampAttribute> =
+        {
+            type: StatementTypes.AttributeNotInSet,
+            attributeTag: 'graduationDate',
+            set: [dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP - 1))],
+        };
 
     expect(() =>
         verifyAtomicStatements([statement], schemaWithTimeStamp)
@@ -645,11 +652,15 @@ test('A timestamp not in set statement with a lower out of bounds item fails', (
 });
 
 test('A timestamp not in set statement with valid items succeeds', () => {
-    const statement: GenericNonMembershipStatement<string, Date> = {
-        type: StatementTypes.AttributeNotInSet,
-        attributeTag: 'graduationDate',
-        set: [new Date(MIN_DATE_TIMESTAMP), new Date(MAX_DATE_TIMESTAMP)],
-    };
+    const statement: GenericNonMembershipStatement<string, TimestampAttribute> =
+        {
+            type: StatementTypes.AttributeNotInSet,
+            attributeTag: 'graduationDate',
+            set: [
+                dateToTimestampAttribute(new Date(MIN_DATE_TIMESTAMP)),
+                dateToTimestampAttribute(new Date(MAX_DATE_TIMESTAMP)),
+            ],
+        };
 
     expect(
         verifyAtomicStatements([statement], schemaWithTimeStamp)

--- a/packages/nodejs/CHANGELOG.md
+++ b/packages/nodejs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.3.0
+
+- Bumped @concordium/common-sdk to 9.3.0.
+
 ## 9.2.0
 
 - Bumped @concordium/common-sdk to 9.2.0.

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/node-sdk",
-    "version": "9.2.0",
+    "version": "9.3.0",
     "description": "Helpers for interacting with the Concordium node",
     "repository": {
         "type": "git",
@@ -60,7 +60,7 @@
         "build-dev": "tsc"
     },
     "dependencies": {
-        "@concordium/common-sdk": "9.2.0",
+        "@concordium/common-sdk": "9.3.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpc-transport": "^2.8.2",
         "buffer": "^6.0.3",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.0
+
+- Bumped @concordium/common-sdk to 9.3.0.
+
 ## 6.2.1
 
 - Bumped @concordium/common-sdk to 9.2.1.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "6.2.1",
+    "version": "6.3.0",
     "license": "Apache-2.0",
     "browser": "lib/concordium.min.js",
     "types": "lib/index.d.ts",
@@ -48,7 +48,7 @@
         "webpack-cli": "^4.9.2"
     },
     "dependencies": {
-        "@concordium/common-sdk": "9.2.1",
+        "@concordium/common-sdk": "9.3.0",
         "@concordium/rust-bindings": "1.2.0",
         "@grpc/grpc-js": "^1.3.4",
         "@protobuf-ts/grpcweb-transport": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,7 +1312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/common-sdk@9.2.1, @concordium/common-sdk@workspace:packages/common":
+"@concordium/common-sdk@9.3.0, @concordium/common-sdk@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@concordium/common-sdk@workspace:packages/common"
   dependencies:
@@ -1352,27 +1352,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@concordium/common-sdk@npm:9.2.0":
-  version: 9.2.0
-  resolution: "@concordium/common-sdk@npm:9.2.0"
-  dependencies:
-    "@concordium/rust-bindings": 1.2.0
-    "@grpc/grpc-js": ^1.3.4
-    "@noble/ed25519": ^1.7.1
-    "@protobuf-ts/runtime-rpc": ^2.8.2
-    "@scure/bip39": ^1.1.0
-    big.js: ^6.2.0
-    bs58check: ^2.1.2
-    buffer: ^6.0.3
-    cross-fetch: 3.1.5
-    hash.js: ^1.1.7
-    iso-3166-1: ^2.1.1
-    json-bigint: ^1.0.0
-    uuid: ^8.3.2
-  checksum: 780f75408d98ba9285e8e889c0ba0e9fef1d8dec3e25437c27d9e99ca010430b16dce2040c4fee49781c5e6d05734b7139dfb62decf55af5cf9fac372c91276f
-  languageName: node
-  linkType: hard
-
 "@concordium/examples@workspace:examples":
   version: 0.0.0-use.local
   resolution: "@concordium/examples@workspace:examples"
@@ -1399,7 +1378,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/node-sdk@workspace:packages/nodejs"
   dependencies:
-    "@concordium/common-sdk": 9.2.0
+    "@concordium/common-sdk": 9.3.0
     "@grpc/grpc-js": ^1.3.4
     "@noble/ed25519": ^1.7.1
     "@protobuf-ts/grpc-transport": ^2.8.2
@@ -1438,7 +1417,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@concordium/web-sdk@workspace:packages/web"
   dependencies:
-    "@concordium/common-sdk": 9.2.1
+    "@concordium/common-sdk": 9.3.0
     "@concordium/rust-bindings": 1.2.0
     "@grpc/grpc-js": ^1.3.4
     "@protobuf-ts/grpcweb-transport": ^2.8.2


### PR DESCRIPTION
## Purpose
Align `AttributeType` with schema types for timestamps.

## Changes
- Removed `Date` from `AttributeType`.
- Statement builders are extended so that both `TimestampAttribute` and `Date` can be used.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.