### PR TITLE
ccd-js-gen: Flag for generating @ts-nocheck

### DIFF
--- a/packages/ccd-js-gen/CHANGELOG.md
+++ b/packages/ccd-js-gen/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Add output-type flag to cli.
+- Add optional flag `--ts-nocheck`, enabling it will add `// @ts-nocheck` in each generated file.
+- Add `--output-type <type>` flag to CLI allowing to specify whether to generate TypeScript or JavaScript directly.
 - Fix the executable version of the package on Windows.
 
 ## 1.0.1

--- a/packages/ccd-js-gen/src/cli.ts
+++ b/packages/ccd-js-gen/src/cli.ts
@@ -13,7 +13,7 @@ type Options = {
     outDir: string;
     /** The output file types for the generated code */
     outputType: lib.OutputOptions;
-    /** Generate `// @ts-nocheck` annotations in each file. Disabled by default. */
+    /** Generate `// @ts-nocheck` annotations in each file. */
     tsNocheck: boolean;
 };
 
@@ -53,7 +53,7 @@ export async function main(): Promise<void> {
             'Everything'
         )
         .option(
-            '--ts-nocheck',
+            '-n, --ts-nocheck',
             'Generate `@ts-nocheck` annotations at the top of each typescript file.',
             false
         )

--- a/packages/ccd-js-gen/src/cli.ts
+++ b/packages/ccd-js-gen/src/cli.ts
@@ -13,6 +13,8 @@ type Options = {
     outDir: string;
     /** The output file types for the generated code */
     outputType: lib.OutputOptions;
+    /** Generate `// @ts-nocheck` annotations in each file. Disabled by default. */
+    tsNocheck: boolean;
 };
 
 // Main function, which is called in the executable script in `bin`.
@@ -50,6 +52,11 @@ export async function main(): Promise<void> {
             },
             'Everything'
         )
+        .option(
+            '--ts-nocheck',
+            'Generate `@ts-nocheck` annotations at the top of each typescript file.',
+            false
+        )
         .parse(process.argv);
     const options = program.opts<Options>();
     console.log('Generating smart contract clients...');
@@ -57,6 +64,7 @@ export async function main(): Promise<void> {
     const startTime = Date.now();
     await lib.generateContractClientsFromFile(options.module, options.outDir, {
         output: options.outputType,
+        tsNocheck: options.tsNocheck,
         onProgress(update) {
             if (update.type === 'Progress') {
                 console.log(

--- a/packages/ccd-js-gen/src/lib.ts
+++ b/packages/ccd-js-gen/src/lib.ts
@@ -21,6 +21,8 @@ export type OutputOptions =
 export type GenerateContractClientsOptions = {
     /** Options for the output. */
     output?: OutputOptions;
+    /** Generate `// @ts-nocheck` annotations in each file. Disabled by default. */
+    tsNocheck?: boolean;
     /** Callback for getting notified on progress. */
     onProgress?: NotifyProgress;
 };
@@ -97,6 +99,7 @@ export async function generateContractClients(
         outName,
         outDirPath,
         moduleSource,
+        options.tsNocheck ?? false,
         options.onProgress
     );
 
@@ -118,6 +121,7 @@ export async function generateContractClients(
  * @param {string} outModuleName The name for outputting the module client file.
  * @param {string} outDirPath The directory to use for outputting files.
  * @param {SDK.VersionedModuleSource} moduleSource The source of the smart contract module.
+ * @param {boolean} tsNocheck When `true` generate `// @ts-nocheck` annotations in each file.
  * @param {NotifyProgress} [notifyProgress] Callback to report progress.
  */
 async function generateCode(
@@ -125,6 +129,7 @@ async function generateCode(
     outModuleName: string,
     outDirPath: string,
     moduleSource: SDK.VersionedModuleSource,
+    tsNocheck: boolean,
     notifyProgress?: NotifyProgress
 ) {
     const [moduleInterface, moduleRef, rawModuleSchema] = await Promise.all([
@@ -150,9 +155,13 @@ async function generateCode(
         name: outModuleName,
         ext: '.ts',
     });
-    const moduleSourceFile = project.createSourceFile(outputFilePath, '', {
-        overwrite: true,
-    });
+    const moduleSourceFile = project.createSourceFile(
+        outputFilePath,
+        tsNocheck ? '// @ts-nocheck' : '',
+        {
+            overwrite: true,
+        }
+    );
     const moduleClientId = 'moduleClient';
     const moduleClientType = `${toPascalCase(outModuleName)}Module`;
     const internalModuleClientId = 'internalModuleClient';
@@ -188,7 +197,7 @@ async function generateCode(
         });
         const contractSourceFile = project.createSourceFile(
             contractOutputFilePath,
-            '',
+            tsNocheck ? '// @ts-nocheck' : '',
             {
                 overwrite: true,
             }

--- a/packages/ccd-js-gen/src/lib.ts
+++ b/packages/ccd-js-gen/src/lib.ts
@@ -155,13 +155,9 @@ async function generateCode(
         name: outModuleName,
         ext: '.ts',
     });
-    const moduleSourceFile = project.createSourceFile(
-        outputFilePath,
-        tsNocheck ? '// @ts-nocheck' : '',
-        {
-            overwrite: true,
-        }
-    );
+    const moduleSourceFile = project.createSourceFile(outputFilePath, '', {
+        overwrite: true,
+    });
     const moduleClientId = 'moduleClient';
     const moduleClientType = `${toPascalCase(outModuleName)}Module`;
     const internalModuleClientId = 'internalModuleClient';
@@ -171,7 +167,8 @@ async function generateCode(
         moduleRef,
         moduleClientId,
         moduleClientType,
-        internalModuleClientId
+        internalModuleClientId,
+        tsNocheck
     );
 
     for (const contract of moduleInterface.values()) {
@@ -197,7 +194,7 @@ async function generateCode(
         });
         const contractSourceFile = project.createSourceFile(
             contractOutputFilePath,
-            tsNocheck ? '// @ts-nocheck' : '',
+            '',
             {
                 overwrite: true,
             }
@@ -214,6 +211,7 @@ async function generateCode(
             contractClientId,
             contractClientType,
             moduleRef,
+            tsNocheck,
             contractSchema
         );
 
@@ -254,14 +252,19 @@ function generateModuleBaseCode(
     moduleRef: SDK.ModuleReference.Type,
     moduleClientId: string,
     moduleClientType: string,
-    internalModuleClientId: string
+    internalModuleClientId: string,
+    tsNocheck: boolean
 ) {
     const moduleRefId = 'moduleReference';
 
-    moduleSourceFile.addImportDeclaration({
-        namespaceImport: 'SDK',
-        moduleSpecifier: '@concordium/web-sdk',
-    });
+    moduleSourceFile.addStatements([
+        tsNocheck ? '// @ts-nocheck' : '',
+        {
+            kind: tsm.StructureKind.ImportDeclaration,
+            namespaceImport: 'SDK',
+            moduleSpecifier: '@concordium/web-sdk',
+        },
+    ]);
 
     moduleSourceFile.addVariableStatement({
         isExported: true,
@@ -574,6 +577,7 @@ function generateContractBaseCode(
     contractClientId: string,
     contractClientType: string,
     moduleRef: SDK.ModuleReference.Type,
+    tsNocheck: boolean,
     contractSchema?: SDK.SchemaContractV3
 ) {
     const moduleRefId = 'moduleReference';
@@ -583,10 +587,14 @@ function generateContractBaseCode(
     const contractAddressId = 'contractAddress';
     const blockHashId = 'blockHash';
 
-    contractSourceFile.addImportDeclaration({
-        namespaceImport: 'SDK',
-        moduleSpecifier: '@concordium/web-sdk',
-    });
+    contractSourceFile.addStatements([
+        tsNocheck ? '// @ts-nocheck' : '',
+        {
+            kind: tsm.StructureKind.ImportDeclaration,
+            namespaceImport: 'SDK',
+            moduleSpecifier: '@concordium/web-sdk',
+        },
+    ]);
 
     contractSourceFile.addVariableStatement({
         docs: [

--- a/packages/ccd-js-gen/src/lib.ts
+++ b/packages/ccd-js-gen/src/lib.ts
@@ -21,7 +21,7 @@ export type OutputOptions =
 export type GenerateContractClientsOptions = {
     /** Options for the output. */
     output?: OutputOptions;
-    /** Generate `// @ts-nocheck` annotations in each file. Disabled by default. */
+    /** Generate `// @ts-nocheck` annotations in each file. Defaults to `false`. */
     tsNocheck?: boolean;
     /** Callback for getting notified on progress. */
     onProgress?: NotifyProgress;


### PR DESCRIPTION
## Purpose

Closes #313.
Provide flag for generating `// @ts-nocheck`.

## Changes

- Introduce a new option in both CLI and library for enabling this.
- Extend some details in the changelog.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
