### PR TITLE
Revise SDK types to match non-dynamic token module implementation

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Removed additional field from TokenModuleAccountState type
+- Removed `additional` field from TokenModuleAccountState and TokenModuleState types as they never contained any data
 
 ## 12.0.2
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Removed additional field from TokenModuleAccountState type
+
 ## 12.0.2
 
 ### Changed

--- a/packages/sdk/src/plt/module.ts
+++ b/packages/sdk/src/plt/module.ts
@@ -41,18 +41,12 @@ export type TokenModuleState = {
  * managed by the Token Kernel, such as the token identifier and account balance.
  *
  * All fields are optional, and can be omitted if the module implementation does not support them.
- * The structure supports additional fields for future extensibility. Non-standard fields (i.e. any
- * fields that are not defined by a standard, and are specific to the module implementation) may
- * be included, and their tags should be prefixed with an underscore ("_") to distinguish them
- * as such.
  */
 export type TokenModuleAccountState = {
     /** Whether the account is on the allow list. */
     allowList?: boolean;
     /** Whether the account is on the deny list. */
     denyList?: boolean;
-    /** Any additional state information depending on the module implementation. */
-    [key: string]: unknown;
 };
 
 /**

--- a/packages/sdk/src/plt/module.ts
+++ b/packages/sdk/src/plt/module.ts
@@ -9,10 +9,7 @@ import { Cbor, CborAccountAddress, CreatePLTPayload, TokenAmount, TokenMetadataU
  * `GetAccountInfo` instead.
  *
  * The "name" and "metadata" fields are required. Other fields are optional, and can be omitted if
- * the module implementation does not support them. The structure supports additional fields for
- * future extensibility. Non-standard fields (i.e. any fields that are not defined by a standard,
- * and are specific to the module implementation) may be included, and their tags should be
- * prefixed with an underscore ("_") to distinguish them as such.
+ * the module implementation does not support them.
  */
 export type TokenModuleState = {
     /** The name of the token. */
@@ -31,8 +28,6 @@ export type TokenModuleState = {
     burnable?: boolean;
     /** Whether the token operations are paused or not. */
     paused?: boolean;
-    /** Any additional state information depending on the module implementation */
-    [key: string]: unknown;
 };
 
 /**

--- a/packages/sdk/test/ci/plt/Cbor.test.ts
+++ b/packages/sdk/test/ci/plt/Cbor.test.ts
@@ -81,7 +81,6 @@ describe('PLT Cbor', () => {
                 initialSupply,
                 mintable: true,
                 burnable: true,
-                customField: 'custom value',
             };
 
             const encoded = Cbor.encode(params);

--- a/packages/sdk/test/ci/plt/Cbor.test.ts
+++ b/packages/sdk/test/ci/plt/Cbor.test.ts
@@ -127,7 +127,6 @@ describe('PLT Cbor', () => {
             const state = {
                 allowList: true,
                 denyList: false,
-                customField: 'custom value',
             };
 
             const encoded = Cbor.encode(state);
@@ -135,7 +134,6 @@ describe('PLT Cbor', () => {
 
             expect(decoded.allowList).toBe(state.allowList);
             expect(decoded.denyList).toBe(state.denyList);
-            expect(decoded.customField).toBe(state.customField);
         });
 
         test('should throw error if TokenModuleAccountState has invalid field types', () => {

--- a/packages/sdk/test/ci/plt/Cbor.test.ts
+++ b/packages/sdk/test/ci/plt/Cbor.test.ts
@@ -25,7 +25,6 @@ describe('PLT Cbor', () => {
                 denyList: false,
                 mintable: true,
                 burnable: true,
-                customField: 'custom value',
             };
 
             const encoded = Cbor.encode(state);
@@ -38,7 +37,6 @@ describe('PLT Cbor', () => {
             expect(decoded.denyList).toBe(state.denyList);
             expect(decoded.mintable).toBe(state.mintable);
             expect(decoded.burnable).toBe(state.burnable);
-            expect(decoded.customField).toBe(state.customField);
         });
 
         test('should encode and decode minimal TokenModuleState correctly', () => {


### PR DESCRIPTION
## Purpose
1. Following the changes on cddl, https://github.com/Concordium/concordium-base/pull/892/changes
we need to remove "additional" from tokenModuleAccountState on the SDK.
2. TokenInitializationParameters has no "additional" on the SDK.
3. TokenModuleState, remove the "additional" from the type structure

## Changes
module.ts, amended the type TokenModuleAccountState.
Cbor.test.ts, there is an existing test involving TokenInitializationParameters which was using customField incorrectly, removed that from the test. 
Also for TokenModuleState test in Cbor.test.ts, amended the test.

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ x ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
