### PR TITLE
Fix errors in the GenericContract.

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased changes
+
+### Added
+
+- `ContractAddress.toString` function that converts the address to a string in
+  the `<index, subindex>` format.
+  
+### Fixed
+
+- Error messages in `GenericContract` now display the data, e.g., the contract
+  address, rather than `[object Object]`.
+
+
 ## 7.1.0
 
 ### Added

--- a/packages/sdk/src/GenericContract.ts
+++ b/packages/sdk/src/GenericContract.ts
@@ -231,7 +231,7 @@ class ContractBase<E extends string = string, V extends string = string> {
             return await grpcClient.getInstanceInfo(contractAddress);
         } catch (e) {
             throw new Error(
-                `Could not get contract instance info for contract at address ${stringify(
+                `Could not get contract instance info for contract at address ${ContractAddress.toString(
                     contractAddress
                 )}: ${(e as Error).message ?? e}`
             );
@@ -290,7 +290,11 @@ class ContractBase<E extends string = string, V extends string = string> {
 
         if (!ContractName.equals(contractNameOnChain, this.contractName)) {
             throw new Error(
-                `Instance ${this.contractAddress} have contract name '${contractNameOnChain}' on chain. The client expected: '${this.contractName}'.`
+                `Instance ${ContractAddress.toString(
+                    this.contractAddress
+                )} has contract name '${
+                    contractNameOnChain.value
+                }' on chain. The client expected: '${this.contractName.value}'.`
             );
         }
 
@@ -299,7 +303,11 @@ class ContractBase<E extends string = string, V extends string = string> {
             info.sourceModule.moduleRef !== options.moduleReference.moduleRef
         ) {
             throw new Error(
-                `Instance ${this.contractAddress} uses module with reference '${info.sourceModule.moduleRef}' expected '${options.moduleReference.moduleRef}'`
+                `Instance ${ContractAddress.toString(
+                    this.contractAddress
+                )} uses module with reference '${
+                    info.sourceModule.moduleRef
+                }' expected '${options.moduleReference.moduleRef}'`
             );
         }
     }
@@ -517,7 +525,7 @@ class ContractBase<E extends string = string, V extends string = string> {
             response.returnValue === undefined
         ) {
             throw new Error(
-                `Failed to invoke view ${entrypoint} for contract at ${stringify(
+                `Failed to invoke view ${entrypoint} for contract at ${ContractAddress.toString(
                     this.contractAddress
                 )}${
                     response.tag === 'failure' &&

--- a/packages/sdk/src/types/ContractAddress.ts
+++ b/packages/sdk/src/types/ContractAddress.ts
@@ -161,6 +161,15 @@ export function toSerializable(contractAddress: ContractAddress): Serializable {
 }
 
 /**
+ * Converts {@linkcode ContractAddress} into a string using the `<index, subindex>` format.
+ * @param {ContractAddress} contractAddress
+ * @returns {string} The string representation of the address.
+ */
+export function toString(contractAddress: ContractAddress): string {
+    return `<${contractAddress.index}, ${contractAddress.subindex}>`;
+}
+
+/**
  * Takes an {@linkcode Type} and transforms it to a {@linkcode TypedJson} format.
  *
  * @param {Type} value - The account address instance to transform.


### PR DESCRIPTION
This changes the errors from the useless

```
Instance [object Object] have contract name '[object Object]' on chain. The client expected: '[object Object]'.
```

to

```
Error: Instance <3, 0> has contract name 'CIS2-wCCD' on chain. The client expected: 'credential_registry'.
```

## Purpose

_Describe the purpose of the pull request, link to issue describing the problem, etc.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.