### PR TITLE
Support "any" variant for recipients in lock config

### DIFF
--- a/examples/nodejs/client/getLockInfo.ts
+++ b/examples/nodejs/client/getLockInfo.ts
@@ -69,7 +69,7 @@ const client = new ConcordiumGRPCNodeClient(
     console.log('Lock ID:', lockInfo.lock.toString());
     console.log(
         'Recipients:',
-        lockInfo.recipients.map((recipient) => recipient.toString())
+        lockInfo.recipients === 'any' ? 'any' : lockInfo.recipients.map((recipient) => recipient.toString())
     );
     console.log('Expiry:', lockInfo.expiry.expiry.toString());
     console.log('Funds:', JSON.stringify(lockInfo.funds, null, 2));

--- a/examples/nodejs/plt/lock-create-and-fund.ts
+++ b/examples/nodejs/plt/lock-create-and-fund.ts
@@ -20,7 +20,7 @@ const cli = meow(
     $ yarn run-example <path-to-this-file> [options]
 
   Required
-    --recipient,   -r  Account(s) allowed to receive funds from the lock (repeat for multiple)
+    --recipient,   -r  Account(s) allowed to receive funds from the lock, or 'any' (repeat for multiple addresses)
     --token,       -t  Token id the lock can hold and fund with
     --expiry,      -x  Lock expiry as seconds since Unix epoch
     --amount,      -a  Token amount to fund in decimal notation
@@ -58,9 +58,13 @@ const client = new ConcordiumGRPCNodeClient(
     // #region documentation-snippet
 
     // Parse the lock configuration and fund operation arguments
-    const recipients = cli.flags.recipient.map((r) =>
-        CborAccountAddress.fromAccountAddress(AccountAddress.fromBase58(r))
-    );
+    const recipients =
+        cli.flags.recipient.length === 1 && cli.flags.recipient[0] === 'any'
+            ? 'any'
+            : cli.flags.recipient.map((r) => CborAccountAddress.fromAccountAddress(AccountAddress.fromBase58(r)));
+    if (recipients !== 'any' && cli.flags.recipient.includes('any')) {
+        throw new Error("Use either '--recipient any' or one or more account addresses, not both.");
+    }
     const tokenId = TokenId.fromString(cli.flags.token);
     const expiry = CborEpoch.fromEpochSeconds(cli.flags.expiry);
 
@@ -74,6 +78,7 @@ const client = new ConcordiumGRPCNodeClient(
 
         // Build the lock configuration. Here the sender is granted all capabilities,
         // but this can be adjusted to fit the desired access control model.
+        // Use `recipients: 'any'` instead of the parsed address array to allow any eligible recipient.
         const config = {
             recipients,
             expiry,
@@ -115,6 +120,7 @@ const client = new ConcordiumGRPCNodeClient(
         // Or from a wallet perspective:
         // Build the lockCreate + lockFund payload without submitting.
         // The sender is still needed so the proposal can derive the predicted lock id from chain state.
+        // Use `recipients: 'any'` instead of the parsed address array to allow any eligible recipient.
         const sender = AccountAddress.fromBase58(cli.flags.sender);
         const config = {
             recipients,

--- a/examples/nodejs/plt/lock-create-and-fund.ts
+++ b/examples/nodejs/plt/lock-create-and-fund.ts
@@ -58,7 +58,7 @@ const client = new ConcordiumGRPCNodeClient(
     // #region documentation-snippet
 
     // Parse the lock configuration and fund operation arguments
-    const recipients =
+    const recipients: 'any' | CborAccountAddress.Type[] =
         cli.flags.recipient.length === 1 && cli.flags.recipient[0] === 'any'
             ? 'any'
             : cli.flags.recipient.map((r) => CborAccountAddress.fromAccountAddress(AccountAddress.fromBase58(r)));

--- a/examples/nodejs/plt/lock-create.ts
+++ b/examples/nodejs/plt/lock-create.ts
@@ -20,7 +20,7 @@ const cli = meow(
     $ yarn run-example <path-to-this-file> [options]
 
   Required
-    --recipient,   -r  Account(s) allowed to receive funds from the lock (repeat for multiple)
+    --recipient,   -r  Account(s) allowed to receive funds from the lock, or 'any' (repeat for multiple addresses)
     --token,       -t  Token id(s) the lock can hold (repeat for multiple)
     --expiry,      -x  Lock expiry as seconds since Unix epoch
 
@@ -54,9 +54,13 @@ const client = new ConcordiumGRPCNodeClient(
     // #region documentation-snippet
 
     // Parse the lock configuration arguments
-    const recipients = cli.flags.recipient.map((r) =>
-        CborAccountAddress.fromAccountAddress(AccountAddress.fromBase58(r))
-    );
+    const recipients =
+        cli.flags.recipient.length === 1 && cli.flags.recipient[0] === 'any'
+            ? 'any'
+            : cli.flags.recipient.map((r) => CborAccountAddress.fromAccountAddress(AccountAddress.fromBase58(r)));
+    if (recipients !== 'any' && cli.flags.recipient.includes('any')) {
+        throw new Error("Use either '--recipient any' or one or more account addresses, not both.");
+    }
     const tokenIds = cli.flags.token.map(TokenId.fromString);
     const expiry = CborEpoch.fromEpochSeconds(cli.flags.expiry);
 
@@ -99,6 +103,7 @@ const client = new ConcordiumGRPCNodeClient(
     } else {
         // Or from a wallet perspective:
         // Build the lockCreate operation payload without submitting.
+        // Use `recipients: 'any'` instead of an address array to allow any eligible recipient.
         // The controller grants and token list should be configured to match the intended access model.
         const config = {
             recipients,

--- a/examples/nodejs/plt/lock-create.ts
+++ b/examples/nodejs/plt/lock-create.ts
@@ -54,7 +54,7 @@ const client = new ConcordiumGRPCNodeClient(
     // #region documentation-snippet
 
     // Parse the lock configuration arguments
-    const recipients =
+    const recipients: 'any' | CborAccountAddress.Type[] =
         cli.flags.recipient.length === 1 && cli.flags.recipient[0] === 'any'
             ? 'any'
             : cli.flags.recipient.map((r) => CborAccountAddress.fromAccountAddress(AccountAddress.fromBase58(r)));

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 13.0.0-alpha.1 (devnet-p11-2)
+
+### Changed
+
+- Lock configurations can now be created with support for a special "any" value for the `recipients` field.
+
 ## 13.0.0-alpha.0 (devnet-p11-2)
 
 - Added high-level `Lock` client for creating, funding, sending, returning, and cancelling protocol-level locks.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@concordium/web-sdk",
-    "version": "13.0.0-alpha.0",
+    "version": "13.0.0-alpha.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16"

--- a/packages/sdk/src/plt/Lock.ts
+++ b/packages/sdk/src/plt/Lock.ts
@@ -609,9 +609,9 @@ export async function validateFund(lock: Lock, sender: AccountAddress.Type, deta
 export function validateSend(lock: Lock, sender: AccountAddress.Type, details: SendDetails): true {
     validateCapability(lock, sender, LockController.SimpleV0Capability.Send);
 
-    const recipientAllowed = lock.info.recipients.some(
-        (recipient) => recipient.address.address === details.recipient.address
-    );
+    const recipientAllowed =
+        lock.info.recipients === 'any' ||
+        lock.info.recipients.some((recipient) => recipient.address.address === details.recipient.address);
     if (!recipientAllowed) {
         throw new RecipientNotAllowedError(details.recipient, lock.info.lock);
     }

--- a/packages/sdk/src/plt/cbor-types.ts
+++ b/packages/sdk/src/plt/cbor-types.ts
@@ -149,10 +149,13 @@ export type TokenInitializationParameters = {
     burnable?: boolean;
 };
 
+/** Accounts that are permitted to receive funds controlled by a lock. */
+export type LockRecipients = 'any' | CborAccountAddress.Type[];
+
 /** Lock configuration used by `lockCreate` meta update operations. */
 export type LockConfig = {
-    /** Accounts that are permitted to receive funds controlled by the lock. */
-    recipients: CborAccountAddress.Type[];
+    /** Accounts that are permitted to receive funds controlled by the lock, or `'any'` for any eligible recipient. */
+    recipients: LockRecipients;
     /** Lock expiry time. */
     expiry: CborEpoch.Type;
     /** Lock controller configuration. */

--- a/packages/sdk/src/plt/decode.ts
+++ b/packages/sdk/src/plt/decode.ts
@@ -4,6 +4,7 @@ import type {
     AccountLockAmount,
     LockAccountFund,
     LockInfo,
+    LockRecipients,
     TokenAuthorizationsDetails,
     TokenRoleAuthorizations,
 } from './cbor-types.js';
@@ -230,15 +231,20 @@ function convertLockConfig(value: unknown): LockConfig {
     }
 
     const lockConfig = value as Record<string, unknown>;
-    if (!Array.isArray(lockConfig.recipients) || !lockConfig.recipients.every(CborAccountAddress.instanceOf)) {
-        throw new Error('Invalid lock config: expected recipients array');
+    let recipients: LockRecipients;
+    if (lockConfig.recipients === 'any') {
+        recipients = 'any';
+    } else if (Array.isArray(lockConfig.recipients) && lockConfig.recipients.every(CborAccountAddress.instanceOf)) {
+        recipients = lockConfig.recipients;
+    } else {
+        throw new Error('Invalid lock config: expected recipients to be "any" or an array of CBOR account addresses');
     }
     if (!CborEpoch.instanceOf(lockConfig.expiry)) {
         throw new Error('Invalid lock config: expected expiry as CBOR epoch time');
     }
 
     return {
-        recipients: lockConfig.recipients,
+        recipients,
         expiry: lockConfig.expiry,
         controller: LockController.fromCBORValue(lockConfig.controller),
     };

--- a/packages/sdk/test/ci/plt/Lock.test.ts
+++ b/packages/sdk/test/ci/plt/Lock.test.ts
@@ -48,11 +48,12 @@ function pastEpoch(): CborEpoch.Type {
 function createLockInfo(
     roles: LockController.SimpleV0Capability[],
     expiry: CborEpoch.Type = futureEpoch(),
-    account: AccountAddress.Type = ACCOUNT_1
+    account: AccountAddress.Type = ACCOUNT_1,
+    recipients: LockInfo['recipients'] = [CborAccountAddress.fromAccountAddress(ACCOUNT_2)]
 ): LockInfo {
     return {
         lock: LOCK_ID,
-        recipients: [CborAccountAddress.fromAccountAddress(ACCOUNT_2)],
+        recipients,
         expiry,
         controller: LockController.simpleV0(
             [
@@ -270,6 +271,22 @@ describe('PLT Lock validation', () => {
         });
     });
 
+    it('allows sending to any recipient when the lock recipients is "any"', () => {
+        const lock = Lock.fromInfo(
+            mockGrpc(),
+            createLockInfo([LockController.SimpleV0Capability.Send], futureEpoch(), ACCOUNT_1, 'any')
+        );
+
+        expect(
+            Lock.validateSend(lock, ACCOUNT_1, {
+                token: TOKEN_ID,
+                source: ACCOUNT_1,
+                amount: TokenAmount.create(10n, 0),
+                recipient: ACCOUNT_1,
+            })
+        ).toBe(true);
+    });
+
     it('throws RecipientNotAllowedError when the recipient is not configured on the lock', async () => {
         const lock = Lock.fromInfo(mockGrpc(), createLockInfo([LockController.SimpleV0Capability.Send]));
         const recipient = ACCOUNT_1;
@@ -365,6 +382,10 @@ describe('PLT Lock.fromCbor', () => {
         expect(lock.info.funds[0].account.address.address).toBe(ACCOUNT_1.address);
         expect(lock.info.funds[0].amounts[0].token).toEqual(TOKEN_ID);
         expect(lock.info.funds[0].amounts[0].amount).toEqual(TokenAmount.create(100n, 0));
+        expect(lock.info.recipients).not.toBe('any');
+        if (lock.info.recipients === 'any') {
+            fail('Expected limited recipients');
+        }
         expect(lock.info.recipients[0].address.address).toBe(ACCOUNT_2.address);
         expect(lock.info.expiry.expiry.expiryEpochSeconds).toBe(info.expiry.expiry.expiryEpochSeconds);
         expect(lock.info.controller).toEqual(info.controller);

--- a/packages/sdk/test/ci/plt/LockConfig.test.ts
+++ b/packages/sdk/test/ci/plt/LockConfig.test.ts
@@ -39,13 +39,38 @@ describe('PLT LockConfig', () => {
         });
     });
 
-    it('throws if recipients is not an array of CBOR account addresses', () => {
+    it('encodes and decodes any-recipient locks', () => {
+        const anyConfig: LockConfig = {
+            ...config,
+            recipients: 'any',
+        };
+
+        expect(Buffer.from(Cbor.encode(anyConfig).bytes).toString('hex')).toBe(
+            'a366657870697279c10a6a636f6e74726f6c6c6572a16873696d706c655630a2666772616e747381a265726f6c6573826466756e646473656e64676163636f756e74d99d73a201d99d71a101190397035820151515151515151515151515151515151515151515151515151515151515151566746f6b656e73816674546f6b656e6a726563697069656e747363616e79'
+        );
+        expect(Cbor.decode(Cbor.encode(anyConfig), 'LockConfig')).toMatchObject(anyConfig);
+    });
+
+    it('throws if recipients is not "any" or an array of CBOR account addresses', () => {
         const invalid = Cbor.encode({
             ...config,
             recipients: ['not-an-account'],
         });
 
-        expect(() => Cbor.decode(invalid, 'LockConfig')).toThrow(/expected recipients array/);
+        expect(() => Cbor.decode(invalid, 'LockConfig')).toThrow(
+            /expected recipients to be "any" or an array of CBOR account addresses/
+        );
+    });
+
+    it('throws if recipients is invalid text', () => {
+        const invalid = Cbor.encode({
+            ...config,
+            recipients: 'everybody',
+        });
+
+        expect(() => Cbor.decode(invalid, 'LockConfig')).toThrow(
+            /expected recipients to be "any" or an array of CBOR account addresses/
+        );
     });
 
     it('throws if expiry is not a CBOR epoch time', () => {


### PR DESCRIPTION
Closes COR-2421

## Purpose

Adds support for "any" variant of lock configuration recipients

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.