### PR TITLE
Fix isRewardStatusV1

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 - `ContractAddress.toString` function that converts the address to a string in
   the `<index, subindex>` format.
-  
+
 ### Fixed
 
 - Error messages in `GenericContract` now display the data, e.g., the contract
   address, rather than `[object Object]`.
-
+- Incorrect check in isRewardStatusV1.
 
 ## 7.1.0
 

--- a/packages/sdk/src/versionedTypeHelpers.ts
+++ b/packages/sdk/src/versionedTypeHelpers.ts
@@ -129,5 +129,5 @@ export const isInstanceInfoV0 = (info: InstanceInfo): info is InstanceInfoV0 =>
  * @deprecated check the `version` member instead.
  */
 export function isRewardStatusV1(rs: RewardStatus): rs is RewardStatusV1 {
-    return rs.version === 0;
+    return rs.version === 1;
 }


### PR DESCRIPTION
## Purpose

Fix a bug

## Changes

- Changed v1 check to return true when version is 1 instead of 0.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.