### PR TITLE
Fix conversion of token amounts with large decimal values

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 ## 10.0.0-alpha.? (Unreleased)
 
+## 10.0.0-alpha.15
+
 ### Fixed
 
 - Fix conversion in `TokenAmount.fromDecimals` function when used with large `decimal` values.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -49,6 +49,10 @@
 
 ## 10.0.0-alpha.? (Unreleased)
 
+### Fixed
+
+- Fix conversion in `TokenAmount.fromDecimals` function when used with large `decimal` values.
+
 ### Changed
 
 - Remove authorization validation for PLT `Token` client.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "10.0.0-alpha.14",
+    "version": "10.0.0-alpha.15",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/plt/TokenAmount.ts
+++ b/packages/sdk/src/plt/TokenAmount.ts
@@ -170,7 +170,7 @@ export function fromDecimal(amount: BigSource | bigint, decimals: number): Token
     }
 
     const intAmount = bigAmount.mul(Big((10n ** BigInt(decimals)).toString()));
-    return new TokenAmount(BigInt(intAmount.toString()), decimals);
+    return new TokenAmount(BigInt(intAmount.toFixed(0)), decimals);
 }
 
 /**

--- a/packages/sdk/test/ci/plt/TokenAmount.test.ts
+++ b/packages/sdk/test/ci/plt/TokenAmount.test.ts
@@ -14,6 +14,16 @@ describe('PLT TokenAmount', () => {
         );
     });
 
+    test('Parses large decimal values correctly', () => {
+        expect(() => TokenAmount.fromDecimal('1', 255)).toThrow(TokenAmount.Err.exceedsMaxValue());
+        expect(
+            TokenAmount.fromDecimal(
+                '0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001',
+                255
+            )
+        ).toEqual(TokenAmount.create(1n, 255));
+    });
+
     test('Token amounts with invalid values throws', () => {
         expect(() => TokenAmount.create(-504n, 0)).toThrow(TokenAmount.Err.negative());
         expect(() => TokenAmount.create(MAX_U64 + 1n, 0)).toThrow(TokenAmount.Err.exceedsMaxValue());


### PR DESCRIPTION
## Purpose

Previously, the expression `TokenAmount.fromDecimal('1', 255)` would cause following error:

```
Uncaught (in promise) SyntaxError: Cannot convert 1.23e+124 to a BigInt get this here: return new TokenAmount(BigInt(intAmount.toString()), decimals);
```

Now the error returned is correct:
```
TokenAmount.Err.EXCEEDS_MAX_VALUE: Token amounts cannot be larger than 18446744073709551615
```
