### PR TITLE
Fix missing executable in ccd-js-gen deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -82,6 +82,7 @@ jobs:
             ./packages/sdk/src
             ./packages/ccd-js-gen/lib
             ./packages/ccd-js-gen/src
+            ./packages/ccd-js-gen/bin
             ./packages/rust-bindings/lib
             ./packages/*/package.json
             ./packages/*/README.md

--- a/packages/ccd-js-gen/CHANGELOG.md
+++ b/packages/ccd-js-gen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - ccd-js-gen
 
+## 1.0.1
+
+- Fix missing `bin` in deployed package.
+
 ## 1.0.0
 
 - Initial release

--- a/packages/ccd-js-gen/package.json
+++ b/packages/ccd-js-gen/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/ccd-js-gen",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Generate JS clients for the Concordium Blockchain",
     "type": "module",
     "bin": "bin/ccd-js-gen.js",
@@ -16,6 +16,12 @@
         "test": "jest",
         "test-ci": "yarn test"
     },
+    "files": [
+        "lib/**/*.json",
+        "lib/src/**/*",
+        "src",
+        "bin"
+    ],
     "keywords": [
         "concordium",
         "smart-contracts"


### PR DESCRIPTION
## Purpose

Testing of the initial release of `ccd-js-gen`, I saw that the executable script was not included in the deployed package.
So here we have another release with this fixed.

