### PR TITLE
[COR-2368] Fix inability to make a zero-knowledge proof in certain cases

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Removed
+
+- In zero knowledge proofs removed limitation of a single statement per attribute
+
 ## 12.0.2
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "12.0.2",
+    "version": "12.1.0-alpha.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/id/idProofs.ts
+++ b/packages/sdk/src/id/idProofs.ts
@@ -147,9 +147,6 @@ function verifyAtomicStatement(statement: AtomicStatement, existingStatements: I
     if (!(statement.attributeTag in AttributeKeyString)) {
         throw new Error('Unknown attributeTag: ' + statement.attributeTag);
     }
-    if (existingStatements.some((v) => v.attributeTag === statement.attributeTag)) {
-        throw new Error('Only 1 statement is allowed for each attribute');
-    }
     switch (statement.type) {
         case StatementTypes.AttributeInRange:
             return verifyRangeStatement(statement);

--- a/packages/sdk/src/id/idProofs.ts
+++ b/packages/sdk/src/id/idProofs.ts
@@ -137,7 +137,7 @@ function verifySetStatement(statement: MembershipStatement | NonMembershipStatem
     }
 }
 
-function verifyAtomicStatement(statement: AtomicStatement, existingStatements: IdStatement) {
+function verifyAtomicStatement(statement: AtomicStatement) {
     if (statement.type === undefined) {
         throw new Error('Statements must contain a type field');
     }
@@ -174,7 +174,7 @@ export function verifyIdstatement(statements: IdStatement): boolean {
     }
     const checkedStatements = [];
     for (const s of statements) {
-        verifyAtomicStatement(s, checkedStatements);
+        verifyAtomicStatement(s);
         checkedStatements.push(s);
     }
     return true;
@@ -202,7 +202,7 @@ export class IdStatementBuilder implements StatementBuilder {
      */
     private check(statement: AtomicStatement) {
         if (this.checkConstraints) {
-            verifyAtomicStatement(statement, this.statements);
+            verifyAtomicStatement(statement);
         }
     }
 

--- a/packages/sdk/src/web3-id/proofs.ts
+++ b/packages/sdk/src/web3-id/proofs.ts
@@ -250,13 +250,9 @@ function verifyAtomicStatement<AttributeKey>(
  */
 function verifyAtomicStatementInContext<AttributeKey>(
     statement: AtomicStatementV2<AttributeKey>,
-    existingStatements: AtomicStatementV2<AttributeKey>[],
     schema?: CredentialSchemaSubject
 ) {
     verifyAtomicStatement(statement, schema);
-    if (existingStatements.some((v) => v.attributeTag === statement.attributeTag)) {
-        throw new Error('Only 1 statement is allowed for each attribute');
-    }
 }
 
 /**
@@ -269,7 +265,7 @@ export function verifyAtomicStatements(statements: AtomicStatementV2[], schema?:
     }
     const checkedStatements: AtomicStatementV2[] = [];
     for (const s of statements) {
-        verifyAtomicStatementInContext(s, checkedStatements, schema);
+        verifyAtomicStatementInContext(s, schema);
         checkedStatements.push(s);
     }
     return true;
@@ -324,7 +320,7 @@ export class AtomicStatementBuilder<AttributeKey = string> implements InternalBu
      */
     private check(statement: AtomicStatementV2<AttributeKey>) {
         if (this.schema) {
-            verifyAtomicStatementInContext(statement, this.statements, this.schema);
+            verifyAtomicStatementInContext(statement, this.schema);
         }
     }
 

--- a/packages/sdk/test/ci/idProofs.test.ts
+++ b/packages/sdk/test/ci/idProofs.test.ts
@@ -6,23 +6,23 @@ import { IdStatementBuilder } from '../../src/id/idProofs.js';
 import { AttributeKeyString, AttributesKeys, IdDocType } from '../../src/types.js';
 import { getIdProof } from '../../src/wasm/index.js';
 
-test('Creating a statement with multiple atomic statements on the same attribute fails', () => {
+test('Creating a statement with multiple atomic statements on the same attribute should not fail', () => {
     const builder = new IdStatementBuilder(true);
     expect(() =>
         builder
             .addRange(AttributesKeys.dob, '20001010', '20201010')
             .addRange(AttributesKeys.dob, '20001010', '20201010')
-    ).toThrow();
-    expect(() => builder.addMembership(AttributesKeys.countryOfResidence, []).addEUResidency()).toThrow();
+    ).not.toThrow();
+    expect(() => builder.addMembership(AttributesKeys.countryOfResidence, []).addEUResidency()).not.toThrow();
     expect(() =>
         builder
             .addNonMembership(AttributesKeys.countryOfResidence, ['DE'])
             .addNonMembership(AttributesKeys.countryOfResidence, ['DK', 'FR'])
-    ).toThrow();
+    ).not.toThrow();
     expect(() =>
         builder.revealAttribute(AttributesKeys.countryOfResidence).revealAttribute(AttributesKeys.countryOfResidence)
-    ).toThrow();
-    expect(() => builder.addMinimumAge(18).addMinimumAge(20)).toThrow();
+    ).not.toThrow();
+    expect(() => builder.addMinimumAge(18).addMinimumAge(20)).not.toThrow();
 });
 
 test('Minimum age helper adds a range statement on date of birth', () => {

--- a/packages/sdk/test/ci/idProofs.test.ts
+++ b/packages/sdk/test/ci/idProofs.test.ts
@@ -13,7 +13,6 @@ test('Creating a statement with multiple atomic statements on the same attribute
             .addRange(AttributesKeys.dob, '20001010', '20201010')
             .addRange(AttributesKeys.dob, '20001010', '20201010')
     ).not.toThrow();
-    expect(() => builder.addMembership(AttributesKeys.countryOfResidence, []).addEUResidency()).not.toThrow();
     expect(() =>
         builder
             .addNonMembership(AttributesKeys.countryOfResidence, ['DE'])
@@ -23,6 +22,11 @@ test('Creating a statement with multiple atomic statements on the same attribute
         builder.revealAttribute(AttributesKeys.countryOfResidence).revealAttribute(AttributesKeys.countryOfResidence)
     ).not.toThrow();
     expect(() => builder.addMinimumAge(18).addMinimumAge(20)).not.toThrow();
+});
+
+test('Statements may not use empty sets', () => {
+    const builder = new IdStatementBuilder(true);
+    expect(() => builder.addMembership(AttributesKeys.countryOfResidence, []).addEUResidency()).toThrow();
 });
 
 test('Minimum age helper adds a range statement on date of birth', () => {


### PR DESCRIPTION
## Purpose

Fix such that an attribute can both be used in bullet proofs and revealed at the same time. This was not possible for identity based presentations (actually, it depended on the order of the statements, if the prover would fail

## Changes

Removed single statement checks and validation

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

