### PR TITLE
upgraded vite version to 4.5.14

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -27941,8 +27941,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "vite@npm:4.5.0"
+  version: 4.5.14
+  resolution: "vite@npm:4.5.14"
   dependencies:
     esbuild: ^0.18.10
     fsevents: ~2.3.2
@@ -27976,7 +27976,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 06f1a4c858e4dc4c04a10466f4ccacea30c5a9f8574e5ba3deb9d03fa20e80ca6797f02dad97a988da7cdef96238dbc69c3b6a538156585c74722d996223619e
+  checksum: ed61e2bc284968c5f514eae1f0b040ad6aa1b6591575c102d4967da5e34f8e52cd1a7048800bc3154ece0c11b4f11e1be1d0ef382c92993fd2dc6f7feca110ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

upgraded vite version to 4.5.14
this is to remove vulnerable version of 4.5.0


## Changes
ran yarn up vite -R
confirmed the version has moved to 4.5.14 after running npm audit and yarn why

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

