### PR TITLE
ccd-js-gen: Sanitize module names before using as type.

### DIFF
--- a/packages/ccd-js-gen/CHANGELOG.md
+++ b/packages/ccd-js-gen/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix issue related to inferring module type names from the input file name, by removing characters, which are not valid in type names.
 - Improve information when reporting progress during code-generation.
 - Generate `create<ContractName>ParameterWebWallet` and `create<EntrypointName>ParameterWebWallet` functions for constructing the smart contract parameters in the format used by the Concordium Web-Wallet.
 - Minor breaking change: `create<EntrypointName>Parameter` function for contract entries and `create<ContractName>Parameter` function in module are no longer generated when parameter schema type is `Unit`. These functions are mainly used internally, but are still exposed.

--- a/packages/ccd-js-gen/README.md
+++ b/packages/ccd-js-gen/README.md
@@ -85,6 +85,9 @@ const transactionHash = await MyContract.sendTransfer(contractClient, {
     - [type `ErrorMessage<EntrypointName>`](#type-errormessageentrypointname)
     - [function `parseErrorMessage<EntrypointName>`](#function-parseerrormessageentrypointname)
     - [function `create<EntrypointName>ParameterWebWallet`](#function-createentrypointnameparameterwebwallet)
+- [Development](#development)
+  - [Setup](#setup)
+  - [Development workflow](#development-workflow)
 <!--toc:end-->
 
 ## Install the package
@@ -628,4 +631,37 @@ const transactionHash = await webWalletConnection.signAndSendTransaction(
     AccountTransactionType.Update,
     walletParameter
 );
+```
+
+## Development
+
+This section describes how to setup and start developing this package.
+
+### Setup
+To be able to develop `ccd-js-gen` make sure to have:
+
+- [NodeJs](https://nodejs.org/en) (see `package.json` for which versions are supported).
+- [Yarn](https://yarnpkg.com/)
+- [Rust and cargo](https://rustup.rs/)
+
+After cloning this repository makes sure to do the following:
+
+- Initialize git submodules recursively, can be done using `git submodules update --init --recursive`.
+- Install dependencies by running `yarn install` in the root of this repo.
+- Build everything using `yarn build` in the root of this repo.
+
+### Development workflow
+
+After doing changes to the source code of `ccd-js-gen` run `yarn build` from the `packages/ccd-js-gen` directory.
+
+To run CLI locally use:
+
+```
+./bin/ccd-js-gen.js --module "<module>" --out "./lib/generated"
+```
+
+To run tests locally use:
+
+```
+yarn test
 ```

--- a/packages/ccd-js-gen/README.md
+++ b/packages/ccd-js-gen/README.md
@@ -657,7 +657,7 @@ After doing changes to the source code of `ccd-js-gen` run `yarn build` from the
 To run CLI locally use:
 
 ```
-./bin/ccd-js-gen.js --module "<module>" --out "./lib/generated"
+./bin/ccd-js-gen.js --module "<module>" --out-dir "./lib/generated"
 ```
 
 To run tests locally use:

--- a/packages/ccd-js-gen/README.md
+++ b/packages/ccd-js-gen/README.md
@@ -638,6 +638,7 @@ const transactionHash = await webWalletConnection.signAndSendTransaction(
 This section describes how to setup and start developing this package.
 
 ### Setup
+
 To be able to develop `ccd-js-gen` make sure to have:
 
 - [NodeJs](https://nodejs.org/en) (see `package.json` for which versions are supported).
@@ -656,12 +657,12 @@ After doing changes to the source code of `ccd-js-gen` run `yarn build` from the
 
 To run CLI locally use:
 
-```
+```bash
 ./bin/ccd-js-gen.js --module "<module>" --out-dir "./lib/generated"
 ```
 
 To run tests locally use:
 
-```
+```bash
 yarn test
 ```

--- a/packages/ccd-js-gen/package.json
+++ b/packages/ccd-js-gen/package.json
@@ -37,9 +37,6 @@
         "url": "https://concordium.com"
     },
     "license": "Apache-2.0",
-    "engines": {
-        "node": ">=16.15.0 <21"
-    },
     "peerDependencies": {
         "@concordium/web-sdk": "7.x"
     },

--- a/packages/ccd-js-gen/package.json
+++ b/packages/ccd-js-gen/package.json
@@ -37,6 +37,9 @@
         "url": "https://concordium.com"
     },
     "license": "Apache-2.0",
+    "engines": {
+        "node": ">=16.15.0 <21"
+    },
     "peerDependencies": {
         "@concordium/web-sdk": "7.x"
     },

--- a/packages/ccd-js-gen/src/cli.ts
+++ b/packages/ccd-js-gen/src/cli.ts
@@ -1,8 +1,10 @@
 /*
 This file contains code for building the command line inferface to the ccd-js-gen library.
 */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Command } from 'commander';
-import packageJson from '../package.json' assert { type: 'json' };
 import * as lib from './lib.js';
 
 /** Type representing the CLI options/arguments and needs to match the options set with commander.js */
@@ -19,6 +21,16 @@ type Options = {
 
 // Main function, which is called in the executable script in `bin`.
 export async function main(): Promise<void> {
+    // Read package.json for version and description:
+    const scriptPath = fileURLToPath(import.meta.url);
+    const binFolder = path.parse(scriptPath).dir;
+    const cliPath = pathToFileURL(
+        path.resolve(binFolder, '..', '..', 'package.json')
+    );
+    const packageJson: { version: string; description: string } = await fs
+        .readFile(cliPath, 'utf-8')
+        .then(JSON.parse);
+
     const program = new Command();
     program
         .name('ccd-js-gen')

--- a/packages/ccd-js-gen/src/lib.ts
+++ b/packages/ccd-js-gen/src/lib.ts
@@ -212,7 +212,8 @@ async function generateCode(
         overwrite: true,
     });
     const moduleClientId = 'moduleClient';
-    const moduleClientType = `${toPascalCase(outModuleName)}Module`;
+    const sanitizedOutModuleName = sanitizeIdentifier(outModuleName);
+    const moduleClientType = `${toPascalCase(sanitizedOutModuleName)}Module`;
     const internalModuleClientId = 'internalModuleClient';
 
     moduleSourceFile.addStatements(
@@ -2290,3 +2291,20 @@ function defineProp(propId: string, valueId: string): string {
  * when accessing props or defining fields in an object.
  */
 const identifierRegex = /^[$A-Z_][0-9A-Z_$]*$/i;
+
+/**
+ * Regular expression matching any character which cannot be used as an identifier.
+ */
+const notIdentifierSymbolRegex = /[^0-9A-Z_$]/gi;
+
+/**
+ * Remove any characters from a string which cannot be used as an identifier.
+ * @param {string} input Input to sanitize.
+ * @returns {string} Input string without any characters which are invalid for identifiers.
+ *
+ * @example
+ * sanitizeIdentifier("some/weird variable.name") // "someweirdvariablename"
+ */
+function sanitizeIdentifier(input: string): string {
+    return input.replaceAll(notIdentifierSymbolRegex, '');
+}

--- a/packages/ccd-js-gen/tsconfig.build.json
+++ b/packages/ccd-js-gen/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/**/*", "package.json"]
+    "include": ["src/**/*", "package.json"] // package.json is used by the CLI, therefore it is included here.
 }

--- a/packages/ccd-js-gen/tsconfig.json
+++ b/packages/ccd-js-gen/tsconfig.json
@@ -5,7 +5,7 @@
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "outDir": "./lib",
-        "lib": ["ES2020", "dom"], // "dom" is only added to get the typings for the global variable `WebAssembly`.
+        "lib": ["ES2021", "dom"], // "dom" is only added to get the typings for the global variable `WebAssembly`.
         "resolveJsonModule": true
     }
 }


### PR DESCRIPTION
## Purpose

Closes #316

## Changes

- Sanitize module name before using it as type identifier (related to #316).
- Add development section to readme.
- Add supported node versions in `package.json`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

