### PR TITLE
CBOR Representation of PLT Account State

### DIFF
--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -349,8 +349,7 @@ function trTokenAccountInfo(token: GRPC.AccountInfo_Token): PLT.TokenAccountInfo
         id: PLT.TokenId.fromProto(unwrap(token.tokenId)),
         state: {
             balance: PLT.TokenAmount.fromProto(unwrap(token.tokenAccountState?.balance)),
-            memberAllowList: token.tokenAccountState?.memberAllowList,
-            memberDenyList: token.tokenAccountState?.memberDenyList,
+            moduleState: PLT.Cbor.fromProto(unwrap(token.tokenAccountState?.moduleState)),
         },
     };
 }

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -7,10 +7,11 @@ import type { Cbor, CborMemo, TokenAmount, TokenId, TokenModuleReference } from 
 export type TokenAccountState = {
     /** The amount of tokens held by the account. */
     balance: TokenAmount.Type;
-    /** Indicates whether the account is on the allow list. `undefined` if the list type is not supported by the token. */
-    memberAllowList?: boolean;
-    /** Indicates whether the account is on the deny list. `undefined` if the list type is not supported by the token. */
-    memberDenyList?: boolean;
+    /**
+     * Token module specific state (CBOR encoded), such as membership of allow/deny lists.
+     * This should be a CBOR-encoded `TokenModuleAccountState` object.
+     */
+    moduleState?: Cbor.Type;
 };
 
 /**

--- a/packages/sdk/src/plt/v1/Token.ts
+++ b/packages/sdk/src/plt/v1/Token.ts
@@ -6,6 +6,7 @@ import { Token as GenericToken, holderTransaction, scaleAmount, validateAmount }
 import { Cbor, TokenAmount, TokenId, TokenInfo } from '../index.js';
 import {
     TokenHolderOperation,
+    TokenModuleAccountState,
     TokenModuleState,
     TokenOperationType,
     TokenTransfer,
@@ -222,8 +223,11 @@ export async function validateTransfer(
     const accounts = await Promise.all([senderPromise, ...receiverPromises]);
     accounts.forEach((r) => {
         const accToken = r.accountTokens.find((t) => t.id.value === token.info.id.value)?.state;
-        if (accToken?.memberDenyList || accToken?.memberAllowList === false) {
-            throw new NotAllowedError(r.accountAddress);
+        if (accToken?.moduleState !== undefined) {
+            const moduleState = Cbor.decode(accToken.moduleState) as TokenModuleAccountState;
+            if (moduleState.memberDenyList || moduleState.memberAllowList === false) {
+                throw new NotAllowedError(r.accountAddress);
+            }
         }
     });
 

--- a/packages/sdk/src/plt/v1/Token.ts
+++ b/packages/sdk/src/plt/v1/Token.ts
@@ -223,11 +223,12 @@ export async function validateTransfer(
     const accounts = await Promise.all([senderPromise, ...receiverPromises]);
     accounts.forEach((r) => {
         const accToken = r.accountTokens.find((t) => t.id.value === token.info.id.value)?.state;
-        if (accToken?.moduleState !== undefined) {
-            const moduleState = Cbor.decode(accToken.moduleState) as TokenModuleAccountState;
-            if (moduleState.memberDenyList || moduleState.memberAllowList === false) {
-                throw new NotAllowedError(r.accountAddress);
-            }
+        if (accToken?.moduleState === undefined) {
+            return;
+        }
+        const moduleState = Cbor.decode(accToken.moduleState) as TokenModuleAccountState;
+        if (moduleState.memberDenyList || moduleState.memberAllowList === false) {
+            throw new NotAllowedError(r.accountAddress);
         }
     });
 

--- a/packages/sdk/src/plt/v1/types.ts
+++ b/packages/sdk/src/plt/v1/types.ts
@@ -178,6 +178,26 @@ export type TokenModuleState = {
 };
 
 /**
+ * The account state represents account-specific information that is maintained by the Token
+ * Module, and is returned as part of a `GetAccountInfo` query. It does not include state that is
+ * managed by the Token Kernel, such as the token identifier and account balance.
+ *
+ * All fields are optional, and can be omitted if the module implementation does not support them.
+ * The structure supports additional fields for future extensibility. Non-standard fields (i.e. any
+ * fields that are not defined by a standard, and are specific to the module implementation) may
+ * be included, and their tags should be prefixed with an underscore ("_") to distinguish them
+ * as such.
+ */
+export type TokenModuleAccountState = {
+    /** Whether the account is on the allow list. */
+    allowList?: boolean;
+    /** Whether the account is on the deny list. */
+    denyList?: boolean;
+    /** Any additional state information depending on the module implementation. */
+    [key: string]: unknown;
+};
+
+/**
  * These parameters are passed to the token module to initialize the token.
  * The token initialization update will also include the ticker symbol, initial account,
  * number of decimals, and a reference to the token module implementation.


### PR DESCRIPTION
## Purpose

Closes [COR-1497](https://linear.app/concordium/issue/COR-1497/update-js-sdk)

Revises `TokenAccountState` to have a `moduleState` (CBOR) field instead of the `memberAllowList` and `memberDenyList` fields.

## Changes

- Update `TokenAccountState`.
- Add `TokenModuleAccountState`.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
