### PR TITLE
Example wallet, if account exists during recovery go to account page

### DIFF
--- a/examples/wallet/src/RecoverIdentity.tsx
+++ b/examples/wallet/src/RecoverIdentity.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+    ConcordiumHdWallet,
+    CredentialRegistrationId,
     CryptographicParameters,
+    getAccountAddress,
     IdentityRecoveryRequestInput,
     IdRecoveryRequest,
 } from '@concordium/web-sdk';
 import { IdentityProviderWithMetadata } from './types';
 import {
+    client,
+    getCredentialId,
     getCryptographicParameters,
     getIdentityProviders,
     sendIdentityRecoveryRequest,
@@ -88,6 +93,16 @@ export function RecoverIdentity() {
                         identityObjectKey,
                         JSON.stringify(identity.value)
                     );
+
+                    // Check if the account exists, in which case we go directly to the account page.
+                    const credId = getCredentialId(seedPhrase, selectedIdentityProvider.ipInfo.ipIdentity,cryptographicParameters)
+                    try {
+                        const accountInfo = await client.getAccountInfo(CredentialRegistrationId.fromHexString(credId));
+                        navigate(`/account/${accountInfo.accountAddress.address}`);
+                        return;
+                    } catch {
+                        // We assume that the account does not exist, so we continue to the identity page
+                    }
                 }
 
                 navigate('/identity');

--- a/examples/wallet/src/util.ts
+++ b/examples/wallet/src/util.ts
@@ -19,6 +19,7 @@ import {
     serializeCredentialDeploymentPayload,
     signTransaction,
     IdRecoveryRequest,
+    CryptographicParameters,
 } from '@concordium/web-sdk';
 import {
     IdentityProviderWithMetadata,
@@ -85,6 +86,25 @@ export function getAccountSigningKey(
             identityProviderIdentity,
             identityIndex,
             credNumber
+        )
+        .toString('hex');
+}
+
+/**
+ * Derives a credential (registration) id.
+ *
+ * For this example we only work with a single identity and a single account, therefore
+ * those indices are hardcoded to 0. In a production wallet any number of identities and
+ * accounts could be created.
+ */
+export function getCredentialId(seedPhrase: string, identityProviderIdentity: number, global: CryptographicParameters) {
+    const wallet = ConcordiumHdWallet.fromSeedPhrase(seedPhrase, network);
+    return wallet
+        .getCredentialId(
+            identityProviderIdentity,
+            identityIndex,
+            credNumber,
+            global
         )
         .toString('hex');
 }


### PR DESCRIPTION
## Purpose

Add feature that I added to android example wallet.

## Changes

During recovery, check if the account exists, in which case go to the account page.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

