### PR TITLE
fix: webpack bundle bignumber.js alias

### DIFF
--- a/packages/sdk/webpack.config.ts
+++ b/packages/sdk/webpack.config.ts
@@ -30,6 +30,10 @@ function configFor(target: 'web' | 'node' | 'react-native'): webpack.Configurati
                 '.js': ['.ts', '.js'],
             },
             extensions: ['.tsx', '.ts', '.js'],
+            alias: {
+                // Fix bignumber.js export issue - ensure it resolves to the BigNumber constructor
+                'bignumber.js': resolve(__dirname, '../../node_modules/bignumber.js/bignumber.js'),
+            },
         },
         module: {
             rules: [


### PR DESCRIPTION
## Purpose

Fixes an issue with the UMD bundle produced by Webpack. The exports for `bignumber.js` (a dependency of `json-bigint`) are not being handled correctly.

### Reproduction
To reproduce the issue on the current published bundle:
```
// require may require temporarily changing `"type": "commonjs"` in package.json to force node to import as a CJS module
const c = require('lib/min/concordium.node.min.js');
c.serializeTypeValue('a', Buffer.from([]), true);
```
Expected: (Not using real data for serialization, just getting past the use of `bignumber.js`)
```
Uncaught Error: Unable to serialize value due to: Parsing failed
```
Actual:
```
Uncaught TypeError: Right-hand side of 'instanceof' is not callable
```

## Changes

Add an alias in the webpack config to correct the exports of `bignumber.js`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
