### PR TITLE
Expose type BlockItem again

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fix
+
+- Export type `BlockItem` in the public API again, this was removed accidentally in v7.0.0.
+
 ## 7.0.0
 
 ### Breaking changes

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1845,3 +1845,22 @@ export type HealthCheckResponse =
           isHealthy: false;
           message?: string;
       };
+
+/**
+ * Type representing an item which is included in a block, such as account transactions, chain updates or deployments of new credentials.
+ */
+export type BlockItem =
+    | {
+          kind: BlockItemKind.AccountTransactionKind;
+          transaction: {
+              accountTransaction: AccountTransaction;
+              signatures: AccountTransactionSignature;
+          };
+      }
+    | {
+          kind: BlockItemKind.CredentialDeploymentKind;
+          transaction: {
+              credential: TypedCredentialDeployment;
+              expiry: number;
+          };
+      };

--- a/packages/sdk/src/wasm/deserialization.ts
+++ b/packages/sdk/src/wasm/deserialization.ts
@@ -4,12 +4,7 @@ import {
     deserializeUint8,
 } from '../deserialization.js';
 import { Cursor } from '../deserializationHelpers.js';
-import {
-    AccountTransaction,
-    AccountTransactionSignature,
-    BlockItemKind,
-    TypedCredentialDeployment,
-} from '../types.js';
+import { BlockItem, BlockItemKind } from '../types.js';
 
 function deserializeCredentialDeployment(serializedDeployment: Cursor) {
     const raw = wasm.deserializeCredentialDeployment(
@@ -26,22 +21,6 @@ function deserializeCredentialDeployment(serializedDeployment: Cursor) {
         throw new Error(raw);
     }
 }
-
-export type BlockItem =
-    | {
-          kind: BlockItemKind.AccountTransactionKind;
-          transaction: {
-              accountTransaction: AccountTransaction;
-              signatures: AccountTransactionSignature;
-          };
-      }
-    | {
-          kind: BlockItemKind.CredentialDeploymentKind;
-          transaction: {
-              credential: TypedCredentialDeployment;
-              expiry: number;
-          };
-      };
 
 /**
  * Deserializes a transaction, from the binary format used to send it to the node, back into an js object.

--- a/packages/sdk/src/wasm/index.ts
+++ b/packages/sdk/src/wasm/index.ts
@@ -3,7 +3,7 @@ export {
     serializeCredentialDeploymentTransactionForSubmission,
     serializeCredentialDeploymentPayload,
 } from './serialization.js';
-export { deserializeTransaction } from './deserialization.js';
+export { deserializeTransaction, BlockItem } from './deserialization.js';
 export { generateBakerKeys } from './accountHelpers.js';
 export * from './HdWallet.js';
 export * from './identity.js';

--- a/packages/sdk/src/wasm/index.ts
+++ b/packages/sdk/src/wasm/index.ts
@@ -3,7 +3,7 @@ export {
     serializeCredentialDeploymentTransactionForSubmission,
     serializeCredentialDeploymentPayload,
 } from './serialization.js';
-export { deserializeTransaction, BlockItem } from './deserialization.js';
+export { deserializeTransaction } from './deserialization.js';
 export { generateBakerKeys } from './accountHelpers.js';
 export * from './HdWallet.js';
 export * from './identity.js';


### PR DESCRIPTION
## Purpose

Export type `BlockItem` in the public API again, this was removed accidentally in `web-sdk v7.0.0`.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
