### PR TITLE
Add flow to publish versioned documentation via github pages (COR-1714)

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -10,7 +10,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -101,9 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # environment: deploy
+    environment: deploy
     outputs:
       npm_tag: ${{ steps.determine_npm_tag.outputs.npm_tag }}
+      version: ${{ steps.get_tag.outputs.tag }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -112,9 +113,7 @@ jobs:
 
       - name: Extract tag name
         id: get_tag
-        # ${GITHUB_REF#refs/tags/sdk/}
-        # Hardcoded for testing
-        run: echo "tag=10.0.1" >> $GITHUB_OUTPUT
+        run: echo "tag=${GITHUB_REF#refs/tags/sdk/}" >> $GITHUB_OUTPUT
 
       - name: Test that tag version matches package.json version
         run: test "${{ steps.get_tag.outputs.tag }}" = "$(jq -r ".version" packages/sdk/package.json)" || exit 1
@@ -130,38 +129,37 @@ jobs:
           fi
           echo "npm_tag=$npm_tag" >> $GITHUB_OUTPUT
 
-      # - name: Get build-output
-      #   uses: actions/download-artifact@v5
-      #   with:
-      #     name: build-release
-      #     path: packages/sdk
+      - name: Get build-output
+        uses: actions/download-artifact@v5
+        with:
+          name: build-release
+          path: packages/sdk
 
-      # - uses: actions/setup-node@v4
-      #   with:
-      #     node-version: ${{ env.NODE_VERSION }}
-      #     cache: yarn
-      #     registry-url: 'https://registry.npmjs.org'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
 
-      # - name: Publish to NPM
-      #   run: |
-      #     yarn config set npmAuthToken $NPM_AUTH_TOKEN
-      #     yarn workspace @concordium/web-sdk npm publish --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
-      #   env:
-      #     NPM_AUTH_TOKEN: '${{secrets.NPM_PUBLISH_TOKEN}}'
+      - name: Publish to NPM
+        run: |
+          yarn config set npmAuthToken $NPM_AUTH_TOKEN
+          yarn workspace @concordium/web-sdk npm publish --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
+        env:
+          NPM_AUTH_TOKEN: '${{secrets.NPM_PUBLISH_TOKEN}}'
 
-      # - name: Create a GitHub release
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     tag: sdk/${{ steps.get_tag.outputs.tag }}
-      #     name: SDK Release v${{ steps.get_tag.outputs.tag }}
-      #     draft: true
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: sdk/${{ steps.get_tag.outputs.tag }}
+          name: SDK Release v${{ steps.get_tag.outputs.tag }}
+          draft: true
 
   deploy-typedoc:
     needs:
       - upload-release
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -173,28 +171,52 @@ jobs:
           path: typedoc
           name: typedoc-build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      # Put docs into a versioned subfolder
-      - name: Move typedoc into versioned folder
+      # Clone old `gh-pages` branch so we can later build a list of
+      # available documentation versions.
+      - name: Clone old gh-pages content
         run: |
-          VERSION=${{ steps.get_tag.outputs.tag }}
-          mkdir -p docs/$VERSION
-          cp -r typedoc/* docs/latest
+          # Make a local work folder
+          mkdir -p gh-pages
 
-      # (Optional) symlink "latest" → newest tag
-      - name: Update latest symlink
+          # Copy its content into local `gh-pages` folder
+          git clone --branch gh-pages --depth 1 https://github.com/${{ github.repository }} old-gh-pages
+          cp -r old-gh-pages/* gh-pages/ || true
+
+      # Put new docs into a versioned subfolder
+      - name: Generate versioned subfolder
+        run: |
+          VERSION=${{ needs.upload-release.outputs.version }}
+          mkdir -p gh-pages/$VERSION
+          cp -r typedoc/* gh-pages/$VERSION
+
+      # Update the "latest" subfolder content with the newest doc version.
+      - name: Update `latest` subfolder content
         if: needs.upload-release.outputs.npm_tag == 'latest'
         run: |
-          rm -rf docs/latest
-          mv typedoc/* docs/$VERSION
+          mkdir -p gh-pages/latest
+          rm -rf gh-pages/latest/*
+          cp -r typedoc/* gh-pages/latest
 
-      - name: Upload GH Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      # Generate list of available documentation versions.
+      # This needs to be done after the `gh-pages` branch has been fetched with the old docs.
+      - name: Generate docs index
+        run: |
+          echo "<!DOCTYPE html>" > gh-pages/index.html
+          echo "<html><head><title>Documentation Versions</title></head><body>" >> gh-pages/index.html
+          echo "<h1>Available Documentation Versions</h1><ul>" >> gh-pages/index.html
+
+          # Loop over all directories in gh-pages/
+          for d in gh-pages/*/ ; do
+            version=$(basename "$d")
+            echo "<li><a href=\"./$version/\">$version</a></li>" >> gh-pages/index.html
+          done
+
+          echo "</ul>" >> gh-pages/index.html
+          echo "</body></html>" >> gh-pages/index.html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: './docs'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages
+          keep_files: true

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -179,8 +179,8 @@ jobs:
           mkdir -p gh-pages
 
           # Copy its content into local `gh-pages` folder
-          git clone --branch gh-pages --depth 1 https://github.com/${{ github.repository }} old-gh-pages
-          cp -r old-gh-pages/* gh-pages/ || true
+          git clone --branch gh-pages --depth 1 https://github.com/Concordium/concordium-node-sdk-js old-gh-pages
+          cp -r old-gh-pages/* gh-pages/
 
       # Put new docs into a versioned subfolder
       - name: Generate versioned subfolder
@@ -202,7 +202,7 @@ jobs:
       - name: Generate docs index
         run: |
           echo "<!DOCTYPE html>" > gh-pages/index.html
-          echo "<html><head><title>Documentation Versions</title></head><body>" >> gh-pages/index.html
+          echo "<html lang=\"en\"><head><meta charset=\"utf-8\"><title>Documentation Versions</title></head><body>" >> gh-pages/index.html
           echo "<h1>Available Documentation Versions</h1><ul>" >> gh-pages/index.html
 
           # Loop over all directories in gh-pages/

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    environment: deploy
+    # environment: deploy
     outputs:
       npm_tag: ${{ steps.determine_npm_tag.outputs.npm_tag }}
     steps:
@@ -112,7 +112,9 @@ jobs:
 
       - name: Extract tag name
         id: get_tag
-        run: echo "tag=${GITHUB_REF#refs/tags/sdk/}" >> $GITHUB_OUTPUT
+        # ${GITHUB_REF#refs/tags/sdk/}
+        # Hardcoded for testing
+        run: echo "tag=10.0.1" >> $GITHUB_OUTPUT
 
       - name: Test that tag version matches package.json version
         run: test "${{ steps.get_tag.outputs.tag }}" = "$(jq -r ".version" packages/sdk/package.json)" || exit 1
@@ -128,39 +130,38 @@ jobs:
           fi
           echo "npm_tag=$npm_tag" >> $GITHUB_OUTPUT
 
-      - name: Get build-output
-        uses: actions/download-artifact@v5
-        with:
-          name: build-release
-          path: packages/sdk
+      # - name: Get build-output
+      #   uses: actions/download-artifact@v5
+      #   with:
+      #     name: build-release
+      #     path: packages/sdk
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: yarn
-          registry-url: 'https://registry.npmjs.org'
+      # - uses: actions/setup-node@v4
+      #   with:
+      #     node-version: ${{ env.NODE_VERSION }}
+      #     cache: yarn
+      #     registry-url: 'https://registry.npmjs.org'
 
-      - name: Publish to NPM
-        run: |
-          yarn config set npmAuthToken $NPM_AUTH_TOKEN
-          yarn workspace @concordium/web-sdk npm publish --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
-        env:
-          NPM_AUTH_TOKEN: '${{secrets.NPM_PUBLISH_TOKEN}}'
+      # - name: Publish to NPM
+      #   run: |
+      #     yarn config set npmAuthToken $NPM_AUTH_TOKEN
+      #     yarn workspace @concordium/web-sdk npm publish --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
+      #   env:
+      #     NPM_AUTH_TOKEN: '${{secrets.NPM_PUBLISH_TOKEN}}'
 
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: sdk/${{ steps.get_tag.outputs.tag }}
-          name: SDK Release v${{ steps.get_tag.outputs.tag }}
-          draft: true
+      # - name: Create a GitHub release
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     tag: sdk/${{ steps.get_tag.outputs.tag }}
+      #     name: SDK Release v${{ steps.get_tag.outputs.tag }}
+      #     draft: true
 
   deploy-typedoc:
     needs:
       - upload-release
-    if: needs.upload-release.outputs.npm_tag == 'latest'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -175,10 +176,24 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload GH pages artifact
+      # Put docs into a versioned subfolder
+      - name: Move typedoc into versioned folder
+        run: |
+          VERSION=${{ steps.get_tag.outputs.tag }}
+          mkdir -p docs/$VERSION
+          cp -r typedoc/* docs/latest
+
+      # (Optional) symlink "latest" → newest tag
+      - name: Update latest symlink
+        if: needs.upload-release.outputs.npm_tag == 'latest'
+        run: |
+          rm -rf docs/latest
+          mv typedoc/* docs/$VERSION
+
+      - name: Upload GH Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './typedoc'
+          path: './docs'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Purpose

Versioned documentation is now maintained by the github action on this branch:
https://github.com/Concordium/concordium-node-sdk-js/tree/gh-pages
The docs (previous versions of the SDK) generated by previous github action runs will remain in the `gh-pages` branch.

The old documentation url now points to a list of available documentation versions and one `latest` link.
See here: https://docs.concordium.com/concordium-node-sdk-js/

<img width="690" height="275" alt="Screenshot from 2025-08-28 13-06-11" src="https://github.com/user-attachments/assets/3ac0404f-bf63-41a1-a214-de66673dc36f" />

## Changes

- Change CI pipeline to publish versioned documentation.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
