### PR TITLE
Introducing the new proto items to be in the node-js sdk

### DIFF
--- a/examples/nodejs/client/getTokenAuthorizations.ts
+++ b/examples/nodejs/client/getTokenAuthorizations.ts
@@ -64,12 +64,7 @@ const client = new ConcordiumGRPCNodeClient(
     const tokenId = TokenId.fromString(cli.flags.token);
     const blockHash = BlockHash.fromHexString(cli.flags.block);
 
-    const tokenAuthorizationsRequest = {
-        tokenId: tokenId,
-        blockHash: blockHash,
-    };
-
-    const tokenAuthorizations = await client.getTokenAuthorizations(tokenAuthorizationsRequest);
+    const tokenAuthorizations = await client.getTokenAuthorizations(tokenId, blockHash);
 
     console.log('Token authorizations:', tokenAuthorizations);
     // #endregion documentation-snippet

--- a/examples/nodejs/client/getTokenAuthorizations.ts
+++ b/examples/nodejs/client/getTokenAuthorizations.ts
@@ -1,0 +1,76 @@
+import { BlockHash } from '@concordium/web-sdk';
+import { ConcordiumGRPCNodeClient } from '@concordium/web-sdk/nodejs';
+import { TokenId } from '@concordium/web-sdk/plt';
+import { credentials } from '@grpc/grpc-js';
+import meow from 'meow';
+
+import { parseEndpoint } from '../shared/util.js';
+
+const cli = meow(
+    `
+  Usage
+    $ yarn run-example <path-to-this-file> [options]
+
+  Required
+    --token, -t  The token to query information about
+    --block, -b  A block to query from
+
+  Options
+    --help,         Displays this message
+    --endpoint, -e  Specify endpoint of the form "address:port", defaults to localhost:20000
+    --secure,   -s  Whether to use tls or not. Defaults to false.
+`,
+    {
+        importMeta: import.meta,
+        flags: {
+            token: {
+                type: 'string',
+                alias: 't',
+                isRequired: true,
+            },
+            block: {
+                type: 'string',
+                alias: 'b',
+                isRequired: true,
+            },
+            endpoint: {
+                type: 'string',
+                alias: 'e',
+                default: 'localhost:20000',
+            },
+            secure: {
+                type: 'boolean',
+                alias: 's',
+                default: false,
+            },
+        },
+    }
+);
+
+const [address, port] = parseEndpoint(cli.flags.endpoint);
+
+const client = new ConcordiumGRPCNodeClient(
+    address,
+    Number(port),
+    cli.flags.secure ? credentials.createSsl() : credentials.createInsecure()
+);
+
+/**
+ * Retrieves information about token authorizations. The function must be provided a
+ * token authorization request object with a token id and a block hash.
+ */
+(async () => {
+    // #region documentation-snippet
+    const tokenId = TokenId.fromString(cli.flags.token);
+    const blockHash = BlockHash.fromHexString(cli.flags.block);
+
+    const tokenAuthorizationsRequest = {
+        tokenId: tokenId,
+        blockHash: blockHash,
+    };
+
+    const tokenAuthorizations = await client.getTokenAuthorizations(tokenAuthorizationsRequest);
+
+    console.log('Token authorizations:', tokenAuthorizations);
+    // #endregion documentation-snippet
+})();

--- a/packages/rust-bindings/packages/wallet/src/external_functions.rs
+++ b/packages/rust-bindings/packages/wallet/src/external_functions.rs
@@ -426,7 +426,7 @@ pub fn create_verification_request_v1_anchor(raw_input: JsonString) -> JsResult<
     let input: VerificationRequestV1Input = serde_json::from_str(&raw_input)?;
     let public = input.public_info.clone();
     let anchor = VerificationRequestData::from(input).to_anchor(public.map(|p| p.0));
-    cbor_encode(&anchor).map_err(to_js_error)
+    Ok(cbor_encode(&anchor))
 }
 
 #[wasm_bindgen(js_name = computeVerificationRequestV1AnchorHash)]
@@ -451,7 +451,7 @@ pub fn create_verification_audit_v1_anchor(raw_input: JsonString) -> JsResult<Ve
     let input: VerificationAuditV1Input = serde_json::from_str(&raw_input)?;
     let public = input.public_info.clone();
     let anchor = input.record.to_anchor(public.map(|p| p.0));
-    cbor_encode(&anchor).map_err(to_js_error)
+    Ok(cbor_encode(&anchor))
 }
 
 /// Computes the hash of a verification audit v1 anchor.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Token operations for updating metadata, assigning and revoking admin roles have been added.
 - Token events for updating metadata, assigning and revoking admin roles have been added.
+- New Proto types, a translation function for those proto types and a new function getTokenAuthorizations
 
 ## 12.0.2
 

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -38,6 +38,7 @@ import type { BlockItemStatus, BlockItemSummary } from '../types/blockItemSummar
 import { countSignatures, isHex, isValidIp, mapRecord, mapStream, unwrap } from '../util.js';
 import * as translate from './translation.js';
 import type { Upward } from './upward.js';
+import { TokenAuthorizationsRequest } from '../grpc-api/v2/concordium/types.js';
 
 /**
  * @hidden
@@ -1600,6 +1601,24 @@ export class ConcordiumGRPCClient {
         const blockHashInput = getBlockHashInput(blockHash);
         const tokenIds = this.client.getTokenList(blockHashInput, { abort: abortSignal }).responses;
         return mapStream(tokenIds, PLT.TokenId.fromProto);
+    }
+
+    /**
+     * Get the authorizations of a given token in the given block
+     * @param request tokenAuthorizationsRequest structure containing the token ID and block hash
+     * @returns 
+     */
+    async getTokenAuthorizations(request: PLT.TokenAuthorizationsRequest): Promise<PLT.TokenAuthorizations> {
+        const blockHashInput = getBlockHashInput(request.blockHash);
+
+        const req: TokenAuthorizationsRequest = {
+             tokenId: PLT.TokenId.toProto(request.tokenId),
+             blockHash: blockHashInput,
+        };
+
+        const result = await this.client.getTokenAuthorizations(req);
+
+        return translate.trTokenAuthorizations(result.response);
     }
 }
 

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -1609,7 +1609,10 @@ export class ConcordiumGRPCClient {
      * @param blockHash an optional block hash to get the info from, otherwise retrieves from last finalized block.
      * @returns
      */
-    async getTokenAuthorizations(tokenId: PLT.TokenId.Type, blockHash?: BlockHash.Type): Promise<PLT.TokenAuthorizations> {
+    async getTokenAuthorizations(
+        tokenId: PLT.TokenId.Type,
+        blockHash?: BlockHash.Type
+    ): Promise<PLT.TokenAuthorizations> {
         const blockHashInput = getBlockHashInput(blockHash);
 
         const req: TokenAuthorizationsRequest = {

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -15,6 +15,7 @@ import { HealthClient } from '../grpc-api/v2/concordium/health.client.js';
 import * as GRPCKernel from '../grpc-api/v2/concordium/kernel.js';
 import { QueriesClient } from '../grpc-api/v2/concordium/service.client.js';
 import * as GRPC from '../grpc-api/v2/concordium/types.js';
+import { TokenAuthorizationsRequest } from '../grpc-api/v2/concordium/types.js';
 import * as PLT from '../plt/index.js';
 import { RawModuleSchema } from '../schemaTypes.js';
 import { serializeAccountTransactionPayload } from '../serialization.js';
@@ -38,7 +39,6 @@ import type { BlockItemStatus, BlockItemSummary } from '../types/blockItemSummar
 import { countSignatures, isHex, isValidIp, mapRecord, mapStream, unwrap } from '../util.js';
 import * as translate from './translation.js';
 import type { Upward } from './upward.js';
-import { TokenAuthorizationsRequest } from '../grpc-api/v2/concordium/types.js';
 
 /**
  * @hidden
@@ -1606,14 +1606,14 @@ export class ConcordiumGRPCClient {
     /**
      * Get the authorizations of a given token in the given block
      * @param request tokenAuthorizationsRequest structure containing the token ID and block hash
-     * @returns 
+     * @returns
      */
     async getTokenAuthorizations(request: PLT.TokenAuthorizationsRequest): Promise<PLT.TokenAuthorizations> {
         const blockHashInput = getBlockHashInput(request.blockHash);
 
         const req: TokenAuthorizationsRequest = {
-             tokenId: PLT.TokenId.toProto(request.tokenId),
-             blockHash: blockHashInput,
+            tokenId: PLT.TokenId.toProto(request.tokenId),
+            blockHash: blockHashInput,
         };
 
         const result = await this.client.getTokenAuthorizations(req);

--- a/packages/sdk/src/grpc/GRPCClient.ts
+++ b/packages/sdk/src/grpc/GRPCClient.ts
@@ -1605,14 +1605,15 @@ export class ConcordiumGRPCClient {
 
     /**
      * Get the authorizations of a given token in the given block
-     * @param request tokenAuthorizationsRequest structure containing the token ID and block hash
+     * @param tokenId the ID of the token to query information about
+     * @param blockHash an optional block hash to get the info from, otherwise retrieves from last finalized block.
      * @returns
      */
-    async getTokenAuthorizations(request: PLT.TokenAuthorizationsRequest): Promise<PLT.TokenAuthorizations> {
-        const blockHashInput = getBlockHashInput(request.blockHash);
+    async getTokenAuthorizations(tokenId: PLT.TokenId.Type, blockHash?: BlockHash.Type): Promise<PLT.TokenAuthorizations> {
+        const blockHashInput = getBlockHashInput(blockHash);
 
         const req: TokenAuthorizationsRequest = {
-            tokenId: PLT.TokenId.toProto(request.tokenId),
+            tokenId: PLT.TokenId.toProto(tokenId),
             blockHash: blockHashInput,
         };
 

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2784,3 +2784,10 @@ export function BlocksAtHeightRequestToV2(request: SDK.BlocksAtHeightRequest): G
         };
     }
 }
+
+export function trTokenAuthorizations(tokenAuthorizations: GRPC_PLT.TokenAuthorizations ): PLT.TokenAuthorizations {
+    return {
+        tokenId: PLT.TokenId.fromProto(unwrap(tokenAuthorizations.tokenId)),
+        details: PLT.Cbor.fromProto(unwrap(tokenAuthorizations.details)),
+    };
+}

--- a/packages/sdk/src/grpc/translation.ts
+++ b/packages/sdk/src/grpc/translation.ts
@@ -2785,7 +2785,7 @@ export function BlocksAtHeightRequestToV2(request: SDK.BlocksAtHeightRequest): G
     }
 }
 
-export function trTokenAuthorizations(tokenAuthorizations: GRPC_PLT.TokenAuthorizations ): PLT.TokenAuthorizations {
+export function trTokenAuthorizations(tokenAuthorizations: GRPC_PLT.TokenAuthorizations): PLT.TokenAuthorizations {
     return {
         tokenId: PLT.TokenId.fromProto(unwrap(tokenAuthorizations.tokenId)),
         details: PLT.Cbor.fromProto(unwrap(tokenAuthorizations.details)),

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -1,4 +1,3 @@
-import * as BlockHash from '../types/BlockHash.js';
 import type { Cbor, TokenAmount, TokenId, TokenModuleReference } from './index.js';
 
 /**

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -1,4 +1,5 @@
 import type { Cbor, TokenAmount, TokenId, TokenModuleReference } from './index.js';
+import * as BlockHash from '../types/BlockHash.js';
 
 /**
  * Represents a protocol level token state for an account.
@@ -74,3 +75,13 @@ export type CreatePLTPayload = {
     /** The module specific initialization parameters. */
     initializationParameters: Cbor.Type;
 };
+
+export type TokenAuthorizationsRequest = {
+    blockHash: BlockHash.Type;
+    tokenId: TokenId.Type;
+}
+
+export type TokenAuthorizations = {
+    tokenId: TokenId.Type;
+    details: Cbor.Type;
+}

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -76,11 +76,10 @@ export type CreatePLTPayload = {
     initializationParameters: Cbor.Type;
 };
 
-export type TokenAuthorizationsRequest = {
-    blockHash: BlockHash.Type;
-    tokenId: TokenId.Type;
-};
-
+/**
+ * Represents the authorizations of a token, such as allow/deny lists, at a specific block.
+ * see {@link GRPCClient.getTokenAuthorizations} for more details.
+ */
 export type TokenAuthorizations = {
     tokenId: TokenId.Type;
     details: Cbor.Type;

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -1,5 +1,5 @@
-import type { Cbor, TokenAmount, TokenId, TokenModuleReference } from './index.js';
 import * as BlockHash from '../types/BlockHash.js';
+import type { Cbor, TokenAmount, TokenId, TokenModuleReference } from './index.js';
 
 /**
  * Represents a protocol level token state for an account.
@@ -79,9 +79,9 @@ export type CreatePLTPayload = {
 export type TokenAuthorizationsRequest = {
     blockHash: BlockHash.Type;
     tokenId: TokenId.Type;
-}
+};
 
 export type TokenAuthorizations = {
     tokenId: TokenId.Type;
     details: Cbor.Type;
-}
+};


### PR DESCRIPTION
## Purpose
To introduce the recent additions and changes on the proto files and enabling these to be used within the node sdk.
service proto introduced getTokenAuthorizations
types proto introduced TokenAuthorizationsRequest

## Changes
1. Pointing to new protobuf definitions from concordium base, changed the deps/concordium-base branch to feature/rbac
2. Created inside types.ts, two new types to represent TokenAuthorizationsRequest and TokenAuthorizations
3. in translation.ts, a new function to translate proto TokenAuthorizations to sdk type of TokenAuthorizations
4. in GrpcClient.ts, created a new function, getTokenAuthorizations, given a TokenAuthorizationsRequest
5. fixed external_functions.rs, due to failure in compiling as cbor_encode returns Vec<u8> now and map_err no longer applicable for that cbor_encode.

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
