### PR TITLE
Fix `Buffer` use

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "10.0.0-alpha.6",
+    "version": "10.0.0-alpha.7",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/plt/Cbor.ts
+++ b/packages/sdk/src/plt/Cbor.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer/index.js';
+
 import * as Proto from '../grpc-api/v2/concordium/protocol-level-tokens.js';
 import { cborDecode, cborEncode } from '../pub/types.js';
 import { HexString } from '../types.js';

--- a/packages/sdk/src/plt/CborMemo.ts
+++ b/packages/sdk/src/plt/CborMemo.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer/index.js';
 import { decode } from 'cbor2/decoder';
 import { encode, registerEncoder } from 'cbor2/encoder';
 import { Tag } from 'cbor2/tag';

--- a/packages/sdk/src/plt/TokenMetadataUrl.ts
+++ b/packages/sdk/src/plt/TokenMetadataUrl.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer/index.js';
+
 import { HexString, cborDecode, cborEncode } from '../index.js';
 import { Cbor } from './index.js';
 

--- a/packages/sdk/src/plt/v1/types.ts
+++ b/packages/sdk/src/plt/v1/types.ts
@@ -206,7 +206,7 @@ export type TokenInitializationParameters = {
     /** The name of the token. */
     name: string;
     /** A URL pointing to the metadata of the token. */
-    metadata: string; // TODO: will change to url object containing url and checksum
+    metadata: TokenMetadataUrl.Type;
     /** Whether the token supports an allow list */
     allowList?: boolean;
     /** Whether the token supports an deny list */


### PR DESCRIPTION
## Purpose

Fixes an issue where `TokenUpdateHandler.toJSON` would cause a crash in browser contexts due to types depending on `Buffer` implementation from nodeJS.
