### PR TITLE
Release/ccd-js-gen 1.0.0

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -80,6 +80,8 @@ jobs:
           path: |
             ./packages/sdk/lib
             ./packages/sdk/src
+            ./packages/ccd-js-gen/lib
+            ./packages/ccd-js-gen/src
             ./packages/rust-bindings/lib
             ./packages/*/package.json
             ./packages/*/README.md

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ on:
     workflow_dispatch:
 
 env:
-    DUMMY: 2 # For cache busting.
+    DUMMY: 3 # For cache busting.
     NODE_VERSION: 18.16.0
     RUST_VERSION: 1.65
     RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Wrappers for interacting with the Concordium node.
   - [Making a new release](#making-a-new-release)
     - [SDK](#sdk)
     - [rust-bindings](#rust-bindings)
+    - [ccd-js-gen](#ccd-js-gen)
   - [Test](#test)
 <!--toc:end-->
 
@@ -132,6 +133,19 @@ each of the packages contained in this repository.
 - Publish the release to NPM.
   - From the rust-bindings package directory (packages/rust-bindings) run
     `yarn npm publish`
+
+### ccd-js-gen
+
+- Bump the version in [package.json](./packages/ccd-js-gen/package.json).
+- Update the [CHANGELOG](./packages/ccd-js-gen/CHANGELOG.md) describing
+  the changes made.
+- Commit and tag the release.
+  - Tag should be `ccd-js-gen/x.y.z`.
+- Run the deploy workflow.
+  - Under github actions, run the "deploy" workflow and download the
+    `build-release` artifact. Unpack this file and use it for the release.
+- Publish the release to NPM.
+  - From the ccd-js-gen package directory (packages/ccd-js-gen) run `yarn npm publish`
 
 ## Test
 

--- a/packages/ccd-js-gen/CHANGELOG.md
+++ b/packages/ccd-js-gen/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog - ccd-js-gen
+
+## 1.0.0
+
+- Initial release

--- a/packages/ccd-js-gen/package.json
+++ b/packages/ccd-js-gen/package.json
@@ -32,10 +32,10 @@
     },
     "license": "Apache-2.0",
     "peerDependencies": {
-        "@concordium/web-sdk": "7.0.0-rc.5"
+        "@concordium/web-sdk": "7.x"
     },
     "dependencies": {
-        "@concordium/web-sdk": "7.0.0-rc.5",
+        "@concordium/web-sdk": "^7.0.0",
         "buffer": "^6.0.3",
         "commander": "^11.0.0",
         "sanitize-filename": "^1.6.3",


### PR DESCRIPTION
## Purpose

Document and prepare for release of ccd-js-gen v1.0.0

Should be merged into main after https://github.com/Concordium/concordium-node-sdk-js/pull/271

