### PR TITLE
Support decoding CBOR in getTokenAuthorizations

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Token operations for updating metadata, assigning and revoking admin roles have been added.
 - Token events for updating metadata, assigning and revoking admin roles have been added.
 - New Proto types, a translation function for those proto types and a new function getTokenAuthorizations
+- `TokenAdminRole.UpdateAllowList` value corrected from `'allowList'` to `'updateAllowList'`, and `TokenAdminRole.UpdateDenyList` from `'denyList'` to `'updateDenyList'`, to match the canonical CDDL role strings.
 
 ## 12.0.2
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Token events for updating metadata, assigning and revoking admin roles have been added.
 - New Proto types, a translation function for those proto types and a new function getTokenAuthorizations
 - `TokenAdminRole.UpdateAllowList` value corrected from `'allowList'` to `'updateAllowList'`, and `TokenAdminRole.UpdateDenyList` from `'denyList'` to `'updateDenyList'`, to match the canonical CDDL role strings.
+- Added `TokenRoleAuthorizations` and `TokenAuthorizationsDetails` types representing the decoded CBOR structure returned by `getTokenAuthorizations`.
+- `Cbor.decode` now accepts `'TokenAuthorizationsDetails'` as a type hint, decoding the CBOR `details` field of `TokenAuthorizations` into a `Partial<Record<TokenAdminRole, TokenRoleAuthorizations>>`.
 
 ## 12.0.2
 

--- a/packages/sdk/src/plt/TokenOperation.ts
+++ b/packages/sdk/src/plt/TokenOperation.ts
@@ -27,8 +27,8 @@ export enum TokenAdminRole {
     UpdateAdminRoles = 'updateAdminRoles', //Gives authority to perform `token-assign-admin-roles` and `token-revoke-admin-roles` operations.
     Mint = 'mint', //Gives authority to perform `token-mint` operations.
     Burn = 'burn', //Gives authority to perform `token-burn` operations.
-    UpdateAllowList = 'allowList', //Gives authority to perform `token-add-allow-list` and `token-remove-allow-list` operations.
-    UpdateDenyList = 'denyList', //Gives authority to perform `token-add-deny-list` and `token-remove-deny-list` operations.
+    UpdateAllowList = 'updateAllowList', //Gives authority to perform `token-add-allow-list` and `token-remove-allow-list` operations.
+    UpdateDenyList = 'updateDenyList', //Gives authority to perform `token-add-deny-list` and `token-remove-deny-list` operations.
     Pause = 'pause', //Gives authority to perform `token-pause` and `token-unpause` operations.
     UpdateMetadata = 'updateMetadata', //Gives authority to perform `token-update-metadata` operations.
 }

--- a/packages/sdk/src/plt/decode.ts
+++ b/packages/sdk/src/plt/decode.ts
@@ -12,7 +12,7 @@ import {
     UnknownTokenOperation,
     decodeTokenOperations,
 } from './index.js';
-import { TokenAuthorizationsDetails, TokenRoleAuthorizations } from './types.js';
+import { TokenAuthorizationsDetails, TokenRoleAuthorizations } from './module.js';
 
 function decodeTokenAuthorizationsDetails(value: Cbor.Type): TokenAuthorizationsDetails {
     const decoded = cborDecode(value.bytes);
@@ -23,7 +23,7 @@ function decodeTokenAuthorizationsDetails(value: Cbor.Type): TokenAuthorizations
     const result: TokenAuthorizationsDetails = {};
     for (const [key, roleAuth] of Object.entries(decoded)) {
         if (!validRoles.has(key)) {
-            throw new Error(`Invalid TokenAuthorizationsDetails: unknown role "${key}"`);
+            continue;
         }
         if (typeof roleAuth !== 'object' || roleAuth === null || !('accounts' in roleAuth)) {
             throw new Error(`Invalid TokenAuthorizationsDetails: role "${key}" missing "accounts" field`);

--- a/packages/sdk/src/plt/decode.ts
+++ b/packages/sdk/src/plt/decode.ts
@@ -1,4 +1,5 @@
 import { cborDecode } from '../types/cbor.js';
+import { TokenAdminRole } from './TokenOperation.js';
 import {
     Cbor,
     CborAccountAddress,
@@ -11,6 +12,35 @@ import {
     UnknownTokenOperation,
     decodeTokenOperations,
 } from './index.js';
+import { TokenAuthorizationsDetails, TokenRoleAuthorizations } from './types.js';
+
+function decodeTokenAuthorizationsDetails(value: Cbor.Type): TokenAuthorizationsDetails {
+    const decoded = cborDecode(value.bytes);
+    if (typeof decoded !== 'object' || decoded === null) {
+        throw new Error('Invalid CBOR data for TokenAuthorizationsDetails');
+    }
+    const validRoles = new Set<string>(Object.values(TokenAdminRole));
+    const result: TokenAuthorizationsDetails = {};
+    for (const [key, roleAuth] of Object.entries(decoded)) {
+        if (!validRoles.has(key)) {
+            throw new Error(`Invalid TokenAuthorizationsDetails: unknown role "${key}"`);
+        }
+        if (typeof roleAuth !== 'object' || roleAuth === null || !('accounts' in roleAuth)) {
+            throw new Error(`Invalid TokenAuthorizationsDetails: role "${key}" missing "accounts" field`);
+        }
+        const { accounts } = roleAuth as { accounts: unknown };
+        if (!Array.isArray(accounts)) {
+            throw new Error(`Invalid TokenAuthorizationsDetails: role "${key}" accounts must be an array`);
+        }
+        for (const account of accounts) {
+            if (!CborAccountAddress.instanceOf(account)) {
+                throw new Error(`Invalid TokenAuthorizationsDetails: role "${key}" contains invalid account address`);
+            }
+        }
+        result[key as TokenAdminRole] = { accounts: accounts as TokenRoleAuthorizations['accounts'] };
+    }
+    return result;
+}
 
 function decodeTokenModuleState(value: Cbor.Type): TokenModuleState {
     const decoded = cborDecode(value.bytes);
@@ -96,6 +126,7 @@ function decodeTokenInitializationParameters(value: Cbor.Type): TokenInitializat
 }
 
 type DecodeTypeMap = {
+    TokenAuthorizationsDetails: TokenAuthorizationsDetails;
     TokenModuleState: TokenModuleState;
     TokenModuleAccountState: TokenModuleAccountState;
     TokenInitializationParameters: TokenInitializationParameters;
@@ -124,6 +155,8 @@ export function decode(cbor: Cbor.Type, type?: undefined): unknown;
  */
 export function decode<T extends keyof DecodeTypeMap | undefined>(cbor: Cbor.Type, type: T): unknown {
     switch (type) {
+        case 'TokenAuthorizationsDetails':
+            return decodeTokenAuthorizationsDetails(cbor);
         case 'TokenModuleState':
             return decodeTokenModuleState(cbor);
         case 'TokenModuleAccountState':

--- a/packages/sdk/src/plt/module.ts
+++ b/packages/sdk/src/plt/module.ts
@@ -1,5 +1,22 @@
 import { MAX_U8 } from '../constants.js';
+import type { TokenAdminRole } from './TokenOperation.js';
 import { Cbor, CborAccountAddress, CreatePLTPayload, TokenAmount, TokenMetadataUrl } from './index.js';
+
+/**
+ * Represents the authorizations held by accounts for a specific admin role on a token.
+ * An empty `accounts` array means no accounts currently hold the role.
+ */
+export type TokenRoleAuthorizations = {
+    accounts: CborAccountAddress.Type[];
+};
+
+/**
+ * The decoded form of the CBOR `token-authorizations` structure.
+ * A `Partial<Record>` because absent roles indicate that the corresponding feature
+ * is not enabled on the token (e.g. no `"updateDenyList"` key means the deny list
+ * is not active).
+ */
+export type TokenAuthorizationsDetails = Partial<Record<TokenAdminRole, TokenRoleAuthorizations>>;
 
 /**
  * The Token Module state represents global state information that is maintained by the Token Module,

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -1,5 +1,4 @@
-import type { TokenAdminRole } from './TokenOperation.js';
-import type { Cbor, CborAccountAddress, TokenAmount, TokenId, TokenModuleReference } from './index.js';
+import type { Cbor, TokenAmount, TokenId, TokenModuleReference } from './index.js';
 
 /**
  * Represents a protocol level token state for an account.
@@ -75,22 +74,6 @@ export type CreatePLTPayload = {
     /** The module specific initialization parameters. */
     initializationParameters: Cbor.Type;
 };
-
-/**
- * Represents the authorizations held by accounts for a specific admin role on a token.
- * An empty `accounts` array means no accounts currently hold the role.
- */
-export type TokenRoleAuthorizations = {
-    accounts: CborAccountAddress.Type[];
-};
-
-/**
- * The decoded form of the CBOR `token-authorizations` structure.
- * A `Partial<Record>` because absent roles indicate that the corresponding feature
- * is not enabled on the token (e.g. no `"updateDenyList"` key means the deny list
- * is not active).
- */
-export type TokenAuthorizationsDetails = Partial<Record<TokenAdminRole, TokenRoleAuthorizations>>;
 
 /**
  * Represents the authorizations of a token, such as allow/deny lists, at a specific block.

--- a/packages/sdk/src/plt/types.ts
+++ b/packages/sdk/src/plt/types.ts
@@ -1,4 +1,5 @@
-import type { Cbor, TokenAmount, TokenId, TokenModuleReference } from './index.js';
+import type { TokenAdminRole } from './TokenOperation.js';
+import type { Cbor, CborAccountAddress, TokenAmount, TokenId, TokenModuleReference } from './index.js';
 
 /**
  * Represents a protocol level token state for an account.
@@ -76,8 +77,25 @@ export type CreatePLTPayload = {
 };
 
 /**
+ * Represents the authorizations held by accounts for a specific admin role on a token.
+ * An empty `accounts` array means no accounts currently hold the role.
+ */
+export type TokenRoleAuthorizations = {
+    accounts: CborAccountAddress.Type[];
+};
+
+/**
+ * The decoded form of the CBOR `token-authorizations` structure.
+ * A `Partial<Record>` because absent roles indicate that the corresponding feature
+ * is not enabled on the token (e.g. no `"updateDenyList"` key means the deny list
+ * is not active).
+ */
+export type TokenAuthorizationsDetails = Partial<Record<TokenAdminRole, TokenRoleAuthorizations>>;
+
+/**
  * Represents the authorizations of a token, such as allow/deny lists, at a specific block.
  * see {@link GRPCClient.getTokenAuthorizations} for more details.
+ * Use {@link Cbor.decode} with type `'TokenAuthorizationsDetails'` to decode `details`.
  */
 export type TokenAuthorizations = {
     tokenId: TokenId.Type;

--- a/packages/sdk/src/types/cbor.ts
+++ b/packages/sdk/src/types/cbor.ts
@@ -10,6 +10,7 @@ import { CborAccountAddress, CborMemo, TokenAmount, TokenMetadataUrl } from '../
  * - `AccountAddress`: For encoding Concordium account addresses in CBOR format
  * - `TokenAmount`: For encoding protocol-level token amounts in CBOR format
  * - `CborMemo`: For encoding protocol-level token memos in CBOR format
+ * - `TokenMetadataUrl`: For encoding token metadata used by protocol-level tokens in CBOR format
  */
 export function registerCBOREncoders(): void {
     CborAccountAddress.registerCBOREncoder();

--- a/packages/sdk/test/ci/plt/Cbor.test.ts
+++ b/packages/sdk/test/ci/plt/Cbor.test.ts
@@ -2,7 +2,9 @@ import { CborAccountAddress, CborMemo } from '../../../src/plt/index.ts';
 import {
     Cbor,
     TokenAddDenyListOperation,
+    TokenAdminRole,
     TokenAmount,
+    TokenAuthorizationsDetails,
     TokenId,
     TokenMetadataUrl,
     TokenMintOperation,
@@ -1102,6 +1104,86 @@ describe('PLT Cbor', () => {
                     },
                 },
             ]);
+        });
+    });
+
+    describe('TokenAuthorizationsDetails', () => {
+        const addr1 = CborAccountAddress.fromAccountAddress(AccountAddress.fromBuffer(new Uint8Array(32).fill(0x15)));
+        const addr2 = CborAccountAddress.fromAccountAddress(AccountAddress.fromBuffer(new Uint8Array(32).fill(0x42)));
+
+        test('decodes all 7 roles with multiple accounts', () => {
+            // Note we modify the type using `Required` to ensure new roles will cause type errors here.
+            const input: Required<TokenAuthorizationsDetails> = {
+                [TokenAdminRole.UpdateAdminRoles]: { accounts: [addr1, addr2] },
+                [TokenAdminRole.Mint]: { accounts: [addr1] },
+                [TokenAdminRole.Burn]: { accounts: [addr2] },
+                [TokenAdminRole.UpdateAllowList]: { accounts: [addr1, addr2] },
+                [TokenAdminRole.UpdateDenyList]: { accounts: [addr1] },
+                [TokenAdminRole.Pause]: { accounts: [addr2] },
+                [TokenAdminRole.UpdateMetadata]: { accounts: [addr1] },
+            };
+
+            const encoded = Cbor.encode(input);
+            const decoded = Cbor.decode(encoded, 'TokenAuthorizationsDetails');
+
+            expect(decoded[TokenAdminRole.UpdateAdminRoles]?.accounts).toEqual([addr1, addr2]);
+            expect(decoded[TokenAdminRole.Mint]?.accounts).toEqual([addr1]);
+            expect(decoded[TokenAdminRole.Burn]?.accounts).toEqual([addr2]);
+            expect(decoded[TokenAdminRole.UpdateAllowList]?.accounts).toEqual([addr1, addr2]);
+            expect(decoded[TokenAdminRole.UpdateDenyList]?.accounts).toEqual([addr1]);
+            expect(decoded[TokenAdminRole.Pause]?.accounts).toEqual([addr2]);
+            expect(decoded[TokenAdminRole.UpdateMetadata]?.accounts).toEqual([addr1]);
+        });
+
+        test('decodes sparse map — absent roles are undefined', () => {
+            const input: TokenAuthorizationsDetails = {
+                [TokenAdminRole.UpdateAdminRoles]: { accounts: [addr1] },
+                [TokenAdminRole.Mint]: { accounts: [addr1, addr2] },
+            };
+
+            const encoded = Cbor.encode(input);
+            const decoded = Cbor.decode(encoded, 'TokenAuthorizationsDetails');
+
+            expect(Object.keys(decoded)).toHaveLength(2);
+            expect(decoded[TokenAdminRole.UpdateAdminRoles]?.accounts).toEqual([addr1]);
+            expect(decoded[TokenAdminRole.Mint]?.accounts).toEqual([addr1, addr2]);
+            expect(decoded[TokenAdminRole.Burn]).toBeUndefined();
+            expect(decoded[TokenAdminRole.UpdateDenyList]).toBeUndefined();
+        });
+
+        test('decodes role with empty accounts list', () => {
+            const input: TokenAuthorizationsDetails = {
+                [TokenAdminRole.Mint]: { accounts: [] },
+            };
+
+            const encoded = Cbor.encode(input);
+            const decoded = Cbor.decode(encoded, 'TokenAuthorizationsDetails');
+
+            expect(decoded[TokenAdminRole.Mint]?.accounts).toEqual([]);
+        });
+
+        test('throws on unknown role string', () => {
+            const input = { unknownRole: { accounts: [] } };
+            const encoded = Cbor.encode(input);
+
+            expect(() => Cbor.decode(encoded, 'TokenAuthorizationsDetails')).toThrow(
+                'Invalid TokenAuthorizationsDetails: unknown role "unknownRole"'
+            );
+        });
+
+        test('decodes correctly from known hex bytes', () => {
+            // Encodes: mint → [addr1(0x15*32), addr2(0x42*32)], updateAdminRoles → [addr1]
+            const hex =
+                'a2646d696e74a1686163636f756e747382d99d73a201d99d71a1011903970358201515151515151515151515151515151515151515151515151515151515151515d99d73a201d99d71a10119039703582042424242424242424242424242424242424242424242424242424242424242427075706461746541646d696e526f6c6573a1686163636f756e747381d99d73a201d99d71a1011903970358201515151515151515151515151515151515151515151515151515151515151515';
+
+            const decoded = Cbor.decode(Cbor.fromHexString(hex), 'TokenAuthorizationsDetails');
+
+            expect(Object.keys(decoded)).toHaveLength(2);
+            expect(decoded[TokenAdminRole.Mint]?.accounts).toHaveLength(2);
+            expect(decoded[TokenAdminRole.UpdateAdminRoles]?.accounts).toHaveLength(1);
+            expect(decoded[TokenAdminRole.Mint]?.accounts[0]).toEqual(addr1);
+            expect(decoded[TokenAdminRole.Mint]?.accounts[1]).toEqual(addr2);
+            expect(decoded[TokenAdminRole.UpdateAdminRoles]?.accounts[0]).toEqual(addr1);
         });
     });
 });

--- a/packages/sdk/test/ci/plt/Cbor.test.ts
+++ b/packages/sdk/test/ci/plt/Cbor.test.ts
@@ -1162,13 +1162,12 @@ describe('PLT Cbor', () => {
             expect(decoded[TokenAdminRole.Mint]?.accounts).toEqual([]);
         });
 
-        test('throws on unknown role string', () => {
+        test('silently skips unknown role strings', () => {
             const input = { unknownRole: { accounts: [] } };
             const encoded = Cbor.encode(input);
 
-            expect(() => Cbor.decode(encoded, 'TokenAuthorizationsDetails')).toThrow(
-                'Invalid TokenAuthorizationsDetails: unknown role "unknownRole"'
-            );
+            const decoded = Cbor.decode(encoded, 'TokenAuthorizationsDetails');
+            expect(Object.keys(decoded)).toHaveLength(0);
         });
 
         test('decodes correctly from known hex bytes', () => {


### PR DESCRIPTION
## Purpose

Closing [COR-2343](https://linear.app/concordium/issue/COR-2343/decode-cbor-in-gettokenauthorizations-in-web-sdk)

## Changes

- `TokenAdminRole.UpdateAllowList` value corrected from `'allowList'` to `'updateAllowList'`, and `TokenAdminRole.UpdateDenyList` from `'denyList'` to `'updateDenyList'`, to match the canonical CDDL role strings.
- Added `TokenRoleAuthorizations` and `TokenAuthorizationsDetails` types representing the decoded CBOR structure returned by `getTokenAuthorizations`.
- `Cbor.decode` now accepts `'TokenAuthorizationsDetails'` as a type hint, decoding the CBOR `details` field of `TokenAuthorizations` into a `Partial<Record<TokenAdminRole, TokenRoleAuthorizations>>`.
## Checklist

