### PR TITLE
[BRO-48] Enable ZK proof generations with new company identities

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Add `legalCountry` as an allowed attribute for set/not-set membership proofs.
-- Added `AttributeKey` check for `IDENTITY_SUBJECT_SCHEMA`. Implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
+- `IDENTITY_SUBJECT_SCHEMA` implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
 
 ## 8.0.1
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Add `legalCountry` as an allowed attribute for set/not-set membership proofs.
-- added `AttributeKey` check for `IDENTITY_SUBJECT_SCHEMA`. Implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
+- Added `AttributeKey` check for `IDENTITY_SUBJECT_SCHEMA`. Implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
 
 ## 8.0.1
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Add `legalCountry` as an allowed attribute for set/not-set membership proofs.
-- `IDENTITY_SUBJECT_SCHEMA` implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
+- Add attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, and `registrationAuth` to `IDENTITY_SUBJECT_SCHEMA`.
 
 ## 8.0.1
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `legalCountry` as an allowed attribute for set/not-set membership proofs.
+- added `AttributeKey` check for `IDENTITY_SUBJECT_SCHEMA`. Implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
 
 ## 8.0.1
 

--- a/packages/sdk/src/web3-id/types.ts
+++ b/packages/sdk/src/web3-id/types.ts
@@ -100,22 +100,7 @@ export type CredentialSchemaSubject = {
     required: string[];
 };
 
-type Override<Type, NewType> = Omit<Type, keyof NewType> & NewType;
-
-type IdCredentialSchemaSubject = Override<
-    CredentialSchemaSubject,
-    {
-        properties: {
-            id: IdDetails;
-            attributes: Override<
-                CredentialSchemaAttributes,
-                { properties: Record<AttributeKey, CredentialSchemaProperty | TimestampProperty> }
-            >;
-        };
-    }
->;
-
-export const IDENTITY_SUBJECT_SCHEMA: IdCredentialSchemaSubject = {
+export const IDENTITY_SUBJECT_SCHEMA: CredentialSchemaSubject = {
     type: 'object',
     properties: {
         id: {

--- a/packages/sdk/src/web3-id/types.ts
+++ b/packages/sdk/src/web3-id/types.ts
@@ -87,7 +87,7 @@ type CredentialSchemaAttributes = {
     title?: string;
     description?: string;
     type: 'object';
-    properties: Record<string, CredentialSchemaProperty | TimestampProperty>;
+    properties: Record<AttributeKey, CredentialSchemaProperty | TimestampProperty>;
     required: string[];
 };
 
@@ -163,6 +163,26 @@ export const IDENTITY_SUBJECT_SCHEMA: CredentialSchemaSubject = {
                     title: 'Tax ID Number',
                     type: 'string',
                 },
+                lei: {
+                    title: 'Legal Entity Identifier (LEI)',
+                    type: 'string'
+                },
+                legalName: {
+                    title: 'Legal Name',
+                    type: 'string',
+                },
+                legalCountry: {
+                    title: 'Legal Country',
+                    type: 'string',
+                },
+                businessNumber: {
+                    title: 'Business Number',
+                    type: 'string',
+                },
+                registrationAuth: {
+                    title: 'Registration Authority',
+                    type: 'string',
+                }
             },
             required: [],
         },

--- a/packages/sdk/src/web3-id/types.ts
+++ b/packages/sdk/src/web3-id/types.ts
@@ -87,7 +87,7 @@ type CredentialSchemaAttributes = {
     title?: string;
     description?: string;
     type: 'object';
-    properties: Record<AttributeKey, CredentialSchemaProperty | TimestampProperty>;
+    properties: Record<string, CredentialSchemaProperty | TimestampProperty>;
     required: string[];
 };
 
@@ -100,7 +100,22 @@ export type CredentialSchemaSubject = {
     required: string[];
 };
 
-export const IDENTITY_SUBJECT_SCHEMA: CredentialSchemaSubject = {
+type Override<Type, NewType> = Omit<Type, keyof NewType> & NewType;
+
+type IdCredentialSchemaSubject = Override<
+    CredentialSchemaSubject,
+    {
+        properties: {
+            id: IdDetails;
+            attributes: Override<
+                CredentialSchemaAttributes,
+                { properties: Record<AttributeKey, CredentialSchemaProperty | TimestampProperty> }
+            >;
+        };
+    }
+>;
+
+export const IDENTITY_SUBJECT_SCHEMA: IdCredentialSchemaSubject = {
     type: 'object',
     properties: {
         id: {
@@ -165,7 +180,7 @@ export const IDENTITY_SUBJECT_SCHEMA: CredentialSchemaSubject = {
                 },
                 lei: {
                     title: 'Legal Entity Identifier (LEI)',
-                    type: 'string'
+                    type: 'string',
                 },
                 legalName: {
                     title: 'Legal Name',
@@ -182,7 +197,7 @@ export const IDENTITY_SUBJECT_SCHEMA: CredentialSchemaSubject = {
                 registrationAuth: {
                     title: 'Registration Authority',
                     type: 'string',
-                }
+                },
             },
             required: [],
         },


### PR DESCRIPTION
## Purpose

Web-3Id proof rely on keys in IDENTITY_SUBJECT_SCHEMA.
If key not listed in schema it throws error `Statement is not well-formed: Unknown attributeTag:`
Also this keys used to display attribute key name at UI

## Changes
Implemented missed attributes `lei`, `legalName`, `legalCountry`, `businessNumber`, `registrationAuth`
