### PR TITLE
Use ModuleReference in GetModuleList

### DIFF
--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -671,7 +671,7 @@ export class ConcordiumGRPCClient {
      *
      * @param blockHash an optional block hash to get the accounts at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
-     * @returns an async iterable of account addresses represented as Base58 encoded strings.
+     * @returns an async iterable of account addresses.
      */
     getAccountList(
         blockHash?: BlockHash.Type,
@@ -692,16 +692,16 @@ export class ConcordiumGRPCClient {
      *
      * @param blockHash an optional block hash to get the contract modules at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
-     * @returns an async iterable of contract module references, represented as hex strings.
+     * @returns an async iterable of contract module references.
      */
     getModuleList(
         blockHash?: BlockHash.Type,
         abortSignal?: AbortSignal
-    ): AsyncIterable<HexString> {
+    ): AsyncIterable<ModuleReference.Type> {
         const opts = { abort: abortSignal };
         const hash = getBlockHashInput(blockHash);
         const asyncIter = this.client.getModuleList(hash, opts).responses;
-        return mapStream(asyncIter, translate.unwrapValToHex);
+        return mapStream(asyncIter, ModuleReference.fromProto);
     }
 
     /**
@@ -714,7 +714,7 @@ export class ConcordiumGRPCClient {
      * @param maxAmountOfAncestors the maximum amount of ancestors as a bigint.
      * @param blockHash a optional block hash to get the ancestors at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
-     * @returns an async iterable of ancestors' block hashes as hex strings.
+     * @returns an async iterable of ancestors' block hashes.
      */
     getAncestors(
         maxAmountOfAncestors: bigint,

--- a/packages/sdk/test/client/resources/expectedJsons.ts
+++ b/packages/sdk/test/client/resources/expectedJsons.ts
@@ -308,11 +308,11 @@ export const accountList: AccountAddress.Type[] = [
     '4EJJ1hVhbVZT2sR9xPzWUwFcJWK3fPX54z94zskTozFVk8Xd4L',
 ].map(AccountAddress.fromBase58);
 
-export const moduleList = [
+export const moduleList: ModuleReference.Type[] = [
     '67d568433bd72e4326241f262213d77f446db8ba03dfba351ae35c1b2e7e5109',
     '6f0524700ed808a8fe0d7e23014c5138e4fac1fd8ec85c5e3591096f48609206',
     'ceb018e4cd3456c0ccc0bca14285a69fd55f4cb09c322195d49c5c22f85930fe',
-];
+].map(ModuleReference.fromHexString);
 
 export const ancestorList: BlockHash.Type[] = [
     'fe88ff35454079c3df11d8ae13d5777babd61f28be58494efe51b6593e30716e',


### PR DESCRIPTION
## Purpose

Fix left over hex string by using `ModuleReference` in `GetModuleList`.

