### PR TITLE
Fixing deployment, fourth try is the charm :   ^)

### DIFF
--- a/.github/workflows/deploy-ccd-js-gen.yml
+++ b/.github/workflows/deploy-ccd-js-gen.yml
@@ -127,7 +127,13 @@ jobs:
                   cache: yarn
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Publish to NPM
-              run: npm publish --workspace packages/ccd-js-gen
+            - name: Setup .yarnrc.yml
+              run: |
+                yarn config set npmRegistryServer "https://registry.npmjs.org"
+                yarn config set npmAlwaysAuth true
+                yarn config set npmAuthToken $NPM_AUTH_TOKEN
               env:
-                  NODE_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
+                NPM_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
+
+            - name: Publish to NPM
+              run: yarn workspace @concordium/ccd-js-gen npm publish --access public

--- a/.github/workflows/deploy-rust-bindings.yml
+++ b/.github/workflows/deploy-rust-bindings.yml
@@ -127,7 +127,13 @@ jobs:
                   cache: yarn
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Publish to NPM
-              run: npm publish --workspace packages/rust-bindings
+            - name: Setup .yarnrc.yml
+              run: |
+                yarn config set npmRegistryServer "https://registry.npmjs.org"
+                yarn config set npmAlwaysAuth true
+                yarn config set npmAuthToken $NPM_AUTH_TOKEN
               env:
-                  NODE_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
+                NPM_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
+
+            - name: Publish to NPM
+              run: yarn workspace @concordium/rust-bindings npm publish --access public

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -201,4 +201,4 @@ jobs:
                 NPM_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
 
             - name: Publish to NPM
-              run: yarn workspace @concordium/web-sdk npm publish
+              run: yarn workspace @concordium/web-sdk npm publish --access public


### PR DESCRIPTION
Got new error, so authentication should work out now. This fixes the fact that the default behaviour is to publish a private package, but ours is public, so that gave a new error.
The `npm_token` was wrong...