### PR TITLE
Fix rust-bindings compatibility with nodejs ESM

### DIFF
--- a/packages/rust-bindings/package.json
+++ b/packages/rust-bindings/package.json
@@ -16,7 +16,7 @@
         "./lib/*/bundler/index.js",
         "./lib/*/react-native/index.js"
     ],
-    "main": "lib/dapp/node/cjs/index.js",
+    "main": "lib/dapp/node/cjs/index.cjs",
     "react-native": "lib/dapp/react-native/index.js",
     "browser": "lib/dapp/web/umd/index.min.js",
     "types": "lib/dapp/node/cjs/index.d.ts",
@@ -25,7 +25,7 @@
             "types": "./lib/dapp/node/cjs/index.d.ts",
             "react-native": "./lib/dapp/react-native/index.js",
             "node": {
-                "default": "./lib/dapp/node/cjs/index.js"
+                "default": "./lib/dapp/node/cjs/index.cjs"
             },
             "browser": {
                 "types": "./lib/dapp/web/esm/index.d.ts",
@@ -38,7 +38,7 @@
             "types": "./lib/dapp/node/cjs/index.d.ts",
             "react-native": "./lib/dapp/react-native/index.js",
             "node": {
-                "default": "./lib/dapp/node/cjs/index.js"
+                "default": "./lib/dapp/node/cjs/index.cjs"
             },
             "browser": {
                 "types": "./lib/dapp/web/esm/index.d.ts",
@@ -51,7 +51,7 @@
             "types": "./lib/wallet/node/cjs/index.d.ts",
             "react-native": "./lib/wallet/react-native/index.js",
             "node": {
-                "default": "./lib/wallet/node/cjs/index.js"
+                "default": "./lib/wallet/node/cjs/index.cjs"
             },
             "browser": {
                 "types": "./lib/wallet/web/esm/index.d.ts",
@@ -80,7 +80,7 @@
         "rustfmt": "cargo +nightly-2023-04-01-x86_64-unknown-linux-gnu fmt -- --color=always",
         "clippy": "cargo +1.73 clippy --color=always --tests --benches -- -Dclippy::all",
         "build-web": "wasm-pack build ./packages/$0 --target web --out-dir $INIT_CWD/lib/$0/web/esm --out-name index",
-        "build-node": "wasm-pack build ./packages/$0 --target nodejs --out-dir $INIT_CWD/lib/$0/node/cjs --out-name index",
+        "build-node": "wasm-pack build ./packages/$0 --target nodejs --out-dir $INIT_CWD/lib/$0/node/cjs --out-name index && tsx ./scripts/fix-nodejs-ext.ts",
         "build-bundler": "wasm-pack build ./packages/$0 --target bundler --out-dir $INIT_CWD/lib/$0/bundler --out-name index",
         "build-all": "yarn build-web $0 && yarn build-node $0 && yarn build-bundler $0",
         "build": "yarn build-all dapp && tsx ./scripts/build-react-native-dapp.ts && yarn build-all wallet && tsx ./scripts/build-react-native-wallet.ts && yarn webpack && yarn sanitize",

--- a/packages/rust-bindings/scripts/fix-nodejs-ext.ts
+++ b/packages/rust-bindings/scripts/fix-nodejs-ext.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const filesToRename = ['lib/dapp/node/cjs/index.js', 'lib/wallet/node/cjs/index.js'];
+
+for (const file of filesToRename) {
+    const oldPath = path.join(__dirname, '..', file);
+    const newPath = oldPath.replace(/\.js$/, '.cjs');
+
+    if (fs.existsSync(oldPath)) {
+        fs.renameSync(oldPath, newPath);
+        console.log(`Renamed: ${file} -> ${file.replace(/\.js$/, '.cjs')}`);
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes an issue where `@concordium/rust-bindings` could not be executed in an ESM context in nodejs. This fixes unreleased code, so no reason to create a new release for this.