### PR TITLE
Forward comp/special events

### DIFF
--- a/examples/nodejs/client/getBlockSpecialEvents.ts
+++ b/examples/nodejs/client/getBlockSpecialEvents.ts
@@ -1,4 +1,4 @@
-import { BlockHash, BlockSpecialEvent } from '@concordium/web-sdk';
+import { BlockHash, BlockSpecialEvent, Upward, isKnown } from '@concordium/web-sdk';
 import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
 import { credentials } from '@grpc/grpc-js';
 import meow from 'meow';
@@ -50,10 +50,14 @@ const client = new ConcordiumGRPCNodeClient(address, Number(port), credentials.c
 (async () => {
     // #region documentation-snippet
     const blockHash = cli.flags.block === undefined ? undefined : BlockHash.fromHexString(cli.flags.block);
-    const events: AsyncIterable<BlockSpecialEvent> = client.getBlockSpecialEvents(blockHash);
+    const events: AsyncIterable<Upward<BlockSpecialEvent>> = client.getBlockSpecialEvents(blockHash);
     // #endregion documentation-snippet
 
     for await (const event of events) {
-        console.dir(event, { depth: null, colors: true });
+        if (!isKnown(event)) {
+            console.warn('Unknown event encountered');
+        } else {
+            console.dir(event, { depth: null, colors: true });
+        }
     }
 })();

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - `waitForTransactionFinalization` is affected by the changes to `BlockItemSummaryInBlock`
 - `getBlockTransactionEvents` now returns `AsyncIterable<Upward<BlockItemSummary>>`.
+- `getBlockSpecialEvents` now returns `AsyncIterable<Upward<BlockSpecialEvent>>`.
 
 ## 10.0.1
 

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -1147,6 +1147,9 @@ export class ConcordiumGRPCClient {
      * @param blockHash an optional block hash to get the special events at, otherwise retrieves from last finalized block.
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of block item summaries
+     *
+     * **Please note**, these can possibly be unknown if the SDK is not fully compatible with the Concordium
+     * node queried, in which case `null` is returned.
      */
     getBlockSpecialEvents(
         blockHash?: BlockHash.Type,

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -1148,7 +1148,10 @@ export class ConcordiumGRPCClient {
      * @param abortSignal an optional AbortSignal to close the stream.
      * @returns a stream of block item summaries
      */
-    getBlockSpecialEvents(blockHash?: BlockHash.Type, abortSignal?: AbortSignal): AsyncIterable<SDK.BlockSpecialEvent> {
+    getBlockSpecialEvents(
+        blockHash?: BlockHash.Type,
+        abortSignal?: AbortSignal
+    ): AsyncIterable<Upward<SDK.BlockSpecialEvent>> {
         const blockSpecialEvents = this.client.getBlockSpecialEvents(getBlockHashInput(blockHash), {
             abort: abortSignal,
         }).responses;

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2505,7 +2505,7 @@ function trAccountAmount(
     };
 }
 
-export function blockSpecialEvent(specialEvent: GRPC.BlockSpecialEvent): SDK.BlockSpecialEvent {
+export function blockSpecialEvent(specialEvent: GRPC.BlockSpecialEvent): Upward<SDK.BlockSpecialEvent> {
     const event = specialEvent.event;
     switch (event.oneofKind) {
         case 'bakingRewards': {
@@ -2596,7 +2596,7 @@ export function blockSpecialEvent(specialEvent: GRPC.BlockSpecialEvent): SDK.Blo
             };
         }
         case undefined: {
-            throw Error('Error translating BlockSpecialEvent: unexpected undefined');
+            return null;
         }
     }
 }


### PR DESCRIPTION
Ref COR-1718
Closes COR-1835

## Changes

- `getBlockSpecialEvents` now returns `AsyncIterable<Upward<BlockSpecialEvent>>`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.