### PR TITLE
Add output-type flag to cli of ccd-js-gen tool

### DIFF
--- a/packages/ccd-js-gen/CHANGELOG.md
+++ b/packages/ccd-js-gen/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add output-type flag to cli.
 - Fix the executable version of the package on Windows.
 
 ## 1.0.1

--- a/packages/ccd-js-gen/package.json
+++ b/packages/ccd-js-gen/package.json
@@ -12,7 +12,7 @@
         "build-dev": "yarn build",
         "clean": "rm -r lib",
         "lint": "eslint src/** bin/** --cache --ext .ts,.js --max-warnings 0",
-        "lint-fix": "yarn --silent lint --fix; exit 0",
+        "lint-fix": "yarn lint --fix; exit 0",
         "test": "jest",
         "test-ci": "yarn test"
     },

--- a/packages/ccd-js-gen/src/cli.ts
+++ b/packages/ccd-js-gen/src/cli.ts
@@ -31,7 +31,7 @@ export async function main(): Promise<void> {
             'The output directory for the generated code'
         )
         .option<lib.OutputOptions>(
-            '-t, --output-type [TypeScript|JavaScript|TypedJavaScript|Everything]',
+            '-t, --output-type <TypeScript|JavaScript|TypedJavaScript|Everything>',
             'The output file types for the generated code.',
             (value: string) => {
                 switch (value) {
@@ -39,7 +39,7 @@ export async function main(): Promise<void> {
                     case 'JavaScript':
                     case 'TypedJavaScript':
                     case 'Everything':
-                        return value as lib.OutputOptions;
+                        return value;
                     default:
                         // Exit in case `value` is not a valid OutputOptions.
                         console.error(

--- a/packages/ccd-js-gen/src/cli.ts
+++ b/packages/ccd-js-gen/src/cli.ts
@@ -11,6 +11,8 @@ type Options = {
     module: string;
     /** The output directory for the generated code */
     outDir: string;
+    /** The output file types for the generated code */
+    outputType: lib.OutputOptions;
 };
 
 // Main function, which is called in the executable script in `bin`.
@@ -28,12 +30,33 @@ export async function main(): Promise<void> {
             '-o, --out-dir <directory>',
             'The output directory for the generated code'
         )
+        .option<lib.OutputOptions>(
+            '-t, --output-type [TypeScript|JavaScript|TypedJavaScript|Everything]',
+            'The output file types for the generated code.',
+            (value: string) => {
+                switch (value) {
+                    case 'TypeScript':
+                    case 'JavaScript':
+                    case 'TypedJavaScript':
+                    case 'Everything':
+                        return value as lib.OutputOptions;
+                    default:
+                        // Exit in case `value` is not a valid OutputOptions.
+                        console.error(
+                            `Invalid '--output-type' flag: ${value}. Use 'TypeScript', 'JavaScript', 'TypedJavaScript', or 'Everything'.`
+                        );
+                        process.exit(1);
+                }
+            },
+            'Everything'
+        )
         .parse(process.argv);
     const options = program.opts<Options>();
     console.log('Generating smart contract clients...');
 
     const startTime = Date.now();
     await lib.generateContractClientsFromFile(options.module, options.outDir, {
+        output: options.outputType,
         onProgress(update) {
             if (update.type === 'Progress') {
                 console.log(


### PR DESCRIPTION
## Purpose

Closes #321 

## Changes

Add `--output-type` flag to cli of `ccd-js-gen` package.
