### PR TITLE
Add legal country for set and not-set membership proofs

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Fixed
+### Added
 
-- Add `legalCountry` as allowed attribute for set/not-set memebership proofs.
+- Add `legalCountry` as an allowed attribute for set/not-set membership proofs.
 
 ## 8.0.1
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Add `legalCountry` as allowed attribute for set/not-set memebership proofs.
+
 ## 8.0.1
 
 ### Breaking changes

--- a/packages/sdk/src/id/idProofTypes.ts
+++ b/packages/sdk/src/id/idProofTypes.ts
@@ -45,4 +45,10 @@ export const attributesWithRange: AttributeKey[] = ['dob', 'idDocIssuedAt', 'idD
 /**
  * The attributes that can be used for (non)membership statements
  */
-export const attributesWithSet: AttributeKey[] = ['countryOfResidence', 'nationality', 'idDocType', 'idDocIssuer'];
+export const attributesWithSet: AttributeKey[] = [
+    'countryOfResidence',
+    'nationality',
+    'idDocType',
+    'idDocIssuer',
+    'legalCountry',
+];

--- a/packages/sdk/src/id/idProofs.ts
+++ b/packages/sdk/src/id/idProofs.ts
@@ -127,6 +127,11 @@ function verifySetStatement(statement: MembershipStatement | NonMembershipStatem
                 throw new Error('idDocType values must be one from IdDocType enum');
             }
             break;
+        case AttributeKeyString.legalCountry:
+            if (!statement.set.every(isISO3166_1Alpha2)) {
+                throw new Error(statement.attributeTag + ' values must be ISO3166-1 Alpha 2 codes in upper case');
+            }
+            break;
         default:
             throw new Error(statement.attributeTag + ' is not allowed to be used in ' + typeName + ' statements');
     }

--- a/packages/sdk/test/ci/idProofs.test.ts
+++ b/packages/sdk/test/ci/idProofs.test.ts
@@ -74,7 +74,7 @@ test('Upper bound must be greater than lower bound for attribute statement', () 
 test('Unknown attribute tags are rejected', () => {
     const builder = new IdStatementBuilder(true);
     expect(() => builder.addMembership(-1 as unknown as AttributesKeys, ['DK'])).toThrow();
-    expect(() => builder.addMembership(15 as unknown as AttributesKeys, ['DK'])).toThrow();
+    expect(() => builder.addMembership(16 as unknown as AttributesKeys, ['DK'])).toThrow();
     expect(() => builder.addMembership(1000 as unknown as AttributesKeys, ['DK'])).toThrow();
 });
 


### PR DESCRIPTION
## Purpose

The browser wallet calls the `verifySetStatement` function to exclude all the attributes not allowed for these types of proofs. The `LegalCountry` attribute (from company IDs) has been added recently. Propagating this addition to the SDK.

Related: https://github.com/Concordium/concordium-browser-wallet/issues/484
Related: https://github.com/Concordium/concordium-base/pull/542

## Changes

- Add legal country for set and not-set membership proofs