### PR TITLE
Fix transfer example for the preliminary plt node version

### DIFF
--- a/examples/nodejs/plt/v1/burn.ts
+++ b/examples/nodejs/plt/v1/burn.ts
@@ -1,17 +1,10 @@
-import {
-    AccountAddress,
-    AccountTransactionType,
-    buildAccountSigner,
-    parseWallet,
-    serializeAccountTransactionPayload,
-} from '@concordium/web-sdk';
+import { AccountTransactionType, serializeAccountTransactionPayload } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { TokenAmount, TokenId, V1 } from '@concordium/web-sdk/plt';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
-import { readFileSync } from 'node:fs';
 
-import { parseEndpoint } from '../../shared/util.js';
+import { parseEndpoint, parseKeysFile } from '../../shared/util.js';
 
 const cli = meow(
     `
@@ -67,9 +60,7 @@ const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.crea
 
     if (walletFile !== undefined) {
         // Read wallet-file
-        const wallet = parseWallet(readFileSync(walletFile, 'utf8'));
-        const sender = AccountAddress.fromBase58(wallet.value.address);
-        const signer = buildAccountSigner(wallet);
+        const [sender, signer] = parseKeysFile(walletFile);
 
         try {
             // create the token instance

--- a/examples/nodejs/plt/v1/mint.ts
+++ b/examples/nodejs/plt/v1/mint.ts
@@ -1,17 +1,10 @@
-import {
-    AccountAddress,
-    AccountTransactionType,
-    buildAccountSigner,
-    parseWallet,
-    serializeAccountTransactionPayload,
-} from '@concordium/web-sdk';
+import { AccountTransactionType, serializeAccountTransactionPayload } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { TokenAmount, TokenId, V1 } from '@concordium/web-sdk/plt';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
-import { readFileSync } from 'node:fs';
 
-import { parseEndpoint } from '../../shared/util.js';
+import { parseEndpoint, parseKeysFile } from '../../shared/util.js';
 
 const cli = meow(
     `
@@ -67,13 +60,12 @@ const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.crea
 
     if (walletFile !== undefined) {
         // Read wallet-file
-        const wallet = parseWallet(readFileSync(walletFile, 'utf8'));
-        const sender = AccountAddress.fromBase58(wallet.value.address);
-        const signer = buildAccountSigner(wallet);
+        const [sender, signer] = parseKeysFile(walletFile);
 
         try {
             // create the token instance
             const token = await V1.Token.fromId(client, tokenId);
+            console.log(token.info.state.issuer)
 
             // Only the token issuer can mint tokens
             console.log(`Attempting to mint ${tokenAmount.toString()} ${tokenId.toString()} tokens...`);

--- a/examples/nodejs/plt/v1/mint.ts
+++ b/examples/nodejs/plt/v1/mint.ts
@@ -65,7 +65,6 @@ const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.crea
         try {
             // create the token instance
             const token = await V1.Token.fromId(client, tokenId);
-            console.log(token.info.state.issuer)
 
             // Only the token issuer can mint tokens
             console.log(`Attempting to mint ${tokenAmount.toString()} ${tokenId.toString()} tokens...`);

--- a/examples/nodejs/plt/v1/modify-list.ts
+++ b/examples/nodejs/plt/v1/modify-list.ts
@@ -1,17 +1,10 @@
-import {
-    AccountAddress,
-    AccountTransactionType,
-    buildAccountSigner,
-    parseWallet,
-    serializeAccountTransactionPayload,
-} from '@concordium/web-sdk';
+import { AccountAddress, AccountTransactionType, serializeAccountTransactionPayload } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { TokenId, V1 } from '@concordium/web-sdk/plt';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
-import { readFileSync } from 'node:fs';
 
-import { parseEndpoint } from '../../shared/util.js';
+import { parseEndpoint, parseKeysFile } from '../../shared/util.js';
 
 const cli = meow(
     `
@@ -89,9 +82,7 @@ const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.crea
 
     if (walletFile !== undefined) {
         // Read wallet-file
-        const wallet = parseWallet(readFileSync(walletFile, 'utf8'));
-        const sender = AccountAddress.fromBase58(wallet.value.address);
-        const signer = buildAccountSigner(wallet);
+        const [sender, signer] = parseKeysFile(walletFile);
 
         try {
             // create the token instance

--- a/examples/nodejs/plt/v1/transfer.ts
+++ b/examples/nodejs/plt/v1/transfer.ts
@@ -1,17 +1,10 @@
-import {
-    AccountAddress,
-    AccountTransactionType,
-    buildAccountSigner,
-    parseWallet,
-    serializeAccountTransactionPayload,
-} from '@concordium/web-sdk';
+import { AccountAddress, AccountTransactionType, serializeAccountTransactionPayload } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
-import { CborMemo, TokenAmount, TokenId, V1 } from '@concordium/web-sdk/plt';
+import { CborMemo, TokenAmount, TokenId, TokenInfo, V1 } from '@concordium/web-sdk/plt';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
-import { readFileSync } from 'node:fs';
 
-import { parseEndpoint } from '../../shared/util.js';
+import { parseEndpoint, parseKeysFile } from '../../shared/util.js';
 
 const cli = meow(
     `
@@ -84,17 +77,17 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
     console.log('Specified transfer:', JSON.stringify(transfer, null, 2));
 
     if (cli.flags.walletFile !== undefined) {
-        // Read wallet-file
-        const walletFile = readFileSync(cli.flags.walletFile, 'utf8');
-        const wallet = parseWallet(walletFile);
-        const sender = AccountAddress.fromBase58(wallet.value.address);
-        const signer = buildAccountSigner(wallet);
+        const [sender, signer] = parseKeysFile(cli.flags.walletFile);
 
         // From a service perspective:
         // create the token instance
-        const token = await V1.Token.fromId(client, tokenSymbol);
-        const transaction = await V1.Token.transfer(token, sender, transfer, signer);
-        console.log(`Transaction submitted with hash: ${transaction}`);
+        try {
+            const token = await V1.Token.fromId(client, tokenSymbol);
+            const transaction = await V1.Token.transfer(token, sender, transfer, signer);
+            console.log(`Transaction submitted with hash: ${transaction}`);
+        } catch (e) {
+            console.error(e);
+        }
     } else {
         // Or from a wallet perspective:
         // Create transfer payload

--- a/examples/nodejs/plt/v1/transfer.ts
+++ b/examples/nodejs/plt/v1/transfer.ts
@@ -1,6 +1,6 @@
 import { AccountAddress, AccountTransactionType, serializeAccountTransactionPayload } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
-import { CborMemo, TokenAmount, TokenId, TokenInfo, V1 } from '@concordium/web-sdk/plt';
+import { CborMemo, TokenAmount, TokenId, V1 } from '@concordium/web-sdk/plt';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -39,6 +39,8 @@
 - `Token`, which is a client for interacting with PLTs from arbitrary token modules and for V1 PLTs:
   - `V1.Token` which is a client for interacting with V1 PLTs as a token holder.
   - `V1.Governance` which is a client for interacting with V1 PLTs from the perspective of token governance.
+- function `parseSimpleWallet` which parses a `SimpleWalletFormat` (also a subset of `GenesisFormat`), which can be used
+  with `buildAccountSigner`
 
 ## 9.1.0
 

--- a/packages/sdk/src/plt/Token.ts
+++ b/packages/sdk/src/plt/Token.ts
@@ -226,7 +226,7 @@ export async function governanceTransaction(
     expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
 ): Promise<TransactionHash.Type> {
     // Check if the sender is the token issuer
-    if (sender !== token.info.state.issuer) {
+    if (!AccountAddress.equals(sender, token.info.state.issuer)) {
         throw new UnauthorizedGovernanceOperationError(sender);
     }
     const { nonce } = await token.grpc.getNextAccountNonce(sender);

--- a/packages/sdk/src/plt/Token.ts
+++ b/packages/sdk/src/plt/Token.ts
@@ -148,7 +148,7 @@ export function fromInfo(grpc: ConcordiumGRPCClient, tokenInfo: TokenInfo): Toke
  * the expected module reference.
  */
 export function verify(token: Token, expected: TokenModuleReference.Type): void {
-    if (token.info.state.moduleRef !== expected) {
+    if (!TokenModuleReference.equals(token.info.state.moduleRef, expected)) {
         throw new ModuleVersionMismatchError(expected, token.info.state.moduleRef);
     }
 }

--- a/packages/sdk/src/plt/v1/Token.ts
+++ b/packages/sdk/src/plt/v1/Token.ts
@@ -59,7 +59,7 @@ export class NotAllowedError extends TokenError {
 
     /**
      * Constructs a new NotAllowedError.
-     * @param {AccountAddress.Type} address - The account address of the receiver.
+     * @param {AccountAddress.Type} receiver - The account address of the receiver.
      */
     constructor(public readonly receiver: AccountAddress.Type) {
         super(
@@ -246,9 +246,13 @@ export async function transfer(
     sender: AccountAddress.Type,
     payload: TokenTransfer | [TokenTransfer],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    skipValidation = true
 ): Promise<TransactionHash.Type> {
-    await validateTransfer(token, sender, payload);
+    // TODO: this should be removed when the validation function does not fail due to unimplemented grpc endpoints
+    if (!skipValidation) {
+        await validateTransfer(token, sender, payload);
+    }
 
     const ops: TokenHolderOperation[] = [payload].flat().map((p) => ({ [TokenOperationType.Transfer]: p }));
     const encoded = createTokenHolderPayload(token.info.id, ops);

--- a/packages/sdk/src/plt/v1/types.ts
+++ b/packages/sdk/src/plt/v1/types.ts
@@ -6,7 +6,7 @@ import { Cbor, CborMemo, TokenAmount, TokenId, TokenModuleReference } from '../i
  * The module reference for the V1 token.
  */
 export const TOKEN_MODULE_REF = TokenModuleReference.fromHexString(
-    '0EA8121FDC427C9B23AE5E26CFEA3E8CBB544C84AA0C82DB26A85949CE1706C3' // TODO: get the correct module reference...
+    'af5684e70c1438e442066d017e4410af6da2b53bfa651a07d81efa2aa668db20'
 );
 
 /**

--- a/packages/sdk/src/signHelpers.ts
+++ b/packages/sdk/src/signHelpers.ts
@@ -38,15 +38,41 @@ export interface WithAccountKeys {
     accountKeys: AccountKeys;
 }
 
+export type SimpleWalletFormat = WithAccountKeys & {
+    address: Base58String;
+    credentials: Record<number, HexString>;
+};
+
+export type GenesisFormat = SimpleWalletFormat;
+
 export interface WalletExportFormat {
     type: string;
     v: number;
     environment: string;
-    value: {
-        accountKeys: AccountKeys;
-        address: Base58String;
-        credentials: Record<number, HexString>;
-    };
+    value: SimpleWalletFormat;
+}
+
+function validateSimpleWallet(wallet: SimpleWalletFormat): void {
+    if (typeof wallet.address !== 'string') {
+        throw Error('Expected field "address" to be of type "string" but was of type "' + typeof wallet.address + '"');
+    }
+    if (typeof wallet.credentials !== 'object') {
+        throw Error(
+            'Expected field "credentials" to be of type "object" but was of type "' + typeof wallet.credentials + '"'
+        );
+    }
+    if (wallet.accountKeys === undefined) {
+        throw Error('Expected field "accountKeys" to be defined, but was not');
+    }
+}
+
+/**
+ * Parses a wallet export file into a `SimpleWalletFormat`. This format is a subset of the `GenesisFormat`.
+ */
+export function parseSimpleWallet(walletString: JsonString): SimpleWalletFormat {
+    const wallet = JSON.parse(walletString);
+    validateSimpleWallet(wallet);
+    return wallet;
 }
 
 /**
@@ -66,19 +92,7 @@ export function parseWallet(walletString: JsonString): WalletExportFormat {
             'Expected field "environment" to be of type "string" but was of type "' + typeof wallet.environment + '"'
         );
     }
-    if (typeof wallet.value.address !== 'string') {
-        throw Error(
-            'Expected field "value.address" to be of type "string" but was of type "' +
-                typeof wallet.value.address +
-                '"'
-        );
-    }
-    if (wallet.value.accountKeys === undefined) {
-        throw Error('Expected field "value.accountKeys" to be defined, but was not');
-    }
-    if (wallet.value.credentials === undefined) {
-        throw Error('Expected field "value.credentials" to be defined, but was not');
-    }
+    validateSimpleWallet(wallet.value);
     return wallet;
 }
 


### PR DESCRIPTION
## Purpose

Make the plt v1 transfer example work against preliminary implementation of node. This also adds parsing of genesis-format account keys

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
