### PR TITLE
Fix CIS-4 nonce serialization and failing test

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `Parameter.parseWithSchemaTypeBase64` and `Parameter.parseWithSchemaType` to
   help parsing smart contract parameters into typed structures.
 
+### Fixed
+
+- Serialization of nonces with `serializeCIS4RevocationDataHolder` to serialize as little endian.
+
 ## 7.3.2
 
 ### Added

--- a/packages/sdk/src/cis4/util.ts
+++ b/packages/sdk/src/cis4/util.ts
@@ -696,7 +696,7 @@ export function serializeCIS4RevocationDataHolder(
         data.signingData.contractAddress
     );
     const entrypoint = serializeReceiveHookName(data.signingData.entrypoint);
-    const nonce = encodeWord64(data.signingData.nonce);
+    const nonce = encodeWord64(data.signingData.nonce, true);
     const timestamp = serializeDate(data.signingData.timestamp);
     const reason = makeSerializeOptional<string>(serializeReason)(data.reason);
 

--- a/packages/sdk/test/client/cis2Util.test.ts
+++ b/packages/sdk/test/client/cis2Util.test.ts
@@ -419,7 +419,7 @@ test('Custom CIS2 events are deserialized correctly', async () => {
 
 test('CIS2 events are deserialized correctly from a BlockItemSummary', async () => {
     const blockItemSummary = v8.deserialize(
-        fs.readFileSync('./test/client/resources/csi2-block-item-summary.bin')
+        fs.readFileSync('./test/client/resources/cis2-block-item-summary.bin')
     ) as BlockItemSummary;
     const events = deserializeCIS2EventsFromSummary(blockItemSummary);
 


### PR DESCRIPTION
## Purpose

The CIS4 `SigningData` nonces currently incorrectly serialize as big endian.

Furthermore, there is a file name typo in a test.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.