### PR TITLE
Allow specification of nonce for anchor registration helpers

### DIFF
--- a/docs/pages/verifiable-presentations.md
+++ b/docs/pages/verifiable-presentations.md
@@ -180,8 +180,7 @@ const signer: Signer = ...;
 // create the verification request with an on-chain anchor, which can be checked by the owner of the credentials.
 const verificationRequest = await VerificationRequestV1.createAndAnchor(
     grpcClient,
-    sender,
-    signer,
+    { sender, signer }
     context,
     statement
 );
@@ -250,5 +249,5 @@ const uuid: string = ...;
 // Verify the presentation in the context of the verification request and create the audit record.
 const record = VerificationAuditRecordV1.createChecked(uuid, verificationRequest, presentation, grpcClient, network);
 // Register the verification audit anchor on the chain
-const anchorTransactionHash = await VerificationAuditRecordV1.registerAnchor(record, grpcClient, sender, signer);
+const anchorTransactionHash = await VerificationAuditRecordV1.registerAnchor(record, grpcClient, { sender, signer });
 ```

--- a/examples/nodejs/proofs/verifiable-presentation-id-cred.ts
+++ b/examples/nodejs/proofs/verifiable-presentation-id-cred.ts
@@ -132,7 +132,7 @@ const statements = VerificationRequestV1.statementBuilder()
         b.revealAttribute('firstName');
     })
     .getStatements();
-const verificationRequest = await VerificationRequestV1.createAndAnchor(grpc, sender, signer, context, statements, {
+const verificationRequest = await VerificationRequestV1.createAndAnchor(grpc, { sender, signer }, context, statements, {
     info: 'Example VP anchor',
 });
 
@@ -205,9 +205,14 @@ const result = await VerificationAuditRecordV1.createChecked(
 );
 
 if (result.type === 'failed') throw new Error(`Failed to verify presentation: ${result.error}`);
-const auditTransaction = await VerificationAuditRecordV1.registerAnchor(result.result, grpc, sender, signer, {
-    info: 'Some public info',
-});
+const auditTransaction = await VerificationAuditRecordV1.registerAnchor(
+    result.result,
+    grpc,
+    { sender, signer },
+    {
+        info: 'Some public info',
+    }
+);
 
 console.log('Waiting for verification audit report registration to finalize:', auditTransaction.toString());
 await grpc.waitForTransactionFinalization(auditTransaction);

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- `VerificationRequestV1.createAndAnchor` and `VerificationAuditRecordV1.registerAnchor` now also allows for 
+  specififying a sequence number to use for the transaction.
+  The function signature has been changed to take "transaction metadata" as an object, which now includes the
+  the transaction `sender` and `signer`, in addition to an optional `sequenceNumber`.
+
 ## 11.1.0-alpha.3
 
 ### Fixed

--- a/packages/sdk/src/wasm/VerifiablePresentationV1/internal.ts
+++ b/packages/sdk/src/wasm/VerifiablePresentationV1/internal.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer/index.js';
 
-import { BlockHash } from '../../types/index.js';
+import { AccountSigner } from '../../signHelpers.js';
+import { AccountAddress, BlockHash, SequenceNumber } from '../../types/index.js';
 import type { CredentialContextLabel, GivenContext } from './types.js';
 
 /**
@@ -77,3 +78,18 @@ export function givenContextFromJSON(context: GivenContextJSON): GivenContext {
             return context as GivenContext;
     }
 }
+
+export type AnchorTransactionMetadata = {
+    /**
+     * The sender account of the anchor transaction.
+     */
+    sender: AccountAddress.Type;
+    /**
+     * The signer object used to sign the on-chain anchor registration. This must correspond to the `sender` account.
+     */
+    signer: AccountSigner;
+    /**
+     * The sequence number for the sender account to use. If this is not defined it will be fetched from the node.
+     */
+    sequenceNumber?: SequenceNumber.Type;
+};


### PR DESCRIPTION
## Purpose

To enable use cases manually keeping track of the sequence number for an account used to send transactions, the sequence number can now be specified as part of the input to anchor registration functions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.