### PR TITLE
Upgraded the path-to-regexp version to deal with the critical vulnerability alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     },
     "resolutions": {
         "@walletconnect/types": "2.13.0",
-        "@protobuf-ts/runtime-rpc": "2.9.1"
+        "@protobuf-ts/runtime-rpc": "2.9.1",
+        "path-to-regexp": "0.1.12"
     },
     "scripts": {
         "test-ci": "yarn workspace @concordium/web-sdk run test-ci && yarn workspaces foreach --no-private --exclude @concordium/web-sdk run test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22156,10 +22156,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.7":
-  version: 0.1.7
-  resolution: "path-to-regexp@npm:0.1.7"
-  checksum: 69a14ea24db543e8b0f4353305c5eac6907917031340e5a8b37df688e52accd09e3cebfe1660b70d76b6bd89152f52183f28c74813dbf454ba1a01c82a38abce
+"path-to-regexp@npm:0.1.12":
+  version: 0.1.12
+  resolution: "path-to-regexp@npm:0.1.12"
+  checksum: ab237858bee7b25ecd885189f175ab5b5161e7b712b360d44f5c4516b8d271da3e4bf7bf0a7b9153ecb04c7d90ce8ff5158614e1208819cf62bac2b08452722e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

Upgraded the path-to-regexp version to deal with the critical vulnerability alert

## Changes

Added in resolutions section of package.json "path-to-regexp": "0.1.12"
ran yarn why -R path-to-regexp, confirmed the version is updated to 0.1.12. ran yarn npm audit -R --all --severity high, no more alert came back.

─ concordium-dapp-contractupdate@workspace:examples/wallet-connection/contractupdate
│  └─ react-scripts@npm:5.0.1 [0be0d] (via npm:^5.0.1 [0be0d])
│     └─ webpack-dev-server@npm:4.15.2 [63ff3] (via npm:^4.6.0 [63ff3])
│        └─ express@npm:4.19.2 (via npm:^4.17.3)
│           └─ path-to-regexp@npm:0.1.12 (via npm:0.1.12)

## Checklist

- [ x ] My code follows the style of this project.
- [  x] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

