### PR TITLE
Fix deployments

### DIFF
--- a/.github/workflows/deploy-ccd-js-gen.yml
+++ b/.github/workflows/deploy-ccd-js-gen.yml
@@ -92,7 +92,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
-        environment: deploy-ccd-js-gen
+        environment: deploy
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -120,6 +120,12 @@ jobs:
                   artifacts: |
                       packages/*
                   draft: true
+
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: yarn
+                  registry-url: 'https://registry.npmjs.org'
 
             - name: Publish to NPM
               run: npm publish --workspace packages/ccd-js-gen

--- a/.github/workflows/deploy-rust-bindings.yml
+++ b/.github/workflows/deploy-rust-bindings.yml
@@ -92,7 +92,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
-        environment: deploy-rust-bindings
+        environment: deploy
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -120,6 +120,12 @@ jobs:
                   artifacts: |
                       packages/*
                   draft: true
+
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: yarn
+                  registry-url: 'https://registry.npmjs.org'
 
             - name: Publish to NPM
               run: npm publish --workspace packages/rust-bindings

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -157,7 +157,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
-        environment: deploy-sdk
+        environment: deploy
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4
@@ -185,6 +185,12 @@ jobs:
                   artifacts: |
                       packages/*
                   draft: true
+
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: yarn
+                  registry-url: 'https://registry.npmjs.org'
 
             - name: Publish to NPM
               run: npm publish --workspace packages/sdk


### PR DESCRIPTION
## Purpose

Small fix to deployments.

It seems that they can all use the same environment, making maintenance easier. We also need to add the registry field in order to deploy to npm see:

https://github.com/npm/cli/issues/6184