### PR TITLE
Forwards comp/block item summary

### DIFF
--- a/examples/nodejs/client/getBlockItemStatus.ts
+++ b/examples/nodejs/client/getBlockItemStatus.ts
@@ -1,4 +1,4 @@
-import { BlockItemStatus, CcdAmount, TransactionHash } from '@concordium/web-sdk';
+import { BlockItemStatus, CcdAmount, TransactionHash, knownOrError } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
@@ -77,8 +77,7 @@ const client = new ConcordiumGRPCNodeClient(
     if (blockItemStatus.status === 'finalized') {
         console.log('blockItemStatus is "finalized" and therefore there is exactly one outcome \n');
 
-        const { summary } = blockItemStatus.outcome;
-
+        const summary = knownOrError(blockItemStatus.outcome.summary, 'unknown outcome encountered');
         if (summary.type === 'accountTransaction') {
             console.log('The block item is an account transaction');
 

--- a/examples/nodejs/client/getBlockTransactionEvents.ts
+++ b/examples/nodejs/client/getBlockTransactionEvents.ts
@@ -1,4 +1,4 @@
-import { BlockHash, BlockItemSummary } from '@concordium/web-sdk';
+import { BlockHash, BlockItemSummary, Upward, isKnown } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
@@ -48,10 +48,14 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
 (async () => {
     // #region documentation-snippet
     const blockHash = cli.flags.block === undefined ? undefined : BlockHash.fromHexString(cli.flags.block);
-    const events: AsyncIterable<BlockItemSummary> = client.getBlockTransactionEvents(blockHash);
+    const events: AsyncIterable<Upward<BlockItemSummary>> = client.getBlockTransactionEvents(blockHash);
     // #endregion documentation-snippet
 
     for await (const event of events) {
-        console.dir(event, { depth: null, colors: true });
+        if (isKnown(event)) {
+            console.dir(event, { depth: null, colors: true });
+        } else {
+            console.warn('Encountered unknown event');
+        }
     }
 })();

--- a/examples/nodejs/composed-examples/findAccountCreationBlock.ts
+++ b/examples/nodejs/composed-examples/findAccountCreationBlock.ts
@@ -1,4 +1,4 @@
-import { AccountAddress, isRpcError } from '@concordium/web-sdk';
+import { AccountAddress, isKnown, isRpcError } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
@@ -75,6 +75,9 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
 
     // If account is not a genesis account print account creation transaction hash
     for await (const summary of summaries) {
+        if (!isKnown(summary)) {
+            continue;
+        }
         if (summary.type === 'accountCreation' && AccountAddress.equals(summary.address, account)) {
             console.log('Hash of transaction that created the account:', summary.hash);
         }

--- a/examples/nodejs/composed-examples/initAndUpdateContract.ts
+++ b/examples/nodejs/composed-examples/initAndUpdateContract.ts
@@ -17,6 +17,7 @@ import {
     affectedContracts,
     buildAccountSigner,
     deserializeReceiveReturnValue,
+    isKnown,
     parseWallet,
     serializeInitContractParameters,
     serializeUpdateContractParameters,
@@ -117,6 +118,10 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
 
     const initStatus = await client.waitForTransactionFinalization(initTrxHash);
     console.dir(initStatus, { depth: null, colors: true });
+
+    if (!isKnown(initStatus.summary)) {
+        throw new Error('Unexpected transaction outcome');
+    }
 
     const contractAddress = affectedContracts(initStatus.summary)[0];
 

--- a/examples/nodejs/composed-examples/listInitialAccounts.ts
+++ b/examples/nodejs/composed-examples/listInitialAccounts.ts
@@ -1,4 +1,4 @@
-import { unwrap } from '@concordium/web-sdk';
+import { isKnown, unwrap } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
@@ -71,6 +71,9 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
         // Get transactions for block
         const trxStream = client.getBlockTransactionEvents(block.hash);
         for await (const trx of trxStream) {
+            if (!isKnown(trx)) {
+                continue;
+            }
             if (trx.type === 'accountCreation' && trx.credentialType === 'initial') {
                 initAccounts.push(trx.address);
             }

--- a/examples/nodejs/composed-examples/listNumberAccountTransactions.ts
+++ b/examples/nodejs/composed-examples/listNumberAccountTransactions.ts
@@ -1,4 +1,4 @@
-import { AccountAddress, isTransferLikeSummary, unwrap } from '@concordium/web-sdk';
+import { AccountAddress, isKnown, isTransferLikeSummary, unwrap } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
@@ -75,6 +75,9 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
 
         // For each transaction in the block:
         trxLoop: for await (const trx of trxStream) {
+            if (!isKnown(trx)) {
+                continue;
+            }
             if (isTransferLikeSummary(trx)) {
                 const trxAcc = trx.sender;
 

--- a/examples/nodejs/plt/modify-list.ts
+++ b/examples/nodejs/plt/modify-list.ts
@@ -5,6 +5,7 @@ import {
     TransactionEventTag,
     TransactionKindString,
     TransactionSummaryType,
+    isKnown,
     serializeAccountTransactionPayload,
 } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
@@ -136,6 +137,10 @@ const client = new ConcordiumGRPCNodeClient(
 
             const result = await client.waitForTransactionFinalization(transaction);
             console.log('Transaction finalized:', result);
+
+            if (!isKnown(result.summary)) {
+                throw new Error('Unexpected transaction outcome');
+            }
 
             if (result.summary.type !== TransactionSummaryType.AccountTransaction) {
                 throw new Error('Unexpected transaction type: ' + result.summary.type);

--- a/examples/nodejs/plt/pause.ts
+++ b/examples/nodejs/plt/pause.ts
@@ -4,6 +4,7 @@ import {
     TransactionEventTag,
     TransactionKindString,
     TransactionSummaryType,
+    isKnown,
     serializeAccountTransactionPayload,
 } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
@@ -101,6 +102,10 @@ const client = new ConcordiumGRPCNodeClient(
 
             const result = await client.waitForTransactionFinalization(transaction);
             console.log('Transaction finalized:', result);
+
+            if (!isKnown(result.summary)) {
+                throw new Error('Unexpected transaction outcome');
+            }
 
             if (result.summary.type !== TransactionSummaryType.AccountTransaction) {
                 throw new Error('Unexpected transaction type: ' + result.summary.type);

--- a/examples/nodejs/plt/transfer.ts
+++ b/examples/nodejs/plt/transfer.ts
@@ -4,6 +4,7 @@ import {
     RejectReasonTag,
     TransactionKindString,
     TransactionSummaryType,
+    isKnown,
     serializeAccountTransactionPayload,
 } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
@@ -116,6 +117,9 @@ const client = new ConcordiumGRPCNodeClient(
             const result = await client.waitForTransactionFinalization(transaction);
             console.log('Transaction finalized:', result);
 
+            if (!isKnown(result.summary)) {
+                throw new Error('Unexpected transaction outcome');
+            }
             if (result.summary.type !== TransactionSummaryType.AccountTransaction) {
                 throw new Error('Unexpected transaction type: ' + result.summary.type);
             }

--- a/examples/nodejs/plt/update-supply.ts
+++ b/examples/nodejs/plt/update-supply.ts
@@ -3,6 +3,7 @@ import {
     RejectReasonTag,
     TransactionKindString,
     TransactionSummaryType,
+    isKnown,
     serializeAccountTransactionPayload,
 } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
@@ -110,6 +111,9 @@ const client = new ConcordiumGRPCNodeClient(addr, Number(port), credentials.crea
             const result = await client.waitForTransactionFinalization(transaction);
             console.log('Transaction finalized:', result);
 
+            if (!isKnown(result.summary)) {
+                throw new Error('Unexpected transaction outcome');
+            }
             if (result.summary.type !== TransactionSummaryType.AccountTransaction) {
                 throw new Error('Unexpected transaction type: ' + result.summary.type);
             }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added
+
+- `Upward<T>` as a means of representing possibly unknown variants of a type encounted when querying the GRPC API
+  of *future* Concordium node versions. This is a type alias of `T | null`, i.e. unknown variants will be represented
+  as `null`.
+
+### Breaking changes
+
+#### GRPC API query response types
+
+- `BlockItemSummaryInBlock.summary` now has the type `Upward<BlockItemSummary>`.
+
+#### `ConcordiumGRPCClient`:
+
+- `waitForTransactionFinalization` is affected by the changes to `BlockItemSummaryInBlock`
+- `getBlockTransactionEvents` now returns `AsyncIterable<Upward<BlockItemSummary>>`.
+
 ## 10.0.1
 
 ### Fixed

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -947,6 +947,9 @@ export class ConcordiumGRPCClient {
      * @param blockHash an optional block hash to get the transaction events at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of block item summaries
+     *
+     * **Please note**, any of these can possibly be unknown if the SDK is not fully compatible with the Concordium
+     * node queried, in which case `null` is returned.
      */
     getBlockTransactionEvents(
         blockHash?: BlockHash.Type,

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -36,6 +36,7 @@ import { getEmbeddedModuleSchema } from '../types/VersionedModuleSource.js';
 import type { BlockItemStatus, BlockItemSummary } from '../types/blockItemSummary.js';
 import { countSignatures, isHex, isValidIp, mapRecord, mapStream, unwrap } from '../util.js';
 import * as translate from './translation.js';
+import type { Upward } from './upward.js';
 
 /**
  * @hidden
@@ -947,7 +948,10 @@ export class ConcordiumGRPCClient {
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of block item summaries
      */
-    getBlockTransactionEvents(blockHash?: BlockHash.Type, abortSignal?: AbortSignal): AsyncIterable<BlockItemSummary> {
+    getBlockTransactionEvents(
+        blockHash?: BlockHash.Type,
+        abortSignal?: AbortSignal
+    ): AsyncIterable<Upward<BlockItemSummary>> {
         const blockItemSummaries = this.client.getBlockTransactionEvents(getBlockHashInput(blockHash), {
             abort: abortSignal,
         }).responses;

--- a/packages/sdk/src/grpc/index.ts
+++ b/packages/sdk/src/grpc/index.ts
@@ -4,3 +4,4 @@ export {
     getAccountIdentifierInput,
     getBlockHashInput,
 } from './GRPCClient.js';
+export * from './upward.js';

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -23,6 +23,7 @@ import * as SequenceNumber from '../types/SequenceNumber.js';
 import * as Timestamp from '../types/Timestamp.js';
 import * as TransactionHash from '../types/TransactionHash.js';
 import { mapRecord, unwrap } from '../util.js';
+import type { Upward } from './upward.js';
 
 function unwrapToHex(bytes: Uint8Array | undefined): SDK.HexString {
     return Buffer.from(unwrap(bytes)).toString('hex');
@@ -2090,7 +2091,7 @@ function trCreatePltPayload(payload: GRPC_PLT.CreatePLT): PLT.CreatePLTPayload {
     };
 }
 
-export function blockItemSummary(summary: GRPC.BlockItemSummary): SDK.BlockItemSummary {
+export function blockItemSummary(summary: GRPC.BlockItemSummary): Upward<SDK.BlockItemSummary> {
     const base = {
         index: unwrap(summary.index?.value),
         energyCost: Energy.fromProto(unwrap(summary.energyCost)),
@@ -2125,7 +2126,7 @@ export function blockItemSummary(summary: GRPC.BlockItemSummary): SDK.BlockItemS
                 events: summary.details.tokenCreation.events.map(tokenEvent),
             };
         default:
-            throw Error('Invalid BlockItemSummary encountered!');
+            return null;
     }
 }
 

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2125,7 +2125,7 @@ export function blockItemSummary(summary: GRPC.BlockItemSummary): Upward<SDK.Blo
                 payload: trCreatePltPayload(unwrap(summary.details.tokenCreation.createPlt)),
                 events: summary.details.tokenCreation.events.map(tokenEvent),
             };
-        default:
+        case undefined:
             return null;
     }
 }

--- a/packages/sdk/src/grpc/upward.ts
+++ b/packages/sdk/src/grpc/upward.ts
@@ -1,8 +1,8 @@
 import { bail } from '../util.js';
 
 /**
- * Represents types returned by the GRPC API which are possibly unknown to the SDK version.
- * `null` means that the type is unknown.
+ * Represents types returned by the GRPC API of a Concordium node which are
+ * possibly unknown to the SDK version. `null` means that the type is unknown.
  *
  * @template T - The type representing the known variants
  *

--- a/packages/sdk/src/grpc/upward.ts
+++ b/packages/sdk/src/grpc/upward.ts
@@ -1,4 +1,4 @@
-import { bail } from '../util.ts';
+import { bail } from '../util.js';
 
 /**
  * Represents types returned by the GRPC API which are possibly unknown to the SDK version.
@@ -46,7 +46,7 @@ export function isKnown<T>(value: Upward<T>): value is T {
  * @param error - Error to throw if value is unknown.
  * @returns True as a type predicate when value is known.
  */
-export function assertKnown<T>(value: Upward<T>, error: Error): value is T {
+export function assertKnown<T>(value: Upward<T>, error: Error | string): value is T {
     return isKnown(value) || bail(error);
 }
 
@@ -58,7 +58,7 @@ export function assertKnown<T>(value: Upward<T>, error: Error): value is T {
  * @param error - Error to throw if value is unknown.
  * @returns The unwrapped known value of type T.
  */
-export function knownOrError<T>(value: Upward<T>, error: Error): T {
-    if (!isKnown(value)) throw error;
+export function knownOrError<T>(value: Upward<T>, error: Error | string): T {
+    if (!isKnown(value)) throw error instanceof Error ? error : new Error(error);
     return value;
 }

--- a/packages/sdk/src/grpc/upward.ts
+++ b/packages/sdk/src/grpc/upward.ts
@@ -1,0 +1,64 @@
+import { bail } from '../util.ts';
+
+/**
+ * Represents types returned by the GRPC API which are possibly unknown to the SDK version.
+ * `null` means that the type is unknown.
+ *
+ * @template T - The type representing the known variants
+ *
+ * @example
+ * // fail on unknown value
+ * const upwardValue: Upward<string> = ...
+ * if (upwardValue === null) {
+ *   throw new Error('Uncountered unknown value')
+ * }
+ * // the value is known from this point
+ *
+ * @example
+ * // gracefully handle unknown values
+ * const upwardValue: Upward<string> = ...
+ * if (upwardValue === null) {
+ *   console.warn('Uncountered unknown value')
+ * } else {
+ *   // the value is known from this point
+ * }
+ */
+export type Upward<T> = T | null;
+
+/**
+ * Type guard that checks whether an Upward<T> holds a known value.
+ *
+ * @template T - The type representing the known variants
+ * @param value - The possibly-unknown value returned from gRPC.
+ * @returns True if value is not null (i.e., is T).
+ */
+export function isKnown<T>(value: Upward<T>): value is T {
+    return value !== null;
+}
+
+/**
+ * Asserts that an Upward<T> is known, otherwise throws the provided error.
+ *
+ * Useful when unknowns should be treated as hard failures.
+ *
+ * @template T - The type representing the known variants
+ * @param value - The possibly-unknown value returned from gRPC.
+ * @param error - Error to throw if value is unknown.
+ * @returns True as a type predicate when value is known.
+ */
+export function assertKnown<T>(value: Upward<T>, error: Error): value is T {
+    return isKnown(value) || bail(error);
+}
+
+/**
+ * Returns the known value or throws the provided error when unknown.
+ *
+ * @template T - The type representing the known variants
+ * @param value - The possibly-unknown value returned from gRPC.
+ * @param error - Error to throw if value is unknown.
+ * @returns The unwrapped known value of type T.
+ */
+export function knownOrError<T>(value: Upward<T>, error: Error): T {
+    if (!isKnown(value)) throw error;
+    return value;
+}

--- a/packages/sdk/src/types/blockItemSummary.ts
+++ b/packages/sdk/src/types/blockItemSummary.ts
@@ -1,4 +1,5 @@
 import { isEqualContractAddress } from '../contractHelpers.js';
+import type { Upward } from '../grpc/upward.js';
 import { CreatePLTPayload } from '../plt/types.js';
 import { AccountTransactionType, TransactionStatusEnum, TransactionSummaryType } from '../types.js';
 import { isDefined } from '../util.js';
@@ -266,7 +267,7 @@ export type BlockItemSummary =
 
 export interface BlockItemSummaryInBlock {
     blockHash: BlockHash.Type;
-    summary: BlockItemSummary;
+    summary: Upward<BlockItemSummary>;
 }
 
 export interface PendingBlockItem {

--- a/packages/sdk/src/types/blockItemSummary.ts
+++ b/packages/sdk/src/types/blockItemSummary.ts
@@ -267,6 +267,12 @@ export type BlockItemSummary =
 
 export interface BlockItemSummaryInBlock {
     blockHash: BlockHash.Type;
+    /**
+     * The summary/outcome of processing the block item.
+     *
+     * **Please note**, this can possibly be unknown if the SDK is not fully compatible with the Concordium
+     * node queried, in which case `null` is returned.
+     */
     summary: Upward<BlockItemSummary>;
 }
 


### PR DESCRIPTION
## Purpose

Introduces the type `Upward<T>` (aligning with the corresponding type introduced in https://github.com/Concordium/concordium-rust-sdk/pull/297). 

This serves the purpose of marking certain responses from the GRPC API of Concordium nodes as possibly "unknown" due to incompatibility with the version of the SDK used. Previously, the strategy has been to propagate errors to users, but this has proven infeasible in terms of enabling users to write applications and services that are forwards compatible.

This PR will be the first in a sequence of pull requests wrapping response types in this.

## Changes

- Introduces `Upward<T>`, which is an alias for `T | null`. As such, `null` is used for unknown variants encountered in a response.
- Use `Upward` for `BlockItemSummary`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.