### PR TITLE
Use identity index as identity index

### DIFF
--- a/examples/wallet/src/CreateIdentity.tsx
+++ b/examples/wallet/src/CreateIdentity.tsx
@@ -17,6 +17,7 @@ import {
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { Buffer } from 'buffer/';
 import {
+    identityIndex,
     network,
     seedPhraseKey,
     selectedIdentityProviderKey,
@@ -89,7 +90,7 @@ export function CreateIdentity() {
         const identityRequestInput: IdentityRequestInput = {
             net: network,
             seed: Buffer.from(mnemonicToSeedSync(seedPhrase)).toString('hex'),
-            identityIndex: selectedIdentityProvider.ipInfo.ipIdentity,
+            identityIndex,
             arsInfos: selectedIdentityProvider.arsInfos,
             arThreshold: determineAnonymityRevokerThreshold(
                 Object.keys(selectedIdentityProvider.arsInfos).length


### PR DESCRIPTION
## Purpose
Fix a bug where the wrong identity index was used.

## Changes
- Use the hard coded identity index as identity index instead of the identity providers identity number.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.