### PR TITLE
Fix the return type of getAccountTransactionHandler

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.3.1
+
+### Fixed
+
+- Return type of `getAccountTransactionHandler`.
+
 ## 7.3.0
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "7.3.0",
+    "version": "7.3.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/accountTransactions.ts
+++ b/packages/sdk/src/accountTransactions.ts
@@ -570,9 +570,17 @@ export class ConfigureDelegationHandler
     }
 }
 
-export function getAccountTransactionHandler(
-    type: AccountTransactionType
-): AccountTransactionHandler;
+export type AccountTransactionPayloadJSON =
+    | SimpleTransferPayloadJSON
+    | SimpleTransferWithMemoPayloadJSON
+    | DeployModulePayloadJSON
+    | InitContractPayloadJSON
+    | UpdateContractPayloadJSON
+    | UpdateCredentialsPayload
+    | RegisterDataPayloadJSON
+    | ConfigureDelegationPayloadJSON
+    | ConfigureBakerPayloadJSON;
+
 export function getAccountTransactionHandler(
     type: AccountTransactionType.Transfer
 ): SimpleTransferHandler;
@@ -600,6 +608,12 @@ export function getAccountTransactionHandler(
 export function getAccountTransactionHandler(
     type: AccountTransactionType.ConfigureBaker
 ): ConfigureBakerHandler;
+export function getAccountTransactionHandler(
+    type: AccountTransactionType
+): AccountTransactionHandler<
+    AccountTransactionPayload,
+    AccountTransactionPayloadJSON
+>;
 export function getAccountTransactionHandler(
     type: AccountTransactionType
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Purpose

The function `getAccountTransactionHandler` is currently returning an `AccountTransactionHandler` that has the wrong `JSONType`. The function will also never return a more specific `AccountTransactionHandler` due to the ordering of the definitions.

## Changes

Changes the return type and fixes the ordering.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.