### PR TITLE
Recover and save identity in wallet example

### DIFF
--- a/examples/wallet/src/ConfirmIdentity.tsx
+++ b/examples/wallet/src/ConfirmIdentity.tsx
@@ -29,7 +29,7 @@ export function ConfirmIdentity() {
 
     return (
         <>
-            <h3>Identity is not ready yet</h3>
+            <h3>Identity is not ready yet. Please wait.</h3>
         </>
     );
 }

--- a/examples/wallet/src/ConfirmIdentity.tsx
+++ b/examples/wallet/src/ConfirmIdentity.tsx
@@ -1,44 +1,21 @@
-import { AttributeList, IdentityObjectV1 } from '@concordium/web-sdk';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { extractIdentityObjectUrl, fetchIdentity } from './util';
-import { CreateAccount } from './CreateAccount';
 import { identityObjectKey } from './constants';
-
-function DisplayIdentity({ attributes }: { attributes: AttributeList }) {
-    return (
-        <ul>
-            <li>
-                Name: {attributes.chosenAttributes.firstName}{' '}
-                {attributes.chosenAttributes.lastName}
-            </li>
-            <li>Nationality: {attributes.chosenAttributes.nationality}</li>
-        </ul>
-    );
-}
 
 export function ConfirmIdentity() {
     const location = useLocation();
     const [error, setError] = useState<string>();
-    const identity = useMemo<IdentityObjectV1>(
-        () => {
-            const raw = localStorage.getItem(identityObjectKey)
-            if (raw) {
-                return JSON.parse(raw)
-            }
-        },
-        []
-    );
     const navigate = useNavigate();
-    
+
     useEffect(() => {
         const identityObjectUrl = extractIdentityObjectUrl(location.hash);
         fetchIdentity(identityObjectUrl)
-        .then((raw) => {
-            localStorage.setItem(identityObjectKey, JSON.stringify(raw))
-            navigate("/identity")
-        })
-        .catch(setError);
+            .then((raw) => {
+                localStorage.setItem(identityObjectKey, JSON.stringify(raw));
+                navigate('/identity');
+            })
+            .catch(setError);
     }, [location.hash]);
 
     if (error) {

--- a/examples/wallet/src/ConfirmIdentity.tsx
+++ b/examples/wallet/src/ConfirmIdentity.tsx
@@ -1,6 +1,6 @@
 import { AttributeList, IdentityObjectV1 } from '@concordium/web-sdk';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { extractIdentityObjectUrl, fetchIdentity } from './util';
 import { CreateAccount } from './CreateAccount';
 import { identityObjectKey } from './constants';
@@ -17,31 +17,42 @@ function DisplayIdentity({ attributes }: { attributes: AttributeList }) {
     );
 }
 
-export function Identity() {
+export function ConfirmIdentity() {
     const location = useLocation();
-    const [missingIdentity, setMissingIdentity] = useState<boolean>(false);
+    const [error, setError] = useState<string>();
     const identity = useMemo<IdentityObjectV1>(
         () => {
             const raw = localStorage.getItem(identityObjectKey)
             if (raw) {
                 return JSON.parse(raw)
-            } else {
-                setMissingIdentity(true);
             }
         },
         []
     );
+    const navigate = useNavigate();
+    
+    useEffect(() => {
+        const identityObjectUrl = extractIdentityObjectUrl(location.hash);
+        fetchIdentity(identityObjectUrl)
+        .then((raw) => {
+            localStorage.setItem(identityObjectKey, JSON.stringify(raw))
+            navigate("/identity")
+        })
+        .catch(setError);
+    }, [location.hash]);
+
+    if (error) {
+        return (
+            <div>
+                <h3>Identity creation failed</h3>
+                <div>{error}</div>
+            </div>
+        );
+    }
 
     return (
         <>
-            <h3>Your Concordium identity</h3>
-            {missingIdentity && (<h3>Missing identity in storage</h3>)}
-            {identity && (
-                <>
-                    <DisplayIdentity attributes={identity.attributeList} />
-                    <CreateAccount identity={identity} />
-                </>
-            )}
+            <h3>Identity is not ready yet</h3>
         </>
     );
 }

--- a/examples/wallet/src/CreateIdentity.tsx
+++ b/examples/wallet/src/CreateIdentity.tsx
@@ -144,7 +144,7 @@ export function CreateIdentity() {
             >
                 Create identity
             </button>
-            <button onClick={() => navigate("/recover")}>Go to recovery</button>
+            <button onClick={() => navigate('/recover')}>Go to recovery</button>
             {createButtonDisabled && (
                 <div>Generating identity request. This can take a while.</div>
             )}

--- a/examples/wallet/src/CreateIdentity.tsx
+++ b/examples/wallet/src/CreateIdentity.tsx
@@ -144,7 +144,6 @@ export function CreateIdentity() {
             >
                 Create identity
             </button>
-            <button onClick={() => navigate('/recover')}>Go to recovery</button>
             {createButtonDisabled && (
                 <div>Generating identity request. This can take a while.</div>
             )}

--- a/examples/wallet/src/Identity.tsx
+++ b/examples/wallet/src/Identity.tsx
@@ -18,9 +18,9 @@ function DisplayIdentity({ attributes }: { attributes: AttributeList }) {
 export function Identity() {
     const [missingIdentity, setMissingIdentity] = useState<boolean>(false);
     const identity = useMemo<IdentityObjectV1>(() => {
-        const raw = localStorage.getItem(identityObjectKey);
-        if (raw) {
-            return JSON.parse(raw);
+        const identityObjectJson = localStorage.getItem(identityObjectKey);
+        if (identityObjectJson) {
+            return JSON.parse(identityObjectJson);
         } else {
             setMissingIdentity(true);
         }

--- a/examples/wallet/src/Identity.tsx
+++ b/examples/wallet/src/Identity.tsx
@@ -1,7 +1,5 @@
 import { AttributeList, IdentityObjectV1 } from '@concordium/web-sdk';
-import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import { extractIdentityObjectUrl, fetchIdentity } from './util';
+import React, { useMemo, useState } from 'react';
 import { CreateAccount } from './CreateAccount';
 import { identityObjectKey } from './constants';
 
@@ -18,24 +16,20 @@ function DisplayIdentity({ attributes }: { attributes: AttributeList }) {
 }
 
 export function Identity() {
-    const location = useLocation();
     const [missingIdentity, setMissingIdentity] = useState<boolean>(false);
-    const identity = useMemo<IdentityObjectV1>(
-        () => {
-            const raw = localStorage.getItem(identityObjectKey)
-            if (raw) {
-                return JSON.parse(raw)
-            } else {
-                setMissingIdentity(true);
-            }
-        },
-        []
-    );
+    const identity = useMemo<IdentityObjectV1>(() => {
+        const raw = localStorage.getItem(identityObjectKey);
+        if (raw) {
+            return JSON.parse(raw);
+        } else {
+            setMissingIdentity(true);
+        }
+    }, []);
 
     return (
         <>
             <h3>Your Concordium identity</h3>
-            {missingIdentity && (<h3>Missing identity in storage</h3>)}
+            {missingIdentity && <h3>Missing identity in storage</h3>}
             {identity && (
                 <>
                     <DisplayIdentity attributes={identity.attributeList} />

--- a/examples/wallet/src/Index.tsx
+++ b/examples/wallet/src/Index.tsx
@@ -26,7 +26,7 @@ const router = createBrowserRouter([
     },
     {
         path: '/confirm-identity',
-        element: <ConfirmIdentity />
+        element: <ConfirmIdentity />,
     },
     {
         path: '/identity',
@@ -34,7 +34,7 @@ const router = createBrowserRouter([
     },
     {
         path: '/recover',
-        element: <RecoverIdentity />
+        element: <RecoverIdentity />,
     },
     {
         path: '/account/:accountAddress',

--- a/examples/wallet/src/Index.tsx
+++ b/examples/wallet/src/Index.tsx
@@ -6,6 +6,8 @@ import { Identity } from './Identity';
 import { Account } from './Account';
 import { CreateIdentity } from './CreateIdentity';
 import { SetupSeedPhrase } from './Setup';
+import { RecoverIdentity } from './RecoverIdentity';
+import { ConfirmIdentity } from './ConfirmIdentity';
 
 const container = document.getElementById('root');
 
@@ -23,8 +25,16 @@ const router = createBrowserRouter([
         element: <CreateIdentity />,
     },
     {
+        path: '/confirm-identity',
+        element: <ConfirmIdentity />
+    },
+    {
         path: '/identity',
         element: <Identity />,
+    },
+    {
+        path: '/recover',
+        element: <RecoverIdentity />
     },
     {
         path: '/account/:accountAddress',

--- a/examples/wallet/src/Index.tsx
+++ b/examples/wallet/src/Index.tsx
@@ -8,6 +8,7 @@ import { CreateIdentity } from './CreateIdentity';
 import { SetupSeedPhrase } from './Setup';
 import { RecoverIdentity } from './RecoverIdentity';
 import { ConfirmIdentity } from './ConfirmIdentity';
+import { NewIdentity } from './NewIdentity';
 
 const container = document.getElementById('root');
 
@@ -19,6 +20,10 @@ const router = createBrowserRouter([
     {
         path: '/',
         element: <SetupSeedPhrase />,
+    },
+    {
+        path: '/new',
+        element: <NewIdentity />,
     },
     {
         path: '/create',

--- a/examples/wallet/src/NewIdentity.tsx
+++ b/examples/wallet/src/NewIdentity.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export function NewIdentity() {
+    const navigate = useNavigate();
+    return (
+        <div>
+            <h3>Your Concordium Identity</h3>
+            <button onClick={() => navigate('/create')}>
+                Create new identity
+            </button>
+            <button onClick={() => navigate('/recover')}>
+                Recover existing identity
+            </button>
+        </div>
+    );
+}

--- a/examples/wallet/src/RecoverIdentity.tsx
+++ b/examples/wallet/src/RecoverIdentity.tsx
@@ -59,7 +59,7 @@ export function RecoverIdentity() {
         return null;
     }
 
-    async function createIdentity() {
+    async function recoverIdentity() {
         if (!dataLoaded || !seedPhrase) {
             return;
         }
@@ -144,7 +144,7 @@ export function RecoverIdentity() {
             </label>
             <button
                 disabled={createButtonDisabled && dataLoaded}
-                onClick={createIdentity}
+                onClick={recoverIdentity}
             >
                 Recover identity
             </button>

--- a/examples/wallet/src/RecoverIdentity.tsx
+++ b/examples/wallet/src/RecoverIdentity.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
     CryptographicParameters,
-    IdObjectRequestV1,
-    Versioned,
     IdentityRecoveryRequestInput,
     IdRecoveryRequest,
 } from '@concordium/web-sdk';
@@ -11,9 +9,7 @@ import { IdentityProviderWithMetadata } from './types';
 import {
     getCryptographicParameters,
     getIdentityProviders,
-    getRedirectUri,
     sendIdentityRecoveryRequest,
-    sendIdentityRequest,
 } from './util';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { Buffer } from 'buffer/';
@@ -42,7 +38,7 @@ export function RecoverIdentity() {
         cryptographicParameters !== undefined &&
         selectedIdentityProvider !== undefined;
     const seedPhrase = useMemo(() => localStorage.getItem(seedPhraseKey), []);
-    const [recoveryFailed, setRecoveryFailed] = useState<String>();
+    const [recoveryFailed, setRecoveryFailed] = useState<string>();
 
     useEffect(() => {
         getIdentityProviders().then((idps) => {
@@ -80,26 +76,31 @@ export function RecoverIdentity() {
         ) => {
             try {
                 const url = await sendIdentityRecoveryRequest(
-                e.data,
-                selectedIdentityProvider.metadata.recoveryStart
-            );
-            worker.removeEventListener('message', listener);
-            const response = await fetch(url);
+                    e.data,
+                    selectedIdentityProvider.metadata.recoveryStart
+                );
+                worker.removeEventListener('message', listener);
+                const response = await fetch(url);
 
-            if (response.ok) {
-                const identity = await response.json()
-                localStorage.setItem(identityObjectKey, JSON.stringify(identity.value));
-            }
+                if (response.ok) {
+                    const identity = await response.json();
+                    localStorage.setItem(
+                        identityObjectKey,
+                        JSON.stringify(identity.value)
+                    );
+                }
 
-            navigate('/identity');
+                navigate('/identity');
             } catch (e) {
-                setRecoveryFailed((e as any).message);
+                setRecoveryFailed((e as Error).message);
             }
         });
 
         const identityRequestInput: IdentityRecoveryRequestInput = {
             net: network,
-            seedAsHex: Buffer.from(mnemonicToSeedSync(seedPhrase)).toString('hex'),
+            seedAsHex: Buffer.from(mnemonicToSeedSync(seedPhrase)).toString(
+                'hex'
+            ),
             identityIndex: identityIndex,
             ipInfo: selectedIdentityProvider.ipInfo,
             globalContext: cryptographicParameters,
@@ -110,11 +111,13 @@ export function RecoverIdentity() {
 
     if (recoveryFailed) {
         return (
-        <div>
-            <h3>Recovery failed</h3>
-            <p>Error: {recoveryFailed}</p>
-            <button onClick={() => navigate("/create")} >Go to identity creation</button>
-        </div>
+            <div>
+                <h3>Recovery failed</h3>
+                <p>Error: {recoveryFailed}</p>
+                <button onClick={() => navigate('/create')}>
+                    Go to identity creation
+                </button>
+            </div>
         );
     }
 
@@ -146,7 +149,9 @@ export function RecoverIdentity() {
                 Recover identity
             </button>
             {createButtonDisabled && (
-                <div>Generating identity recovery request. This can take a while.</div>
+                <div>
+                    Generating identity recovery request. This can take a while.
+                </div>
             )}
         </div>
     );

--- a/examples/wallet/src/Setup.tsx
+++ b/examples/wallet/src/Setup.tsx
@@ -21,7 +21,7 @@ export function SetupSeedPhrase() {
 
         try {
             localStorage.setItem(seedPhraseKey, seedPhraseWords);
-            navigate('/create');
+            navigate('/new');
         } catch {
             alert('An invalid seed phrase was provided');
             return;

--- a/examples/wallet/src/constants.ts
+++ b/examples/wallet/src/constants.ts
@@ -5,6 +5,7 @@ export const network: Network = 'Testnet';
 // Local storage keys
 export const seedPhraseKey = 'seed-phrase';
 export const selectedIdentityProviderKey = 'selected-identity-provider';
+export const identityObjectKey = 'identity-object';
 
 // The indices of the identity and the credential deployed on the account.
 // These are static in this example as we only create a single identity and

--- a/examples/wallet/src/recovery-worker.ts
+++ b/examples/wallet/src/recovery-worker.ts
@@ -1,6 +1,6 @@
 import {
     createIdentityRecoveryRequest,
-    IdentityRecoveryRequestInput
+    IdentityRecoveryRequestInput,
 } from '@concordium/web-sdk';
 
 self.onmessage = (e: MessageEvent<IdentityRecoveryRequestInput>) => {

--- a/examples/wallet/src/recovery-worker.ts
+++ b/examples/wallet/src/recovery-worker.ts
@@ -1,0 +1,9 @@
+import {
+    createIdentityRecoveryRequest,
+    IdentityRecoveryRequestInput
+} from '@concordium/web-sdk';
+
+self.onmessage = (e: MessageEvent<IdentityRecoveryRequestInput>) => {
+    const recoveryRequest = createIdentityRecoveryRequest(e.data);
+    self.postMessage(recoveryRequest);
+};

--- a/examples/wallet/src/util.ts
+++ b/examples/wallet/src/util.ts
@@ -18,6 +18,7 @@ import {
     buildBasicAccountSigner,
     serializeCredentialDeploymentPayload,
     signTransaction,
+    IdRecoveryRequest,
 } from '@concordium/web-sdk';
 import {
     IdentityProviderWithMetadata,
@@ -40,7 +41,7 @@ import { filterRecord, mapRecord } from '../../../packages/sdk/lib/esm/util';
 // We dynamically resolve this as the hosted server can run at different
 // locations.
 export function getRedirectUri() {
-    return window.location.origin + '/identity';
+    return window.location.origin + '/confirm-identity';
 }
 
 /**
@@ -295,6 +296,27 @@ export async function sendIdentityRequest(
     }
 }
 
+/**
+ * Sends an identity recovery object request, which is the start of the identity recovery flow, to the
+ * provided URL.
+ * @param recoveryRequest the identity recovery request to send
+ * @param baseUrl the identity recovery start URL
+ * @returns the URL that the identity provider redirects to. This URL should point to to versioned identity object.
+ */
+export async function sendIdentityRecoveryRequest(
+    recoveryRequest: IdRecoveryRequest,
+    baseUrl: string
+) {
+    const searchParams = new URLSearchParams({ state: JSON.stringify({idRecoveryRequest: recoveryRequest})});
+    const url = `${baseUrl}?${searchParams.toString()}`;
+    const response = await fetch(url);
+
+    if (response.ok) {
+        return response.url;
+    } else {
+        throw new Error((await response.json()).message);
+    }
+}
 /**
  * Gets information about an account from the node. The method will continue to poll for some time
  * as the account might not be in a block when this is first called.

--- a/examples/wallet/src/util.ts
+++ b/examples/wallet/src/util.ts
@@ -307,7 +307,9 @@ export async function sendIdentityRecoveryRequest(
     recoveryRequest: IdRecoveryRequest,
     baseUrl: string
 ) {
-    const searchParams = new URLSearchParams({ state: JSON.stringify({idRecoveryRequest: recoveryRequest})});
+    const searchParams = new URLSearchParams({
+        state: JSON.stringify({ idRecoveryRequest: recoveryRequest }),
+    });
     const url = `${baseUrl}?${searchParams.toString()}`;
     const response = await fetch(url);
 


### PR DESCRIPTION
## Purpose

- Add Recovery to wallet example.

## Changes

- Added ConfirmIdentity page, which is the new target of the identity provider callback, which waits until confirmation, then saves the identity object and continues to the identity page.
- Added RecoverIdentity page, which performs recovery, saves the identity object and continues to the identity page.
- Identity page no longer fetches the identity, but gets it from storage instead.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
