### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/pages/documentation.md
+++ b/docs/pages/documentation.md
@@ -2,7 +2,7 @@ This is the documentation for the Concordium Javascript SDK. Here we cover
 the JS wrappers for interacting with the Concordium nodes.
 
 Most functionality is provideded by the
-[GRPC-Client](../classes/grpc.ConcordiumGRPCClient.html)
+[GRPC-Client](./classes/grpc.ConcordiumGRPCClient.html)
 however there exists additional helper functions, for example to help with
 creating {@page transactions.md transactions}, or {@page identity-proofs.md
 creating identity proof statements}, or {@page utility-functions.md general

--- a/docs/pages/misc-pages/grpc-v1.md
+++ b/docs/pages/misc-pages/grpc-v1.md
@@ -7,14 +7,14 @@ JSON-RPC server](https://github.com/Concordium/concordium-json-rpc)
 Currently the client only supports the following entrypoints, with the same
 interface as the grpc v1 node client:
 
-- [sendTransaction](./grpc-v1.md#send-account-transaction)
-- [getTransactionStatus](./grpc-v1.md#gettransactionstatus)
-- [getInstanceInfo](./grpc-v1.md#getInstanceInfo)
-- [getConsensusStatus](./grpc-v1.md#getconsensusstatus)
-- [getAccountInfo](./grpc-v1.md#getAccountInfo)
-- [getCryptographicParameters](./grpc-v1.md#getcryptographicparameters)
-- [invokeContract](./grpc-v1.md#invokecontract)
-- [getModuleSource](./grpc-v1.md#getModuleSource)
+- [sendTransaction](#send-account-transaction)
+- [getTransactionStatus](#gettransactionstatus)
+- [getInstanceInfo](#getinstanceinfo)
+- [getConsensusStatus](#getconsensusstatus)
+- [getAccountInfo](#getaccountinfo)
+- [getCryptographicParameters](#getcryptographicparameters)
+- [invokeContract](#invokecontract)
+- [getModuleSource](#getmodulesource)
 
 **Table of Contents:**
 


### PR DESCRIPTION
## Purpose

Fix some broken links in the documentation:

## Changes

On page `https://docs.concordium.com/concordium-node-sdk-js/index.html` `GRPC-Client` has link `https://docs.concordium.com/classes/grpc.ConcordiumGRPCClient.html` trying to change it to `https://docs.concordium.com/concordium-node-sdk-js/classes/grpc.ConcordiumGRPCClient.html`.

On page `https://docs.concordium.com/concordium-node-sdk-js/pages/misc-pages/grpc-v1.html` the list of links at the top
<img width="197" alt="image" src="https://github.com/user-attachments/assets/c178f1aa-c387-402b-aa5a-d4688a14ad8f" />
Links to `.md` instead of `.html`.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

