### PR TITLE
Create app token, and use it to push docs to gh-pages

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -213,9 +213,19 @@ jobs:
           echo "</ul>" >> gh-pages/index.html
           echo "</body></html>" >> gh-pages/index.html
 
+      # Setup based on: 
+      #  - https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
+      #  - https://github.com/actions/create-github-app-token?tab=readme-ov-file#use-app-token-with-actionscheckout
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.DEPLOYER_APPID }}
+          private-key: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           publish_dir: ./gh-pages
           keep_files: true

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -213,7 +213,7 @@ jobs:
           echo "</ul>" >> gh-pages/index.html
           echo "</body></html>" >> gh-pages/index.html
 
-      # Setup based on: 
+      # Setup based on:
       #  - https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
       #  - https://github.com/actions/create-github-app-token?tab=readme-ov-file#use-app-token-with-actionscheckout
       - name: Create GitHub App Token


### PR DESCRIPTION
## Purpose

To protect the gh-pages branch, while still allowing Github actions to publish new docs.

## Changes

Add step to generate app token, and use it in action to push to gh-pages branch

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
