### PR TITLE
Remove dependency on Buffer being used externally

### DIFF
--- a/examples/common/deployModule.ts
+++ b/examples/common/deployModule.ts
@@ -13,7 +13,6 @@ import {
 } from '@concordium/node-sdk';
 import { credentials } from '@grpc/grpc-js';
 import { readFileSync } from 'node:fs';
-import { Buffer } from 'buffer/index.js';
 import { parseEndpoint } from '../shared/util.js';
 
 import meow from 'meow';

--- a/examples/common/simpleTransfer.ts
+++ b/examples/common/simpleTransfer.ts
@@ -15,7 +15,6 @@ import {
 } from '@concordium/node-sdk';
 import { credentials } from '@grpc/grpc-js';
 import { readFileSync } from 'node:fs';
-import { Buffer } from 'buffer/index.js';
 import { parseEndpoint } from '../shared/util.js';
 
 import meow from 'meow';

--- a/examples/composed-examples/initAndUpdateContract.ts
+++ b/examples/composed-examples/initAndUpdateContract.ts
@@ -21,7 +21,6 @@ import {
 } from '@concordium/node-sdk';
 import { credentials } from '@grpc/grpc-js';
 import { readFileSync } from 'node:fs';
-import { Buffer } from 'buffer/index.js';
 import { parseEndpoint } from '../shared/util.js';
 
 import meow from 'meow';

--- a/packages/common/src/signHelpers.ts
+++ b/packages/common/src/signHelpers.ts
@@ -35,7 +35,7 @@ export interface AccountSigner {
 /**
  * Gets Ed25519 signature for `digest`.
  *
- * @param {Buffer} digest - the message to sign.
+ * @param {ArrayBuffer} digest - the message to sign.
  * @param {HexString} privateKey - the ed25519 private key in HEX format.
  *
  * @returns {Buffer} the signature.

--- a/packages/common/src/types/DataBlob.ts
+++ b/packages/common/src/types/DataBlob.ts
@@ -8,11 +8,11 @@ import { packBufferWithWord16Length } from '../serializationHelpers.js';
 export class DataBlob {
     data: Buffer;
 
-    constructor(data: Buffer) {
-        if (data.length > 256) {
+    constructor(data: ArrayBuffer) {
+        if (data.byteLength > 256) {
             throw new Error("A data blob's size cannot exceed 256 bytes");
         }
-        this.data = data;
+        this.data = Buffer.from(data);
     }
 
     toJSON(): string {

--- a/packages/common/src/uleb128.ts
+++ b/packages/common/src/uleb128.ts
@@ -23,7 +23,7 @@ export const uleb128Decode = (buffer: Uint8Array): bigint => {
  * Decodes an unsigned leb128 encoded value to bigint and returns it along
  * with the index of the end of the encoded uleb128 number + 1.
  *
- * @param {Buffer} bytes - The buffer to decode
+ * @param {UInt8Array} bytes - The buffer to decode
  * @param {number} index - A non-negative index to decode at, defaults to 0
  *
  * @returns {[bigint, number]} the decoded bigint value and the index of

--- a/packages/common/src/wasm/deserialization.ts
+++ b/packages/common/src/wasm/deserialization.ts
@@ -1,5 +1,4 @@
 import * as wasm from '@concordium/rust-bindings/wallet';
-import { Buffer } from 'buffer/index.js';
 import {
     deserializeAccountTransaction,
     deserializeUint8,
@@ -50,7 +49,7 @@ export type BlockItem =
  * @returns An object specifiying the blockItemKind that the transaction has. The object also contains the actual transaction under the transaction field.
  **/
 export function deserializeTransaction(
-    serializedTransaction: Buffer
+    serializedTransaction: ArrayBuffer
 ): BlockItem {
     const cursor = Cursor.fromBuffer(serializedTransaction);
 

--- a/packages/common/test/HdWallet.test.ts
+++ b/packages/common/test/HdWallet.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/index.js';
 import { ConcordiumHdWallet } from '../src/wasm/HdWallet.js';
 export const TEST_SEED_1 =
     'efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860';

--- a/packages/common/test/alias.test.ts
+++ b/packages/common/test/alias.test.ts
@@ -1,5 +1,4 @@
 import * as AccountAddress from '../src/types/AccountAddress.js';
-import { Buffer } from 'buffer/index.js';
 
 test('isAlias is reflexive', () => {
     const address = AccountAddress.fromBuffer(

--- a/packages/common/test/deserialization.test.ts
+++ b/packages/common/test/deserialization.test.ts
@@ -1,5 +1,4 @@
 import { deserializeTransaction } from '../src/wasm/deserialization.js';
-import { Buffer } from 'buffer/index.js';
 import { serializeAccountTransactionForSubmission } from '../src/serialization.js';
 import {
     AccountAddress,

--- a/packages/common/test/module-schema.test.ts
+++ b/packages/common/test/module-schema.test.ts
@@ -4,7 +4,6 @@ import {
     getEmbeddedModuleSchema,
     versionedModuleSourceFromBuffer,
 } from '../src/types/VersionedModuleSource.js';
-import { Buffer } from 'buffer/index.js';
 
 // Directory with smart contract modules and schemas for testing.
 const testFileDir = path.resolve(

--- a/packages/common/test/schema.test.ts
+++ b/packages/common/test/schema.test.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import { Buffer } from 'buffer/index.js';
 import {
     displayTypeSchemaTemplate,
     getUpdateContractParameterSchema,

--- a/packages/common/test/uleb128.test.ts
+++ b/packages/common/test/uleb128.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/index.js';
 import {
     uleb128Decode,
     uleb128DecodeWithIndex,

--- a/packages/common/test/util.test.ts
+++ b/packages/common/test/util.test.ts
@@ -4,7 +4,6 @@ import {
     wasmToSchema,
 } from '../src/util.js';
 import { readFileSync } from 'fs';
-import { Buffer } from 'buffer/index.js';
 
 test('intToStringTransformer transform chosen field, but not others', () => {
     const keysToTransform = ['a'];

--- a/packages/nodejs/src/client.ts
+++ b/packages/nodejs/src/client.ts
@@ -1,5 +1,4 @@
 import { ChannelCredentials } from '@grpc/grpc-js';
-import { Buffer as BufferFormater } from 'buffer/index.js';
 import { P2PClient } from './grpc-api/concordium_p2p_rpc.client.js';
 import {
     AccountAddress,
@@ -652,7 +651,7 @@ export default class ConcordiumNodeClient {
                     return {
                         version: 0,
                         ...common,
-                        model: BufferFormater.from(result.model, 'hex'),
+                        model: Buffer.from(result.model, 'hex'),
                     };
                 default:
                     throw new Error(

--- a/packages/nodejs/src/pub/types.ts
+++ b/packages/nodejs/src/pub/types.ts
@@ -1,12 +1,5 @@
-import { Buffer } from 'buffer/index.js';
-
 export { decryptMobileWalletExport, EncryptedData } from '../wallet/crypto.js';
 export { MobileWalletExport } from '../wallet/types.js';
 export { getModuleBuffer } from '../util.js';
-export { Buffer }; // TODO: remove this export as it doesn't make much sense to provide a Buffer polyfill  for nodejs
 
 export * from '@concordium/common-sdk/types';
-
-export function toBuffer(s: string, encoding?: string): Buffer {
-    return Buffer.from(s, encoding);
-}

--- a/packages/nodejs/src/util.ts
+++ b/packages/nodejs/src/util.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import { Buffer } from 'buffer/index.js';
 
 /**
  * @deprecated This is a helper function for the v1 gRPC client, which has been deprecated

--- a/packages/nodejs/test/CIS2Contract.test.ts
+++ b/packages/nodejs/test/CIS2Contract.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/index.js';
 import {
     AccountTransactionType,
     ContractAddress,

--- a/packages/nodejs/test/CIS4Contract.test.ts
+++ b/packages/nodejs/test/CIS4Contract.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer/index.js';
 import { ContractAddress } from '@concordium/common-sdk';
 import { serializeTypeValue } from '@concordium/common-sdk/schema';
 import { CIS4, CIS4Contract, Web3IdSigner } from '@concordium/common-sdk/cis4';

--- a/packages/nodejs/test/clientV2.test.ts
+++ b/packages/nodejs/test/clientV2.test.ts
@@ -21,7 +21,6 @@ import {
 } from './testHelpers.js';
 import * as ed from '@noble/ed25519';
 import * as expected from './resources/expectedJsons.js';
-import { Buffer } from 'buffer/index.js';
 
 import { TextEncoder, TextDecoder } from 'util';
 import {

--- a/packages/nodejs/test/credentialDeployment.test.ts
+++ b/packages/nodejs/test/credentialDeployment.test.ts
@@ -11,7 +11,6 @@ import {
 } from '@concordium/common-sdk';
 import fs from 'fs';
 import * as ed from '@noble/ed25519';
-import { Buffer } from 'buffer/index.js';
 import {
     deserializeTransaction,
     serializeCredentialDeploymentTransactionForSubmission,
@@ -60,7 +59,7 @@ test('test deserialize credentialDeployment ', async () => {
             revealedAttributes,
             expiry
         );
-    const hashToSign: Buffer = getCredentialDeploymentSignDigest(
+    const hashToSign = getCredentialDeploymentSignDigest(
         credentialDeploymentTransaction
     );
 

--- a/packages/nodejs/test/deserialization.test.ts
+++ b/packages/nodejs/test/deserialization.test.ts
@@ -1,6 +1,5 @@
 import { getNodeClient } from './testHelpers.js';
 import { isInstanceInfoV0 } from '@concordium/common-sdk';
-import { Buffer } from 'buffer/index.js';
 import * as fs from 'fs';
 import { deserializeContractState } from '@concordium/common-sdk/schema';
 


### PR DESCRIPTION
## Purpose

Ensure `Buffer` is not required as an external dependency. Also removes all imports of `buffer/index.js` in node-sdk.

Partially implements #250.
