### PR TITLE
Change eslint prettier rules to be warnings instead

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,7 @@ module.exports = {
     },
     plugins: ['@typescript-eslint', 'import'],
     rules: {
+        'prettier/prettier': 'warn',
         quotes: [
             2,
             'single',


### PR DESCRIPTION
## Purpose

Eslint produces errors when formatting is not following `prettier`, which results in a lot of noise drowning the actual compile errors until formatting is fixed.
This PR changes eslint config to use warnings instead of errors for formatting.

