### PR TITLE
Support company attributes in SDK

### DIFF
--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+
+- Support creating account with company related attributes: `lei`, `legalName`, `legalCountry`, `businessNumber` and `registrationAuth`, allow for company account creation.
+
 ## 3.1.0
 
 ### Added

--- a/packages/rust-bindings/CHANGELOG.md
+++ b/packages/rust-bindings/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.2.0
 
+### Added
+
 - Support creating account with company related attributes: `lei`, `legalName`, `legalCountry`, `businessNumber` and `registrationAuth`, allow for company account creation.
 
 ## 3.1.0

--- a/packages/rust-bindings/package.json
+++ b/packages/rust-bindings/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/rust-bindings",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.5.0
+
+- Support company related attributes: `lei`, `legalName`, `legalCountry`, `businessNumber` and `registrationAuth`, allow for company account creation using the SDK.
+
 ## 7.4.0
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 7.5.0
 
-- Support company related attributes: `lei`, `legalName`, `legalCountry`, `businessNumber` and `registrationAuth`, allow for company account creation using the SDK.
+### Added
+
+- Bumped @concordium/rust-bindings to 3.2.0: Support company related attributes: `lei`, `legalName`, `legalCountry`, `businessNumber` and `registrationAuth`, allow for company account creation using the SDK.
 
 ## 7.4.0
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "7.4.0",
+    "version": "7.5.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -127,7 +127,7 @@ export enum AttributesKeys {
     legalName,
     legalCountry,
     businessNumber,
-    registrationAuth
+    registrationAuth,
 }
 
 export type Attributes = {
@@ -149,11 +149,11 @@ export enum AttributeKeyString {
     idDocExpiresAt = 'idDocExpiresAt',
     nationalIdNo = 'nationalIdNo',
     taxIdNo = 'taxIdNo',
-    lei = "lei",
-    legalName = "legalName",
-    legalCountry = "legalCountry",
-    businessNumber = "businessNumber",
-    registrationAuth = "registrationAuth"
+    lei = 'lei',
+    legalName = 'legalName',
+    legalCountry = 'legalCountry',
+    businessNumber = 'businessNumber',
+    registrationAuth = 'registrationAuth',
 }
 
 export enum Sex {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -123,6 +123,11 @@ export enum AttributesKeys {
     idDocExpiresAt,
     nationalIdNo,
     taxIdNo,
+    lei,
+    legalName,
+    legalCountry,
+    businessNumber,
+    registrationAuth
 }
 
 export type Attributes = {
@@ -144,6 +149,11 @@ export enum AttributeKeyString {
     idDocExpiresAt = 'idDocExpiresAt',
     nationalIdNo = 'nationalIdNo',
     taxIdNo = 'taxIdNo',
+    lei = "lei",
+    legalName = "legalName",
+    legalCountry = "legalCountry",
+    businessNumber = "businessNumber",
+    registrationAuth = "registrationAuth"
 }
 
 export enum Sex {


### PR DESCRIPTION
## Purpose

Closes #351 and is required for the SDK to support account creation from company IDs.

## Changes

- Update `deps/concordium-base` which now have the company attributes.
- Prepare release of `rust-bindings` and `web-sdk` with company attribute support.
