### PR TITLE
Plt token amounts force decimals

### DIFF
--- a/examples/nodejs/plt/v1/modify-list.ts
+++ b/examples/nodejs/plt/v1/modify-list.ts
@@ -19,7 +19,7 @@ const cli = meow(
     $ yarn run-example <path-to-this-file> <list-name> <action> [options]
 
   Required
-    --token-symbol, -t  The symbol of the token to manage
+    --token-id,     -t  The unique id of the token to transfer
     --address,      -a  The account address to add to the allow list (in base58 format)
 
   Options
@@ -31,7 +31,7 @@ const cli = meow(
     {
         importMeta: import.meta,
         flags: {
-            tokenSymbol: {
+            tokenId: {
                 type: 'string',
                 alias: 't',
                 isRequired: true,
@@ -61,7 +61,7 @@ const cli = meow(
     }
 );
 
-const { tokenSymbol, address, walletFile, endpoint } = cli.flags;
+const { tokenId: id, address, walletFile, endpoint } = cli.flags;
 
 const [addr, port] = parseEndpoint(endpoint);
 const client = new ConcordiumGRPCNodeClient(
@@ -94,7 +94,7 @@ const client = new ConcordiumGRPCNodeClient(
     }
 
     // parse the arguments
-    const tokenId = TokenId.fromString(tokenSymbol);
+    const tokenId = TokenId.fromString(id);
     const targetAddress = AccountAddress.fromBase58(address);
 
     if (walletFile !== undefined) {

--- a/examples/nodejs/plt/v1/transfer.ts
+++ b/examples/nodejs/plt/v1/transfer.ts
@@ -19,7 +19,7 @@ const cli = meow(
     $ yarn run-example <path-to-this-file> [options]
 
   Required
-    --token-symbol, -t  The symbol of the token to transfer
+    --token-id,     -t  The unique id of the token to transfer
     --amount,       -a  The amount of tokens to transfer
     --recipient,    -r  The recipient address in base58 format
 
@@ -47,7 +47,7 @@ const cli = meow(
                 type: 'string',
                 alias: 'w',
             },
-            tokenSymbol: {
+            tokenId: {
                 type: 'string',
                 alias: 't',
                 isRequired: true,
@@ -81,8 +81,9 @@ const client = new ConcordiumGRPCNodeClient(
     // #region documentation-snippet
 
     // parse the other arguments
-    const tokenSymbol = TokenId.fromString(cli.flags.tokenSymbol);
-    const amount = TokenAmount.fromDecimal(cli.flags.amount);
+    const tokenId = TokenId.fromString(cli.flags.tokenId);
+    const token = await V1.Token.fromId(client, tokenId);
+    const amount = TokenAmount.fromDecimal(cli.flags.amount, token.info.state.decimals);
     const recipient = AccountAddress.fromBase58(cli.flags.recipient);
     const memo = cli.flags.memo ? CborMemo.fromString(cli.flags.memo) : undefined;
 
@@ -99,7 +100,6 @@ const client = new ConcordiumGRPCNodeClient(
         // From a service perspective:
         // create the token instance
         try {
-            const token = await V1.Token.fromId(client, tokenSymbol);
             const transaction = await V1.Token.transfer(token, sender, transfer, signer);
             console.log(`Transaction submitted with hash: ${transaction}`);
 
@@ -133,7 +133,7 @@ const client = new ConcordiumGRPCNodeClient(
         const transferOperation: V1.TokenTransferOperation = {
             transfer,
         };
-        const payload = V1.createTokenHolderPayload(tokenSymbol, transferOperation);
+        const payload = V1.createTokenHolderPayload(tokenId, transferOperation);
         console.log('Created payload:', payload);
 
         // Serialize payload for signing/submission

--- a/examples/nodejs/plt/v1/update-supply.ts
+++ b/examples/nodejs/plt/v1/update-supply.ts
@@ -18,7 +18,7 @@ const cli = meow(
     $ yarn run-example <path-to-this-file> <action> [options]
 
   Required
-    --token-symbol, -t  The symbol of the token to mint/burn
+    --token-id,     -t  The unique id of the token to transfer
     --amount,       -a  The amount of tokens to mint/burn
 
   Options
@@ -44,7 +44,7 @@ const cli = meow(
                 type: 'string',
                 alias: 'w',
             },
-            tokenSymbol: {
+            tokenId: {
                 type: 'string',
                 alias: 't',
                 isRequired: true,
@@ -58,7 +58,7 @@ const cli = meow(
     }
 );
 
-const { tokenSymbol, walletFile, endpoint, amount } = cli.flags;
+const { tokenId: id, walletFile, endpoint, amount } = cli.flags;
 
 const [addr, port] = parseEndpoint(endpoint);
 const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.createInsecure());
@@ -79,8 +79,9 @@ const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.crea
     }
 
     // parse the arguments
-    const tokenId = TokenId.fromString(tokenSymbol);
-    const tokenAmount = TokenAmount.fromDecimal(amount);
+    const tokenId = TokenId.fromString(id);
+    const token = await V1.Token.fromId(client, tokenId);
+    const tokenAmount = TokenAmount.fromDecimal(amount, token.info.state.decimals);
 
     if (walletFile !== undefined) {
         // Read wallet-file

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -13,6 +13,8 @@
   the parameter/return values are internal-only.
 - Added `TokenHolderPayload` and `TokenGovernancePayload` to `AccountTransactionPayload` union type.
 - Added reject reasons related to PLT transactions to `RejectReason` union type.
+- `CcdAmount.fromDecimal` no longer supports creation from a string with comma used as the decimal separator, e.g.
+  "10,123".
 
 ### Added
 

--- a/packages/sdk/src/plt/Token.ts
+++ b/packages/sdk/src/plt/Token.ts
@@ -219,6 +219,7 @@ export async function holderTransaction(
  * @param {TokenGovernancePayload} payload - The transaction payload.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {boolean} [validate=true] - Whether to validate the sender's authorization.
  *
  * @returns {Promise<TransactionHash.Type>} A promise that resolves to the transaction hash.
  * @throws {UnauthorizedGovernanceOperationError} If the sender is not the token issuer.
@@ -228,12 +229,14 @@ export async function governanceTransaction(
     sender: AccountAddress.Type,
     payload: TokenGovernancePayload,
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    validate: boolean = true
 ): Promise<TransactionHash.Type> {
     // Check if the sender is the token issuer
-    if (!AccountAddress.equals(sender, token.info.state.issuer)) {
+    if (validate && !AccountAddress.equals(sender, token.info.state.issuer)) {
         throw new UnauthorizedGovernanceOperationError(sender);
     }
+
     const { nonce } = await token.grpc.getNextAccountNonce(sender);
     const header: AccountTransactionHeader = {
         expiry,

--- a/packages/sdk/src/plt/TokenAmount.ts
+++ b/packages/sdk/src/plt/TokenAmount.ts
@@ -154,26 +154,23 @@ export function instanceOf(value: unknown): value is TokenAmount {
  *
  * @throws {Err} If the value exceeds the maximum allowed or is negative.
  */
-export function fromDecimal(amount: BigSource | bigint): TokenAmount {
+export function fromDecimal(amount: BigSource | bigint, decimals: number): TokenAmount {
     let parsed: BigSource;
     if (typeof amount !== 'bigint') {
-        parsed = newBig(amount);
+        parsed = Big(amount);
     } else {
         parsed = amount.toString();
     }
 
-    const bigAmount = newBig(parsed);
-    const decimals = bigAmount.toString().split('.')[1]?.length ?? 0;
-    const intAmount = bigAmount.mul(Big(10 ** decimals));
+    const bigAmount = Big(parsed);
+    const parsedDecimals = bigAmount.toString().split('.')[1]?.length ?? 0;
 
-    return new TokenAmount(BigInt(intAmount.toString()), decimals);
-}
-
-function newBig(bigSource: BigSource): Big {
-    if (typeof bigSource === 'string') {
-        return Big(bigSource.replace(',', '.'));
+    if (parsedDecimals > decimals) {
+        throw new Error('The amount has more decimal places than the specified decimals.');
     }
-    return Big(bigSource);
+
+    const intAmount = bigAmount.mul(Big((10n ** BigInt(decimals)).toString()));
+    return new TokenAmount(BigInt(intAmount.toString()), decimals);
 }
 
 /**
@@ -201,22 +198,23 @@ export function fromJSON(json: JSON): TokenAmount {
  * Creates a token amount from its integer representation and a number of decimals.
  *
  * @param {bigint} value The integer representation of the token amount.
- * @param {number} decimals The decimals of the token amount, defining the precision at which amounts of the token can be specified. Defaults to `0`.
+ * @param {number} decimals The decimals of the token amount, defining the precision at which amounts of the token can be specified.
  *
  * @returns {TokenAmount} The token amount.
  * @throws {Err} If the value/decimals exceeds the maximum allowed or is negative.
  */
-export function create(value: bigint, decimals: number = 0): TokenAmount {
+export function create(value: bigint, decimals: number): TokenAmount {
     return new TokenAmount(value, decimals);
 }
 
 /**
  * Creates a token amount with a value of zero.
  *
+ * @param {number} decimals The decimals of the token amount, defining the precision at which amounts of the token can be specified.
  * @returns {TokenAmount} The token amount.
  */
-export function zero(): TokenAmount {
-    return new TokenAmount(BigInt(0), 0);
+export function zero(decimals: number): TokenAmount {
+    return new TokenAmount(BigInt(0), decimals);
 }
 
 /**

--- a/packages/sdk/src/plt/v1/Governance.ts
+++ b/packages/sdk/src/plt/v1/Governance.ts
@@ -14,7 +14,7 @@ import {
     createTokenGovernancePayload,
 } from './types.js';
 
-type SupplyUpdateOtions = {
+type SupplyUpdateOptions = {
     /** Whether to automatically scale a token amount to the correct number of decimals as the token */
     autoScale?: boolean;
     /** Whether to validate the payload executing it */
@@ -29,7 +29,7 @@ type SupplyUpdateOtions = {
  * @param {TokenAmount.Type | TokenAmount.Type[]} amounts - The amount(s) of tokens to mint.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
- * @param {SupplyUpdateOtions} [opts={ autoScale: true, validate: true }] - Options for supply update operations.
+ * @param {SupplyUpdateOptions} [opts={ autoScale: true, validate: true }] - Options for supply update operations.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {InvalidTokenAmountError} If the token amount is not compatible with the token.
@@ -41,7 +41,7 @@ export async function mint(
     amounts: TokenAmount.Type | TokenAmount.Type[],
     signer: AccountSigner,
     expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
-    opts: SupplyUpdateOtions = { autoScale: true, validate: true }
+    opts: SupplyUpdateOptions = { autoScale: true, validate: true }
 ): Promise<TransactionHash.Type> {
     const amountsList = [amounts].flat();
     const ops: TokenMintOperation[] = amountsList.map((amount) => {
@@ -61,7 +61,7 @@ export async function mint(
  * @param {TokenAmount.Type | TokenAmount.Type[]} amounts - The amount(s) of tokens to burn.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
- * @param {SupplyUpdateOtions} [opts={ autoScale: true, validate: true }] - Options for supply update operations.
+ * @param {SupplyUpdateOptions} [opts={ autoScale: true, validate: true }] - Options for supply update operations.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {InvalidTokenAmountError} If the token amount is not compatible with the token.
@@ -73,7 +73,7 @@ export async function burn(
     amounts: TokenAmount.Type | TokenAmount.Type[],
     signer: AccountSigner,
     expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
-    opts: SupplyUpdateOtions = { autoScale: true, validate: true }
+    opts: SupplyUpdateOptions = { autoScale: true, validate: true }
 ): Promise<TransactionHash.Type> {
     const amountsList = [amounts].flat();
     const ops: TokenBurnOperation[] = amountsList.map((amount) => {

--- a/packages/sdk/src/plt/v1/Governance.ts
+++ b/packages/sdk/src/plt/v1/Governance.ts
@@ -1,5 +1,5 @@
 import { AccountAddress, AccountSigner, TransactionExpiry, TransactionHash } from '../../pub/types.js';
-import { governanceTransaction, scaleAmount, validateAmount } from '../Token.js';
+import { governanceTransaction, scaleAmount } from '../Token.js';
 import { TokenAmount } from '../index.js';
 import { Type as Token } from './Token.js';
 import {
@@ -14,6 +14,13 @@ import {
     createTokenGovernancePayload,
 } from './types.js';
 
+type SupplyUpdateOtions = {
+    /** Whether to automatically scale a token amount to the correct number of decimals as the token */
+    autoScale?: boolean;
+    /** Whether to validate the payload executing it */
+    validate?: boolean;
+};
+
 /**
  * Mints a specified amount of tokens.
  *
@@ -22,6 +29,7 @@ import {
  * @param {TokenAmount.Type | TokenAmount.Type[]} amounts - The amount(s) of tokens to mint.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {SupplyUpdateOtions} [opts={ autoScale: true, validate: true }] - Options for supply update operations.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {InvalidTokenAmountError} If the token amount is not compatible with the token.
@@ -32,15 +40,17 @@ export async function mint(
     sender: AccountAddress.Type,
     amounts: TokenAmount.Type | TokenAmount.Type[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    opts: SupplyUpdateOtions = { autoScale: true, validate: true }
 ): Promise<TransactionHash.Type> {
     const amountsList = [amounts].flat();
-    amountsList.forEach((amount) => validateAmount(token, amount));
-
-    const ops: TokenMintOperation[] = amountsList.map((amount) => ({
-        [TokenOperationType.Mint]: { amount: scaleAmount(token, amount) },
-    }));
-    return batchOperations(token, sender, ops, signer, expiry);
+    const ops: TokenMintOperation[] = amountsList.map((amount) => {
+        const scaled = opts.autoScale ? scaleAmount(token, amount) : amount;
+        return {
+            [TokenOperationType.Mint]: { amount: scaled },
+        };
+    });
+    return batchOperations(token, sender, ops, signer, expiry, opts.validate);
 }
 
 /**
@@ -51,6 +61,7 @@ export async function mint(
  * @param {TokenAmount.Type | TokenAmount.Type[]} amounts - The amount(s) of tokens to burn.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {SupplyUpdateOtions} [opts={ autoScale: true, validate: true }] - Options for supply update operations.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {InvalidTokenAmountError} If the token amount is not compatible with the token.
@@ -61,16 +72,23 @@ export async function burn(
     sender: AccountAddress.Type,
     amounts: TokenAmount.Type | TokenAmount.Type[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    opts: SupplyUpdateOtions = { autoScale: true, validate: true }
 ): Promise<TransactionHash.Type> {
     const amountsList = [amounts].flat();
-    amountsList.forEach((amount) => validateAmount(token, amount));
-
-    const ops: TokenBurnOperation[] = amountsList.map((amount) => ({
-        [TokenOperationType.Burn]: { amount: scaleAmount(token, amount) },
-    }));
-    return batchOperations(token, sender, ops, signer, expiry);
+    const ops: TokenBurnOperation[] = amountsList.map((amount) => {
+        const scaled = opts.autoScale ? scaleAmount(token, amount) : amount;
+        return {
+            [TokenOperationType.Burn]: { amount: scaled },
+        };
+    });
+    return batchOperations(token, sender, ops, signer, expiry, opts.validate);
 }
+
+type UpdateListOptions = {
+    /** Whether to validate the payload executing it */
+    validate?: boolean;
+};
 
 /**
  * Adds an account to the allow list of a token.
@@ -80,6 +98,7 @@ export async function burn(
  * @param {AccountAddress.Type | AccountAddress.Type[]} targets - The account address(es) to be added to the list.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {UpdateListOptions} [opts={ validate: true }] - Options for updating the allow/deny list.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {UnauthorizedGovernanceOperationError} If the sender is not the token issuer.
@@ -89,12 +108,13 @@ export async function addAllowList(
     sender: AccountAddress.Type,
     targets: AccountAddress.Type | AccountAddress.Type[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    { validate }: UpdateListOptions = { validate: true }
 ): Promise<TransactionHash.Type> {
     const ops: TokenAddAllowListOperation[] = [targets]
         .flat()
         .map((target) => ({ [TokenOperationType.AddAllowList]: { target } }));
-    return batchOperations(token, sender, ops, signer, expiry);
+    return batchOperations(token, sender, ops, signer, expiry, validate);
 }
 
 /**
@@ -105,6 +125,7 @@ export async function addAllowList(
  * @param {AccountAddress.Type | AccountAddress.Type[]} targets - The account address(es) to be added to the list.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {UpdateListOptions} [opts={ validate: true }] - Options for updating the allow/deny list.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {UnauthorizedGovernanceOperationError} If the sender is not the token issuer.
@@ -114,12 +135,13 @@ export async function removeAllowList(
     sender: AccountAddress.Type,
     targets: AccountAddress.Type | AccountAddress.Type[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    { validate }: UpdateListOptions = { validate: true }
 ): Promise<TransactionHash.Type> {
     const ops: TokenRemoveAllowListOperation[] = [targets]
         .flat()
         .map((target) => ({ [TokenOperationType.RemoveAllowList]: { target } }));
-    return batchOperations(token, sender, ops, signer, expiry);
+    return batchOperations(token, sender, ops, signer, expiry, validate);
 }
 
 /**
@@ -130,6 +152,7 @@ export async function removeAllowList(
  * @param {AccountAddress.Type | AccountAddress.Type[]} targets - The account address(es) to be added to the list.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {UpdateListOptions} [opts={ validate: true }] - Options for updating the allow/deny list.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {UnauthorizedGovernanceOperationError} If the sender is not the token issuer.
@@ -139,12 +162,13 @@ export async function addDenyList(
     sender: AccountAddress.Type,
     targets: AccountAddress.Type | AccountAddress.Type[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    { validate }: UpdateListOptions = { validate: true }
 ): Promise<TransactionHash.Type> {
     const ops: TokenAddDenyListOperation[] = [targets]
         .flat()
         .map((target) => ({ [TokenOperationType.AddDenyList]: { target } }));
-    return batchOperations(token, sender, ops, signer, expiry);
+    return batchOperations(token, sender, ops, signer, expiry, validate);
 }
 
 /**
@@ -155,6 +179,7 @@ export async function addDenyList(
  * @param {AccountAddress.Type | AccountAddress.Type[]} targets - The account address(es) to be added to the list.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {UpdateListOptions} [opts={ validate: true }] - Options for updating the allow/deny list.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {UnauthorizedGovernanceOperationError} If the sender is not the token issuer.
@@ -164,12 +189,13 @@ export async function removeDenyList(
     sender: AccountAddress.Type,
     targets: AccountAddress.Type | AccountAddress.Type[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    { validate }: UpdateListOptions = { validate: true }
 ): Promise<TransactionHash.Type> {
     const ops: TokenRemoveDenyListOperation[] = [targets]
         .flat()
         .map((target) => ({ [TokenOperationType.RemoveDenyList]: { target } }));
-    return batchOperations(token, sender, ops, signer, expiry);
+    return batchOperations(token, sender, ops, signer, expiry, validate);
 }
 
 /**
@@ -180,6 +206,7 @@ export async function removeDenyList(
  * @param {TokenGovernanceOperation[]} operations - An array of governance operations to execute.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {boolean} [validate=true] - Whether to validate the operations before executing.
  *
  * @returns A promise that resolves to the transaction hash.
  * @throws {InvalidTokenAmountError} If a token amount is not compatible with the token.
@@ -190,8 +217,9 @@ export async function batchOperations(
     sender: AccountAddress.Type,
     operations: TokenGovernanceOperation[],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    validate: boolean = true
 ): Promise<TransactionHash.Type> {
     const payload = createTokenGovernancePayload(token.info.id, operations);
-    return governanceTransaction(token, sender, payload, signer, expiry);
+    return governanceTransaction(token, sender, payload, signer, expiry, validate);
 }

--- a/packages/sdk/src/plt/v1/Token.ts
+++ b/packages/sdk/src/plt/v1/Token.ts
@@ -230,6 +230,13 @@ export async function validateTransfer(
     return true;
 }
 
+type TransferOtions = {
+    /** Whether to automatically scale a token amount to the correct number of decimals as the token */
+    autoScale?: boolean;
+    /** Whether to validate the payload executing it */
+    validate?: boolean;
+};
+
 /**
  * Transfers tokens from the sender to the specified recipients.
  *
@@ -238,6 +245,7 @@ export async function validateTransfer(
  * @param {TokenTransfer | [TokenTransfer]} payload - The transfer payload.
  * @param {AccountSigner} signer - The signer responsible for signing the transaction.
  * @param {TransactionExpiry.Type} [expiry=TransactionExpiry.futureMinutes(5)] - The expiry time for the transaction.
+ * @param {TransferOtions} [opts={ autoScale: true, validate: true }] - Options for the transfer.
  *
  * @returns {Promise<TransactionHash.Type>} A promise that resolves to the transaction hash.
  * @throws {InvalidTokenAmountError} If any token amount is not compatible with the token.
@@ -249,13 +257,19 @@ export async function transfer(
     sender: AccountAddress.Type,
     payload: TokenTransfer | [TokenTransfer],
     signer: AccountSigner,
-    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5)
+    expiry: TransactionExpiry.Type = TransactionExpiry.futureMinutes(5),
+    opts: TransferOtions = { autoScale: true, validate: true }
 ): Promise<TransactionHash.Type> {
-    await validateTransfer(token, sender, payload);
+    if (opts.validate) {
+        await validateTransfer(token, sender, payload);
+    }
 
-    const ops: TokenHolderOperation[] = [payload]
-        .flat()
-        .map((p) => ({ [TokenOperationType.Transfer]: { ...p, amount: scaleAmount(token, p.amount) } }));
+    const ops: TokenHolderOperation[] = [payload].flat().map((p) => {
+        const amount = opts.autoScale ? scaleAmount(token, p.amount) : p.amount;
+        return {
+            [TokenOperationType.Transfer]: { ...p, amount },
+        };
+    });
     const encoded = createTokenHolderPayload(token.info.id, ops);
 
     return holderTransaction(token, sender, encoded, signer, expiry);

--- a/packages/sdk/src/plt/v1/Token.ts
+++ b/packages/sdk/src/plt/v1/Token.ts
@@ -199,15 +199,16 @@ export async function validateTransfer(
 
     // Validate all amounts
     payloads.forEach((p) => validateAmount(token, p.amount));
+    const { decimals } = token.info.state;
 
     // Check the sender balance.
-    const senderBalance = (await balanceOf(token, sender)) ?? TokenAmount.zero(); // We fall back to zero, as the `token` has already been validated at this point.
+    const senderBalance = (await balanceOf(token, sender)) ?? TokenAmount.zero(decimals); // We fall back to zero, as the `token` has already been validated at this point.
     const payloadTotal = payloads.reduce(
         (acc, { amount }) => acc.add(TokenAmount.toDecimal(amount)),
-        TokenAmount.toDecimal(TokenAmount.zero())
+        TokenAmount.toDecimal(TokenAmount.zero(decimals))
     );
     if (TokenAmount.toDecimal(senderBalance).lt(payloadTotal)) {
-        throw new InsufficientFundsError(sender, TokenAmount.fromDecimal(payloadTotal));
+        throw new InsufficientFundsError(sender, TokenAmount.fromDecimal(payloadTotal, decimals));
     }
 
     const moduleState = Cbor.decode(token.info.state.moduleState) as TokenModuleState;

--- a/packages/sdk/src/types/CcdAmount.ts
+++ b/packages/sdk/src/types/CcdAmount.ts
@@ -74,7 +74,6 @@ export function instanceOf(value: unknown): value is CcdAmount {
 
 /**
  * Constructs a CcdAmount and checks that it is valid. It accepts a number, string, big, or bigint as parameter.
- * It can accept a string as parameter with either a comma or a dot as the decimal separator.
  *
  * @param microCcdAmount The amount of micro CCD as a number, string, big, or bigint.
  * @throws If an invalid micro CCD amount is passed, i.e. any value which is not an unsigned 64-bit integer
@@ -82,7 +81,7 @@ export function instanceOf(value: unknown): value is CcdAmount {
 export function fromMicroCcd(microCcdAmount: BigSource | bigint): CcdAmount {
     // If the input is a "BigSource" assert that the number is whole
     if (typeof microCcdAmount !== 'bigint') {
-        microCcdAmount = newBig(microCcdAmount);
+        microCcdAmount = Big(microCcdAmount);
 
         if (!microCcdAmount.mod(Big(1)).eq(Big(0))) {
             throw Error('Can not create CcdAmount from a non-whole number!');
@@ -124,15 +123,8 @@ export function fromCcd(ccd: BigSource | bigint): CcdAmount {
         ccd = ccd.toString();
     }
 
-    const microCcd = newBig(ccd).mul(Big(MICRO_CCD_PER_CCD));
+    const microCcd = Big(ccd).mul(Big(MICRO_CCD_PER_CCD));
     return fromMicroCcd(microCcd);
-}
-
-function newBig(bigSource: BigSource): Big {
-    if (typeof bigSource === 'string') {
-        return Big(bigSource.replace(',', '.'));
-    }
-    return Big(bigSource);
 }
 
 /**

--- a/packages/sdk/test/ci/plt/TokenAmount.test.ts
+++ b/packages/sdk/test/ci/plt/TokenAmount.test.ts
@@ -5,18 +5,20 @@ import { TokenAmount } from '../../../src/pub/plt.js';
 
 describe('PLT TokenAmount', () => {
     test('Parses decimals correctly', () => {
-        expect(TokenAmount.fromDecimal('1')).toEqual(TokenAmount.create(1n));
-        expect(TokenAmount.fromDecimal('1.002')).toEqual(TokenAmount.create(1002n, 3));
-        expect(TokenAmount.fromDecimal('15.002456687544126548')).toEqual(TokenAmount.create(15002456687544126548n, 18));
+        expect(TokenAmount.fromDecimal('1', 0)).toEqual(TokenAmount.create(1n, 0));
+        expect(TokenAmount.fromDecimal('1.002', 3)).toEqual(TokenAmount.create(1002n, 3));
+        expect(TokenAmount.fromDecimal('15.002456687544126548', 18)).toEqual(
+            TokenAmount.create(15002456687544126548n, 18)
+        );
     });
 
     test('Token amounts with invalid values throws', () => {
-        expect(() => TokenAmount.create(-504n)).toThrow(TokenAmount.Err.negative());
-        expect(() => TokenAmount.create(MAX_U64 + 1n)).toThrow(TokenAmount.Err.exceedsMaxValue());
+        expect(() => TokenAmount.create(-504n, 0)).toThrow(TokenAmount.Err.negative());
+        expect(() => TokenAmount.create(MAX_U64 + 1n, 0)).toThrow(TokenAmount.Err.exceedsMaxValue());
     });
 
     test('Returns expected amount', () => {
-        expect(TokenAmount.zero()).toEqual(TokenAmount.create(0n));
+        expect(TokenAmount.zero(0)).toEqual(TokenAmount.create(0n, 0));
     });
 
     test('JSON conversion works both ways', () => {
@@ -30,18 +32,13 @@ describe('PLT TokenAmount', () => {
     });
 
     test('Returns correct decimal amount', () => {
-        expect(TokenAmount.toDecimal(TokenAmount.create(1n))).toEqual(Big('1'));
+        expect(TokenAmount.toDecimal(TokenAmount.create(1n, 0))).toEqual(Big('1'));
         expect(TokenAmount.toDecimal(TokenAmount.create(1000n, 6))).toEqual(Big('0.001'));
         expect(TokenAmount.toDecimal(TokenAmount.create(123456789n, 2))).toEqual(Big('1234567.89'));
     });
 
-    test('FromCcd correctly takes comma as a decimal seperator', () => {
-        const amount = TokenAmount.fromDecimal('10,000');
-        expect(amount).toEqual(TokenAmount.create(10n));
-    });
-
-    test('TokenAmount constructor correctly rejects multiple comma seperators', () => {
-        expect(() => TokenAmount.fromDecimal('10,000,000')).toThrow(Error('[big.js] Invalid number'));
+    test('TokenAmount constructor correctly rejects multiple seperators', () => {
+        expect(() => TokenAmount.fromDecimal('10.000.000', 3)).toThrow(Error('[big.js] Invalid number'));
     });
 
     test('Equals checks for numeric equality, not object equality', () => {

--- a/packages/sdk/test/ci/types/ccdAmount.test.ts
+++ b/packages/sdk/test/ci/types/ccdAmount.test.ts
@@ -39,12 +39,8 @@ describe('To and from ccd as strings', () => {
         expect(CcdAmount.toCcd(ccd)).toEqual(Big('123.456789'));
     });
 
-    test('FromCcd correctly takes comma as a decimal seperator', () => {
-        expect(CcdAmount.toCcd(CcdAmount.fromCcd('10,000'))).toEqual(Big('10'));
-    });
-
-    test('CcdAmount constructor correctly rejects multiple comma seperators', () => {
-        expect(() => CcdAmount.fromCcd('10,000,000')).toThrow(Error('[big.js] Invalid number'));
+    test('CcdAmount constructor correctly rejects multiple seperators', () => {
+        expect(() => CcdAmount.fromCcd('10.000.000')).toThrow(Error('[big.js] Invalid number'));
     });
 
     test('fromCcd is equal to ccdToMicroCcd', () => {


### PR DESCRIPTION
## Purpose

Aligns token amount creation as per discussion

## Changes

- Don't allow creating ccd or token amounts from strings with other decimal separators than dot to align with standard number parsing from strings.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
