### PR TITLE
Wrapped PassiveCommitteeInfo with Upward

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `UpdateSummary.payload` now has the type `Upward<UpdateInstructionPayload>`.
 - `UpdateEnqueuedEvent.payload` now has the type `Upward<UpdateInstructionPayload>`.
 - `PendingUpdate.effect` now has the type `Upward<PendingUpateEffect>`.
+- `PassiveCommitteeInfo` now has been wrapped in `Upward`
 
 #### `ConcordiumGRPCClient`:
 

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2373,7 +2373,7 @@ export function nextUpdateSequenceNumbers(nextNums: GRPC.NextUpdateSequenceNumbe
 
 function trPassiveCommitteeInfo(
     passiveCommitteeInfo: GRPC.NodeInfo_BakerConsensusInfo_PassiveCommitteeInfo
-): SDK.PassiveCommitteeInfo {
+): Upward<SDK.PassiveCommitteeInfo> {
     const passiveCommitteeInfoV2 = GRPC.NodeInfo_BakerConsensusInfo_PassiveCommitteeInfo;
     switch (passiveCommitteeInfo) {
         case passiveCommitteeInfoV2.NOT_IN_COMMITTEE:
@@ -2382,6 +2382,8 @@ function trPassiveCommitteeInfo(
             return SDK.PassiveCommitteeInfo.AddedButNotActiveInCommittee;
         case passiveCommitteeInfoV2.ADDED_BUT_WRONG_KEYS:
             return SDK.PassiveCommitteeInfo.AddedButWrongKeys;
+        default: 
+            return null;
     }
 }
 

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2382,7 +2382,7 @@ function trPassiveCommitteeInfo(
             return SDK.PassiveCommitteeInfo.AddedButNotActiveInCommittee;
         case passiveCommitteeInfoV2.ADDED_BUT_WRONG_KEYS:
             return SDK.PassiveCommitteeInfo.AddedButWrongKeys;
-        default: 
+        default:
             return null;
     }
 }

--- a/packages/sdk/src/types/NodeInfo.ts
+++ b/packages/sdk/src/types/NodeInfo.ts
@@ -1,3 +1,4 @@
+import type { Upward } from '../grpc/upward.js';
 import type { BakerId, HexString } from '../types.js';
 import type * as Duration from '../types/Duration.js';
 import type * as Timestamp from '../types/Timestamp.js';
@@ -49,7 +50,7 @@ export interface BakerConsensusInfoStatusGeneric {
 
 export interface BakerConsensusInfoStatusPassiveCommitteeInfo {
     tag: 'passiveCommitteeInfo';
-    passiveCommitteeInfo: PassiveCommitteeInfo;
+    passiveCommitteeInfo: Upward<PassiveCommitteeInfo>;
 }
 
 export enum PassiveCommitteeInfo {


### PR DESCRIPTION
## Purpose

Ensure newvariant in gRPC API for PassiveCommitteInfo are forward-compatible.

## Changes

Wrap using Upward

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [  ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ x ] (If necessary) I have updated the CHANGELOG.

