### PR TITLE
To introduce deserialization in UpdateCredentialsHandler

### DIFF
--- a/packages/sdk/src/accountTransactions.ts
+++ b/packages/sdk/src/accountTransactions.ts
@@ -568,7 +568,7 @@ export class UpdateCredentialsHandler implements AccountTransactionHandler<Updat
             deserializeCredentialDeploymentValues(serializedPayload, partialData, i);
             console.log(`partialData after populating crdValue at i=${i}:`, partialData);
 
-            deserializeCredentialDeploymentProofs(serializedPayload/*, partialData, i*/);
+            deserializeCredentialDeploymentProofs(serializedPayload, partialData, i);
             console.log(`partialData after populating crdProofs at i=${i}:`, partialData);
         }
         

--- a/packages/sdk/src/deserialization.ts
+++ b/packages/sdk/src/deserialization.ts
@@ -133,7 +133,7 @@ export function deserializeCredentialDeploymentValues(serializedPayload: Cursor,
             revocationThreshold: revocationThreshold,
             arData: arData,
 
-            //TODO: Still looking for this
+            //TODO: Still looking for this, not in serialize() but on the bluepaper
             commitments: {
                 cmmPrf: '',
                 cmmCredCounter: '',
@@ -141,7 +141,7 @@ export function deserializeCredentialDeploymentValues(serializedPayload: Cursor,
                 cmmAttributes: {},
                 cmmMaxAccounts: '',
             },
-            //TODO: still looking for this
+            //TODO: still looking for this, not on bluepaper, but this looks to be part of serialize() but how do i generate this back for deserialize?
             proofs: '',
 
             ipIdentity: ipId,
@@ -227,7 +227,7 @@ export function deserializeCredentialVerifyKey(serializedPayload: Cursor): Crede
     }
 }
 
-export function deserializeCredentialDeploymentProofs(serializedPayload: Cursor/*, data: Partial<UpdateCredentialsPayload>, currentLocation: number*/) {
+export function deserializeCredentialDeploymentProofs(serializedPayload: Cursor, data: Partial<UpdateCredentialsPayload>, currentLocation: number) {
 
     //CredentialDeploymentProofs.idProofs
     //  IdOwnershipProofs.sig
@@ -235,7 +235,7 @@ export function deserializeCredentialDeploymentProofs(serializedPayload: Cursor/
 
     //  IdOwnershipProofs.commitments
     /* const prf = */serializedPayload.read(48);
-    /* const credCounter = */serializedPayload.read(48);
+    const credCounter = serializedPayload.read(48);
     /* const maxAccounts = */serializedPayload.read(48);
     
     const attributeCommitmentRecords: Record<any, any> = {};
@@ -297,6 +297,10 @@ export function deserializeCredentialDeploymentProofs(serializedPayload: Cursor/
     }
 
     //populate placeholder, if any can be populated, and go back to the for loop in deserialize() and read next CredentialDeploymentInformation, if any    
+    if(data.newCredentials) {
+        //TODO: is cmmCredCounter the same as bluepaper.credCounter inside CredentialDeploymentCommitments
+        data.newCredentials[currentLocation].cdi.commitments.cmmCredCounter = credCounter.toString(); 
+    }
 }
 
 export function deserializeCredentialsToBeRemoved(serializedPayload: Cursor, data: Partial<UpdateCredentialsPayload>) {


### PR DESCRIPTION
## Purpose

To introduce deserialization in UpdateCredentialsHandler

## Changes

read the serialized payload in the deserialize function within accountTransactions.ts, instead of throwing an exception of not suported method.

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

