### PR TITLE
Fix init contract serialization issue

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.0.3
+
+### Fixed
+
+- An issue with the serialization of init contract account transactions.
+
 ## 7.0.2
 
 ### Fixed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/accountTransactions.ts
+++ b/packages/sdk/src/accountTransactions.ts
@@ -139,7 +139,10 @@ export class InitContractHandler
 
     serialize(payload: InitContractPayload): Buffer {
         const serializedAmount = encodeWord64(payload.amount.microCcdAmount);
-        const initNameBuffer = Buffer.from('init_' + payload.initName, 'utf8');
+        const initNameBuffer = Buffer.from(
+            'init_' + payload.initName.value,
+            'utf8'
+        );
         const serializedInitName = packBufferWithWord16Length(initNameBuffer);
         const serializedModuleRef = payload.moduleRef.decodedModuleRef;
         const parameterBuffer = Parameter.toBuffer(payload.param);


### PR DESCRIPTION
## Purpose
Fix an issue in the serialization of init contract payloads.

## Changes
- Use the actual String value as the init name when doing serialization.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.