### PR TITLE
Add Documentation for ccd-js-gen package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Wrappers for interacting with the Concordium node.
   - [Packages](#packages)
     - [SDK package](#sdk-package)
     - [Rust-bindings package](#rust-bindings-package)
+    - [Ccd-js-gen package](#ccd-js-gen-package)
   - [Install/updating dependencies](#installupdating-dependencies)
     - [MacOS arm64](#macos-arm64)
   - [Build](#build)
@@ -43,6 +44,11 @@ both a web and NodeJS environment.
 The [rust-bindings](./packages/rust-bindings) contains bindings for Rust code,
 which is used by the SDK through WASM. This package is a utility package that
 should not be used directly, only through the usage of the SDK.
+
+### Ccd-js-gen package
+
+The [ccd-js-gen](./packages/ccd-js-gen) contains a library and CLI for
+generating smart contract clients for TypeScript and JavaScript.
 
 ## Install/updating dependencies
 

--- a/packages/ccd-js-gen/README.md
+++ b/packages/ccd-js-gen/README.md
@@ -1,0 +1,484 @@
+# Smart Contract Client Generator <!-- omit in toc -->
+
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](https://github.com/Concordium/.github/blob/main/.github/CODE_OF_CONDUCT.md)
+
+Generate TypeScript/JavaScript code for interating with smart contracts and modules on the Concordium blockchain.
+
+- Functions for dry-running and calling entrypoints of the smart contract.
+- Functions for constructing parameters.
+- Parsing logged events, return values and error messages.
+- Structured types for parameter, logged events, return values and error messages.
+
+The code is generated from deployable smart contract modules, meaning it can be done with any smart contract available locally and any smart contract deployed on chain.
+
+### Example usage of a generated client
+
+```typescript
+import * as SDK from "@concordium/node-sdk"; // or use @concordium/web-sdk.
+import * as MyContract from "./generated/my-contract.js"; // Code generated from a smart contract module.
+
+const grpcClient = // Setup gRPC client code here ...
+const contractAddress = SDK.ContractAddress.create(42) // Address of the smart contract.
+const signer = // Keys for signing an account transaction.
+const sender = // AccountAddress
+
+// Create a client for 'my-contract' smart contract.
+const contractClient = await MyContract.create(
+    grpcClient,
+    contractAddress
+);
+
+// Construct the parameter for the 'transfer' entrypoint.
+const receiver = AccountAddress.fromBase58('4UC8o4m8AgTxt5VBFMdLwMCwwJQVJwjesNzW7RPXkACynrULmd');
+const parameter: MyContract.TransferParameter = [{
+    tokenId: "",
+    amount: 10,
+    from: { type: 'Account', content: sender },
+    to: { type: 'Account', content: receiver },
+    data: "",
+}];
+
+// Send transaction for invoking the 'transfer' entrypoint of the smart contract.
+const transactionHash = await MyContract.sendTransfer(contractClient, {
+    senderAddress: sender,
+    energy: Energy.create(12000)
+}, parameter, signer);
+```
+
+<!--toc:start-->
+- [Install the package](#install-the-package)
+- [Using the CLI](#using-the-cli)
+  - [Example](#example)
+- [Using the library](#using-the-library)
+  - [Generate from smart contract module file](#generate-from-smart-contract-module-file)
+  - [Generate from smart contract module on chain](#generate-from-smart-contract-module-on-chain)
+- [Using the generated client](#using-the-generated-client)
+  - [Generated module client](#generated-module-client)
+    - [The client type](#the-client-type)
+    - [function `create`](#function-create)
+    - [function `createUnchecked`](#function-createunchecked)
+    - [const `moduleReference`](#const-modulereference)
+    - [function `getModuleSource`](#function-getmodulesource)
+    - [type `<ContractName>Parameter`](#type-contractnameparameter)
+    - [function `instantiate<ContractName>`](#function-instantiatecontractname)
+  - [Generated contract client](#generated-contract-client)
+    - [The contract client type](#the-contract-client-type)
+    - [function `create`](#function-create-1)
+    - [function `createUnchecked`](#function-createunchecked-1)
+    - [const `moduleReference`](#const-modulereference-1)
+    - [type `Event`](#type-event)
+    - [function `parseEvent`](#function-parseevent)
+    - [type `<EntrypointName>Parameter`](#type-entrypointnameparameter)
+    - [function `send<EntrypointName>`](#function-sendentrypointname)
+    - [function `dryRun<EntrypointName>`](#function-dryrunentrypointname)
+    - [type `ReturnValue<EntrypointName>`](#type-returnvalueentrypointname)
+    - [function `parseReturnValue<EntrypointName>`](#function-parsereturnvalueentrypointname)
+    - [type `ErrorMessage<EntrypointName>`](#type-errormessageentrypointname)
+    - [function `parseErrorMessage<EntrypointName>`](#function-parseerrormessageentrypointname)
+<!--toc:end-->
+
+## Install the package
+
+Install the package, saving it to `devDependencies`:
+
+**npm**
+```
+npm install --save-dev @concordium/ccd-js-gen
+```
+
+**yarn**
+```
+yarn add --dev @concordium/ccd-js-gen
+```
+
+**pnpm**
+```
+pnpm install --save-dev @concordium/ccd-js-gen
+```
+
+> The package can also be used directly using `npx`, without first adding it as a dependency,
+however it is recommended to add it in `package.json` to keep track the exact version used when
+generating the code, as different version might produce different code.
+
+## Using the CLI
+
+This package provides the `ccd-js-gen` command, which can be used from the commandline.
+
+**Options**:
+
+- `-m, --module <path>` Path to the smart contract module.
+- `-o, --out-dir <path>` Directory to use for the generated code.
+
+### Example
+
+To generate smart contract clients into a directory `generated` from the smart contract
+module `./my-contract.wasm.v1`:
+
+```
+ccd-js-gen --module ./my-contract.wasm.v1 --out-dir ./generated
+```
+
+> For a dapp project, it is recommended to have this as part of a script in `package.json`.
+
+## Using the library
+
+This package can be used programmatically as well.
+
+```typescript
+import * as ccdJsGen from "@concordium/ccd-js-gen"
+```
+
+### Generate from smart contract module file
+
+To generate smart contract clients for a smart contract module file,
+either downloaded from the blockchain or build from the smart contract source code:
+
+```typescript
+import * as ccdJsGen from "@concordium/ccd-js-gen"
+
+const moduleFilePath = "./my-contract.wasm.v1"; // Path to smart contract module.
+const outDirPath = "./generated"; // The directory to use for the generated files.
+
+// Read the module and generate the smart contract clients.
+console.log('Generating smart contract module clients.')
+await ccdJsGen.generateContractClientsFromFile(moduleFilePath, outDirPath);
+console.log('Code generation was successful.')
+```
+
+### Generate from smart contract module on chain
+
+To generate smart contract clients for a smart contract module on chain, you need access to the gRPC of a Concordium node.
+Use `@concordium/web-sdk` to download the smart contract module and use it to generate the clients.
+
+```typescript
+import * as ccdJsGen from "@concordium/ccd-js-gen"
+import * as SDK from "@concordium/web-sdk"
+
+const moduleFilePath = "./my-contract.wasm.v1"; // Path to smart contract module.
+const outDirPath = "./generated"; // The directory to use for the generated files.
+const outputModuleName = "wCCD-module"; // The name to give the output smart contract module.
+
+const grpcClient = ...; // A Concordium gRPC client from @concordium/web-sdk.
+const moduleRef = SDK.ModuleReference.fromHexString('<hex of module referecene>');
+
+// Fetch the smart contract module source from chain.
+const moduleSource = await grpcClient.getModuleSource(moduleRef);
+
+// Generate the smart contract clients from module source.
+console.info('Generating smart contract module clients.');
+await ccdJsGen.generateContractClients(moduleSource, outputModuleName, outDirPath);
+console.info('Code generation was successful.');
+```
+
+## Using the generated client
+
+The generator produces a file with functions for interacting with the smart contract module and files for each smart contract in the smart contract module used.
+
+For example: generating clients for a smart contract module `my-module` containing
+the smart contracts `my-contract-a` and `my-contract-b`.
+into the directory `./generated` produces the following structure:
+
+```
+generated/
+├─ my-module.js        // Functions for interacting with the 'my-module' smart contract module on chain.
+├─ my-contract-a.js    // Functions for interacting with the 'my-contract-a' smart contract.
+└─ my-contract-b.js    // Functions for interacting with the 'my-contract-b' smart contract.
+```
+
+> There might also be type declarations (`<file>.d.ts`) for TypeScript, depending on the provided options.
+
+### Generated module client
+
+A file is produced with a client for interacting with the smart contract module.
+This provides functions for instantiating smart contract instances.
+
+An example of importing a smart contract module generated from a `my-module.wasm.v1` file:
+
+```typescript
+import * as MyModule from "./generated/my-module.js";
+```
+
+#### The client type
+
+The type representing the client for the smart contract module is accessable using `MyModule.Type`.
+
+#### function `create`
+
+Construct a module client for interacting with a smart contract module on chain.
+This function ensures the smart contract module is deployed on chain and throws an error otherwise.
+
+**Parameter:** The function takes a gRPC client from '@concordium/web-sdk'.
+
+```typescript
+const grpcClient = ...; // Concordium gRPC client from '@concordium/web-sdk'.
+const myModule: MyModule.Type = await MyModule.create(grpcClient);
+```
+
+#### function `createUnchecked`
+
+Construct a module client for interacting with a smart contract module on chain.
+This function _skips_ the check of the smart contract module being deployed on chain and leaves it up to the caller to ensure this.
+
+**Parameter:** The function takes a gRPC client from '@concordium/web-sdk'.
+
+```typescript
+const grpcClient = ...; // Concordium gRPC client from '@concordium/web-sdk'.
+const myModule: MyModule.Type = MyModule.createUnchecked(grpcClient);
+```
+
+> To run the checks manually use `await MyModule.checkOnChain(myModule);`.
+
+#### const `moduleReference`
+
+Variable with the reference of the smart contract module.
+
+```typescript
+const ref = MyModule.moduleReference;
+```
+
+#### function `getModuleSource`
+
+Get the module source of the deployed smart contract module from chain.
+
+```typescript
+const myModule: MyModule.Type = ...; // Generated module client
+const moduleSource = await MyModule.getModuleSource(myModule);
+```
+
+#### type `<ContractName>Parameter`
+
+Type representing the parameter for when instantiating a smart contract. The type is name `<ContractName>Parameter` where `<ContractName>` is the smart contract name in Pascal case.
+
+_This is only generated when the schema contains init-function parameter type._
+
+#### function `instantiate<ContractName>`
+
+For each smart contract in module a function for instantiating new instance is produced.
+These are named `instantiate<ContractName>` where `<ContractName>` is the smart contract name in Pascal case.
+
+An example for a smart contract module containing a smart contract named `my-contract`, the function becomes `instantiateMyContract`.
+
+**Parameters**
+
+The function parameters are:
+
+- `moduleClient` The client of the on-chain smart contract module.
+- `transactionMetadata` Metadata related to constructing the transaction, such as energy and CCD amount to include.
+- `parameter` Parameter to provide the smart contract module for the instantiation.
+
+  _With schema type:_ If the schema contains type information for the parameter, a type for the parameter is generated and used for this function. The type is name `<ContractName>Parameter` where `<ContractName>` is the smart contract name in Pascal case.
+
+  _Without schema type:_ If no schema information is present, the function uses the generic `Parameter` from `@concordium/web-sdk`.
+
+- `signer` The keys of to use for signing the transaction.
+
+**Returns**: Promise with the hash of the transaction.
+
+```typescript
+const myModule: MyModule.Type = ...; // Generated module client.
+const transactionMeta = { ... }; // Transaction meta information.
+const parameter = ...; // Parameter to pass the smart contract init-function.
+const signer = ...; // The keys to use for signing the transaction.
+const transactionHash = await MyModule.instantiateMyContract(myModule, transactionMeta, parameter, signer);
+```
+
+### Generated contract client
+
+For each of the smart contracts in the module a file is produced named after the smart contract.
+Each file contains functions for interacting with an instance of this smart contract.
+
+An example of importing a smart contract contract client generated from a module containing a smart contract named `my-contract`:
+
+```typescript
+import * as MyContract from "./generated/my-contract.js";
+```
+
+#### The contract client type
+
+The type representing the client for the smart contract instance is accessable using `MyContract.Type`.
+
+#### function `create`
+
+Construct a client for interacting with a smart contract instance on chain.
+This function ensures the smart contract instance exists on chain, and that it is using a smart contract module with a matching reference.
+
+**Parameters:**
+
+- `grpcClient` The function takes a gRPC client from `@concordium/web-sdk`.
+- `contractAddress` The contract address of the smart contract instance.
+
+```typescript
+const grpcClient = ...; // Concordium gRPC client from '@concordium/web-sdk'.
+const contractAddress = ContractAddress.create(...) // The address of the contract instance.
+const myContract: MyContract.Type = await MyContract.create(grpcClient, contractAddress);
+```
+
+#### function `createUnchecked`
+
+Construct a client for interacting with a smart contract instance on chain.
+This function _skips_ the check ensuring the smart contract instance exists on chain, and that it is using a smart contract module with a matching reference, leaving it up to the caller to ensure this.
+
+**Parameters:**
+
+- `grpcClient` The function takes a gRPC client from `@concordium/web-sdk`.
+- `contractAddress` The contract address of the smart contract instance.
+
+```typescript
+const grpcClient = ...; // Concordium gRPC client from '@concordium/web-sdk'.
+const contractAddress = ContractAddress.create(...) // The address of the contract instance.
+const myContract: MyContract.Type = MyContract.createUnchecked(grpcClient, contractAddress);
+```
+
+> To run the checks manually use `await MyContract.checkOnChain(myContract);`.
+
+#### const `moduleReference`
+
+Variable with the reference of the smart contract module used by this contract.
+
+```typescript
+const ref = MyContract.moduleReference;
+```
+
+#### type `Event`
+
+Type representing the structured event logged by this smart contract.
+
+_This is only generated when the schema contains contract event type._
+
+#### function `parseEvent`
+
+Parse a raw contract event logged by this contract into a structured representation.
+
+_This is only generated when the schema contains contract event type._
+
+**Parameter:** `event` The contract event to parse.
+
+**Returns:** The structured event of the `Event` type (see type above).
+
+```typescript
+const rawContractEvent = ...; // The unparsed contract event from some transaction.
+const event: MyContract.Event = MyContract.parseEvent(rawContractEvent);
+```
+
+#### type `<EntrypointName>Parameter`
+
+Type representing the parameter of for an entrypoint. The type is named `<EntrypointName>Parameter` where `<EntrypointName>` is the name of the entrypoint in Pascal case.
+
+_This is only generated when the schema contains contract entrypoint parameter type._
+
+#### function `send<EntrypointName>`
+
+For each entrypoint of the smart contract a function for sending a transaction calling this entrypoint is produced.
+These are named `send<EntrypointName>` where `<EntrypointName>` is the name of the entrypoint in Pascal case.
+
+An example for a smart contract with an entrypoint named `launch-rocket`, the function becomes `sendLaunchRocket`.
+
+**Parameters**
+
+The function parameters are:
+
+- `contractClient` The client of the smart contract instance.
+- `transactionMetadata` Metadata related to constructing the transaction, such as energy and CCD amount to include.
+- `parameter` Parameter to provide to the smart contract entrypoint.
+
+  _With schema type:_ If the schema contains type information for the parameter, a type for the parameter is generated and used for this function (see type above).
+
+  _Without schema type:_ If no schema information is present, the function uses the generic `Parameter` from `@concordium/web-sdk`.
+
+- `signer` The keys of to use for signing the transaction.
+
+**Returns**: Promise with the hash of the transaction.
+
+```typescript
+const myContract: MyContract.Type = ...; // Generated contract client.
+const transactionMeta = { ... }; // Transaction meta information.
+const parameter = ...; // Parameter to pass the smart contract entrypoint.
+const signer = ...; // The keys to use for signing the transaction.
+const transactionHash = await MyContract.sendLaunchRocket(myContract, transactionMeta, parameter, signer);
+```
+
+#### function `dryRun<EntrypointName>`
+
+For each entrypoint of the smart contract a function for dry-running a transaction calling this entrypoint is produced.
+These are named `dryRun<EntrypointName>` where `<EntrypointName>` is the name of the entrypoint in Pascal case.
+
+An example for a smart contract with an entrypoint named `launch-rocket`, the function becomes `dryRunLaunchRocket`.
+
+**Parameters**
+
+The function parameters are:
+
+- `contractClient` The client of the smart contract instance.
+- `invoker` TODO
+- `parameter` Parameter to provide to the smart contract entrypoint.
+
+  _With schema type:_ If the schema contains type information for the parameter, a type for the parameter is generated and used for this function (see type above).
+
+  _Without schema type:_ If no schema information is present, the function uses the generic `Parameter` from `@concordium/web-sdk`.
+
+- `blockHash` (optional) Provide to specify the block hash, for which the state will be used for dry-running.
+  When not provided, the last finalized block is used.
+
+**Returns**: Promise with the invoke result.
+
+```typescript
+const myContract: MyContract.Type = ...; // Generated contract client.
+const invoker = { ... }; // TODO
+const parameter = ...; // Parameter to pass the smart contract entrypoint.
+const invokeResult = await MyContract.dryRunLaunchRocket(myContract, invoker, parameter);
+```
+
+#### type `ReturnValue<EntrypointName>`
+
+Type representing the return value from a successful dry-run/invocation of an entrypoint. The type is named `ReturnValue<EntrypointName>` where `<EntrypointName>` is the name of the relevant entrypoint in Pascal case.
+
+_This is only generated when the schema contains entrypoint return value type._
+
+#### function `parseReturnValue<EntrypointName>`
+
+For each entrypoint of the smart contract a function for parsing the return value in a successful invocation/dry-running.
+These are named `parseReturnValue<EntrypointName>` where `<EntrypointName>` is the name of the entrypoint in Pascal case.
+
+_This is only generated when the schema contains entrypoint return value type._
+
+An example for a smart contract with an entrypoint named `launch-rocket`, the function becomes `parseReturnValueLaunchRocket`.
+
+**Parameter:** `invokeResult` The result from dry-running a transactions calling the entrypoint.
+
+**Returns:** Undefined if the invocation was not successful otherwise the parsed return value of the type `ReturnValue<EntrypointName>`.
+
+```typescript
+// Dry run the entrypoint
+const invokeResult = await MyContract.dryRunLaunchRocket(myContract, invoker, parameter);
+
+// Parse the return value
+const returnValue: MyContract.ReturnValueLaunchRocket | undefined = parseReturnValueLaunchRocket(invokeResult);
+```
+
+#### type `ErrorMessage<EntrypointName>`
+
+Type representing the error message from a rejected dry-run/invocation of an entrypoint. The type is named `ErrorMessage<EntrypointName>` where `<EntrypointName>` is the name of the relevant entrypoint in Pascal case.
+
+_This is only generated when the schema contains entrypoint error message type._
+
+
+#### function `parseErrorMessage<EntrypointName>`
+
+For each entrypoint of the smart contract a function for parsing the error message in a rejected invocation/dry-running.
+These are named `parseErrorMessage<EntrypointName>` where `<EntrypointName>` is the name of the entrypoint in Pascal case.
+
+_This is only generated when the schema contains entrypoint error message type._
+
+An example for a smart contract with an entrypoint named `launch-rocket`, the function becomes `parseErrorMessageLaunchRocket`.
+
+**Parameter:** `invokeResult` The result from dry-running a transactions calling some entrypoint.
+
+**Returns:** Undefined if the invocation was not rejected, otherwise the parsed error message of the type `ReturnValue<EntrypointName>`.
+
+```typescript
+// Dry run the entrypoint
+const invokeResult = await MyContract.dryRunLaunchRocket(myContract, invoker, parameter);
+
+// Parse the error message
+const message: MyContract.ErrorMessageLaunchRocket | undefined = parseErrorMessageLaunchRocket(invokeResult);
+```

--- a/packages/ccd-js-gen/README.md
+++ b/packages/ccd-js-gen/README.md
@@ -181,8 +181,8 @@ into the directory `./generated` produces the following structure:
 ```
 generated/
 ├─ my-module.js        // Functions for interacting with the 'my-module' smart contract module on chain.
-├─ my-contract-a.js    // Functions for interacting with the 'my-contract-a' smart contract.
-└─ my-contract-b.js    // Functions for interacting with the 'my-contract-b' smart contract.
+├─ my-module_my-contract-a.js    // Functions for interacting with the 'my-contract-a' smart contract.
+└─ my-module_my-contract-b.js    // Functions for interacting with the 'my-contract-b' smart contract.
 ```
 
 > There might also be type declarations (`<file>.d.ts`) for TypeScript, depending on the provided options.
@@ -290,7 +290,7 @@ Each file contains functions for interacting with an instance of this smart cont
 An example of importing a smart contract contract client generated from a module containing a smart contract named `my-contract`:
 
 ```typescript
-import * as MyContract from "./generated/my-contract.js";
+import * as MyContract from "./generated/my-module_my-contract.js";
 ```
 
 #### The contract client type
@@ -409,13 +409,16 @@ An example for a smart contract with an entrypoint named `launch-rocket`, the fu
 The function parameters are:
 
 - `contractClient` The client of the smart contract instance.
-- `invoker` TODO
 - `parameter` Parameter to provide to the smart contract entrypoint.
 
   _With schema type:_ If the schema contains type information for the parameter, a type for the parameter is generated and used for this function (see type above).
 
   _Without schema type:_ If no schema information is present, the function uses the generic `Parameter` from `@concordium/web-sdk`.
 
+- `invokeMetadata` Optional transaction metadata object with the following optional properties:
+  - `invoker` The address invoking this call, can be either an `AccountAddress` or `ContractAddress`. Defaults to an `AccountAddress` (Base58check encoding of 32 bytes with value zero).
+  - `amount` The amount of CCD included in the transaction. Defaults to 0.
+  - `energy` The energy reserved for executing this transaction. Defaults to max energy possible.
 - `blockHash` (optional) Provide to specify the block hash, for which the state will be used for dry-running.
   When not provided, the last finalized block is used.
 
@@ -423,9 +426,9 @@ The function parameters are:
 
 ```typescript
 const myContract: MyContract.Type = ...; // Generated contract client.
-const invoker = { ... }; // TODO
 const parameter = ...; // Parameter to pass the smart contract entrypoint.
-const invokeResult = await MyContract.dryRunLaunchRocket(myContract, invoker, parameter);
+const metadata = { ... }; // Transaction metadata for invoking.
+const invokeResult = await MyContract.dryRunLaunchRocket(myContract, parameter, metadata);
 ```
 
 #### type `ReturnValue<EntrypointName>`


### PR DESCRIPTION
## Purpose

Add documentation of how to use the `ccd-js-gen` package.

This can be review already, but a single TODO is still there to be fixed related to metadata for invoking/dry-running contract calls.