### PR TITLE
Wrapped NodeInfoConsensusStatus and NodeCatchupStatus with Upward

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `UpdateSummary.payload` now has the type `Upward<UpdateInstructionPayload>`.
 - `UpdateEnqueuedEvent.payload` now has the type `Upward<UpdateInstructionPayload>`.
 - `PendingUpdate.effect` now has the type `Upward<PendingUpateEffect>`.
+- `NodeInfoConsensusStatus` and `NodeCatchupStatus` now have been wrapped in `Upward`.
 
 #### `ConcordiumGRPCClient`:
 

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2460,7 +2460,7 @@ export function nodeInfo(nodeInfo: GRPC.NodeInfo): SDK.NodeInfo {
     };
 }
 
-function trCatchupStatus(catchupStatus: GRPC.PeersInfo_Peer_CatchupStatus): SDK.NodeCatchupStatus {
+function trCatchupStatus(catchupStatus: GRPC.PeersInfo_Peer_CatchupStatus): Upward<SDK.NodeCatchupStatus> {
     const CatchupStatus = GRPC.PeersInfo_Peer_CatchupStatus;
     switch (catchupStatus) {
         case CatchupStatus.CATCHINGUP:
@@ -2469,6 +2469,8 @@ function trCatchupStatus(catchupStatus: GRPC.PeersInfo_Peer_CatchupStatus): SDK.
             return SDK.NodeCatchupStatus.Pending;
         case CatchupStatus.UPTODATE:
             return SDK.NodeCatchupStatus.UpToDate;
+        default:
+            return null;
     }
 }
 

--- a/packages/sdk/src/types/PeerInfo.ts
+++ b/packages/sdk/src/types/PeerInfo.ts
@@ -1,5 +1,5 @@
-import type { HexString, IpAddressString } from '../types.js';
 import type { Upward } from '../grpc/upward.js';
+import type { HexString, IpAddressString } from '../types.js';
 
 export interface PeerInfo {
     peerId: HexString;

--- a/packages/sdk/src/types/PeerInfo.ts
+++ b/packages/sdk/src/types/PeerInfo.ts
@@ -1,4 +1,5 @@
 import type { HexString, IpAddressString } from '../types.js';
+import type { Upward } from '../grpc/upward.js';
 
 export interface PeerInfo {
     peerId: HexString;
@@ -22,7 +23,7 @@ export interface PeerConsensusInfoBootstrapper {
 
 export interface PeerConsensusInfoCatchupStatus {
     tag: 'nodeCatchupStatus';
-    catchupStatus: NodeCatchupStatus;
+    catchupStatus: Upward<NodeCatchupStatus>;
 }
 
 export enum NodeCatchupStatus {


### PR DESCRIPTION
Jira-Id: COR-1841

## Purpose

Ensure new variants in gRPC API for NodeCatchupStatus and NodeInfoConsensusStatus are forward-compatible.

## Changes

Wrapped using Upward

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ x ] (If necessary) I have updated the CHANGELOG.

