### PR TITLE
Fix typo in upgrade guide

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-    "singleQuote": true
-}

--- a/docs/pages/misc-pages/upgrade-guide.md
+++ b/docs/pages/misc-pages/upgrade-guide.md
@@ -54,7 +54,7 @@ Furthermore, the SDK is now published as an ES module, making it possible to
 eliminate dead code.
 
 For **TypeScript** users, at least typescript version 5 is required along with
-the setting `compilerOptions.moduleResultion` to `"bundler"` to match the
+the setting `compilerOptions.moduleResolution` to `"bundler"` to match the
 resolution strategy of modern bundlers.
 
 The following entrypoints are made available for consumers of
@@ -115,7 +115,7 @@ Alternatively, files names with the extension `mjs` (or `mts` for TypeScript)
 are always handled as ES modules.
 
 For **TypeScript** users, at least typescript version 4.7 is required along
-with the setting `compilerOptions.moduleResultion` to `"node16"` or
+with the setting `compilerOptions.moduleResolution` to `"node16"` or
 `"nodenext"` to match the resolution strategy of node version 16 and later.
 
 ## Common SDK version 5 to 6 (Web 2->3) (Node 5->6)


### PR DESCRIPTION
## Purpose
Needs to be deployed (run the github action when merged to main).

Also removed `.prettierrc` as a config was already present in `package.json`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
