### PR TITLE
docs: document constructing IdentityInput from a seed phrase

### DIFF
--- a/docs/pages/misc-pages/add-credential.md
+++ b/docs/pages/misc-pages/add-credential.md
@@ -1,0 +1,114 @@
+
+All credential material is derived from the wallet **seed phrase**. There
+is no API that extracts it from a running wallet (browser, mobile, or
+desktop) — you reconstruct it from the seed. This is by design and is what
+keeps the identity layer private.
+
+If a guide asks you to "construct an `IdentityInput`" and you have only a
+seed phrase, this page is what you are looking for.
+
+## Which path do I need?
+
+**1. Do you control the seed phrase for the identity?**
+
+- **No — it is an end user's identity and you want to act for them.** Not
+    possible, and you should not try. Never ask a user for their seed
+    phrase. Have them sign in their own wallet instead.
+- **Yes — you own the seed (you are building the wallet).** Continue.
+
+**2. What are you creating?**
+
+- **A brand new account** under the identity → use
+    `createCredentialTransaction`. This is a credential *deployment* and
+    creates a new account address. See
+    [Account Creation](./account-creation.md).
+- **An extra credential on an *existing* account address** → use
+    `createUnsignedCredentialForExistingAccount`, which needs an
+    `IdentityInput`. Continue below.
+
+## Construct `IdentityInput` from a seed phrase
+
+`IdentityInput` bundles the identity object, the identity provider info,
+and the three private values derived from the seed. All three are the
+same `HexString` the SDK derives internally, so you build them straight
+from `ConcordiumHdWallet`:
+
+```ts
+import { ConcordiumHdWallet, IdentityInput } from '@concordium/web-sdk';
+
+const wallet = ConcordiumHdWallet.fromSeedPhrase(seedPhrase, net);
+
+const identityInput: IdentityInput = {
+    identityObject,                        // see "Recover the identity object" below
+    identityProvider: { ipInfo, arsInfos },
+    idCredSecret: wallet.getIdCredSec(ipIndex, identityIndex).toString('hex'),
+    prfKey: wallet.getPrfKey(ipIndex, identityIndex).toString('hex'),
+    randomness: wallet
+        .getSignatureBlindingRandomness(ipIndex, identityIndex)
+        .toString('hex'),
+};
+```
+
+Where the public inputs come from:
+
+- `ipInfo` — `getIdentityProviders()`, pick your provider.
+- `arsInfos` — `getAnonymityRevokers()`.
+- `ipIndex` — `ipInfo.ipIdentity`.
+
+> If instead you have a mobile wallet export or a user-cli `id-use-data`
+> file (not a seed), construct `IdentityInput` from those as shown in
+> [Old GRPC-Client](./grpc-v1.md#construct-identityinput-for-creating-credentials).
+
+Pass this `identityInput` to `createUnsignedCredentialForExistingAccount`,
+then submit it in an update-credentials transaction. See
+[Transactions](../transactions.md#create-a-credential-for-an-existing-account).
+
+## Recover the identity object
+
+Don't have `identityObject` stored? Recover it from the seed via the
+identity provider's `recoveryStart` endpoint:
+
+```ts
+import { ConcordiumHdWallet, createIdentityRecoveryRequest } from '@concordium/web-sdk';
+
+const idp = (await client.getIdentityProviders())[ipIndex]; // has metadata.recoveryStart
+const globalContext = await client.getCryptographicParameters();
+
+const request = createIdentityRecoveryRequest({
+    ipInfo: idp.ipInfo,
+    globalContext,
+    seedAsHex: ConcordiumHdWallet.fromSeedPhrase(seedPhrase, net).seedAsHex,
+    net,
+    identityIndex,
+    timestamp: Math.floor(Date.now() / 1000),
+});
+
+// GET recoveryStart?state={"idRecoveryRequest": <request>}, then fetch the
+// returned URL. The response's `.value` is the identityObject.
+const params = new URLSearchParams({
+    state: JSON.stringify({ idRecoveryRequest: request }),
+});
+const resolved = await fetch(`${idp.metadata.recoveryStart}?${params}`);
+const identityObject = (await (await fetch(resolved.url)).json()).value;
+```
+
+If your secret is held separately, use
+`createIdentityRecoveryRequestWithKeys({ idCredSec, ipInfo, globalContext, timestamp })`.
+
+## FAQ
+
+**"I can't extract or reconstruct `IdentityInput` from my web wallet."**
+You reconstruct it from your seed phrase, not from the running wallet —
+see [above](#construct-identityinput-from-a-seed-phrase). The wallet never
+exposes these secrets through an API, by design.
+
+**"Can I add a credential to a user's account without their seed?"** No.
+The material is seed-derived and the wallet does not expose it. The user
+must sign in their own wallet.
+
+## Term mapping
+
+| Older term / gap | Use now |
+| --- | --- |
+| "Construct `IdentityInput`" (was a TODO) | Derive from the seed, as above |
+| `createCredentialDeploymentPayload` (deprecated) | `createCredentialTransaction` |

--- a/docs/pages/misc-pages/add-credential.md
+++ b/docs/pages/misc-pages/add-credential.md
@@ -106,9 +106,3 @@ exposes these secrets through an API, by design.
 The material is seed-derived and the wallet does not expose it. The user
 must sign in their own wallet.
 
-## Term mapping
-
-| Older term / gap | Use now |
-| --- | --- |
-| "Construct `IdentityInput`" (was a TODO) | Derive from the seed, as above |
-| `createCredentialDeploymentPayload` (deprecated) | `createCredentialTransaction` |

--- a/docs/pages/misc-pages/add-credential.md
+++ b/docs/pages/misc-pages/add-credential.md
@@ -105,4 +105,3 @@ exposes these secrets through an API, by design.
 **"Can I add a credential to a user's account without their seed?"** No.
 The material is seed-derived and the wallet does not expose it. The user
 must sign in their own wallet.
-

--- a/docs/pages/transactions.md
+++ b/docs/pages/transactions.md
@@ -86,7 +86,12 @@ owner with an update credentials transaction. See [Create an update credentials
 transaction](#create-an-update-credentials-transaction) for how to create this
 transaction payload using the output from the example below:
 
-<!-- TODO: Recreate documentation for `Construct IdentityInput` -->
+This path requires an `IdentityInput`. If you have only a seed phrase
+(e.g. a browser/mobile wallet), see [Add a Credential
+(IdentityInput)](./misc-pages/add-credential.md) for how to construct it
+from the seed. To construct it from a mobile wallet export or user-cli
+file instead, see [Old
+GRPC-Client](./misc-pages/grpc-v1.md#construct-identityinput-for-creating-credentials).
 
 ```ts
     const lastFinalizedBlockHash = (await client.getConsensusStatus()).lastFinalizedBlock;
@@ -95,9 +100,17 @@ transaction payload using the output from the example below:
         throw new Error('Cryptographic parameters were not found on a block that has been finalized.');
     }
 
-    // The parts of the identity required to create a new credential, parsed from
-    // e.g. a wallet export.
-    const identityInput: IdentityInput = ...
+    // The parts of the identity required to create a new credential.
+    // Construct this from the seed phrase (or a wallet export / user-cli
+    // file). See the "Add a Credential (IdentityInput)" page.
+    const wallet = ConcordiumHdWallet.fromSeedPhrase(seedPhrase, net);
+    const identityInput: IdentityInput = {
+        identityObject,
+        identityProvider: { ipInfo, arsInfos },
+        idCredSecret: wallet.getIdCredSec(ipIndex, identityIndex).toString('hex'),
+        prfKey: wallet.getPrfKey(ipIndex, identityIndex).toString('hex'),
+        randomness: wallet.getSignatureBlindingRandomness(ipIndex, identityIndex).toString('hex'),
+    };
 
     // Require just one key on the credential to sign. This can be any number
     // up to the number of public keys added to the credential.

--- a/docs/typedoc.config.cjs
+++ b/docs/typedoc.config.cjs
@@ -56,6 +56,10 @@ module.exports = {
                                 source: 'account-creation.md',
                             },
                             {
+                                name: 'Add a Credential (IdentityInput)',
+                                source: 'add-credential.md',
+                            },
+                            {
                                 name: 'Optimizing bundled applications',
                                 source: 'bundler-optimizations.md',
                             },


### PR DESCRIPTION
### Problem

Adding a credential to an existing account (`createUnsignedCredentialForExistingAccount`) requires an `IdentityInput`. The only documented ways to build one were from a **mobile wallet export** or a **user-cli file** — see the "Construct IdentityInput" section in the Old GRPC-Client page. A browser/mobile-wallet user has neither; they have only a **seed phrase**. As a result the `Construct IdentityInput` step in `transactions.md` was an unfillable `<!-- TODO -->` for the most common case, and developers had no path from a seed phrase to an `IdentityInput`.

### Change

- **New page** `docs/pages/misc-pages/add-credential.md`: a short decision guide (new account vs. existing account; who controls the seed) plus how to build `IdentityInput`'s `idCredSecret` / `prfKey` / `randomness` directly from `ConcordiumHdWallet`, and how to recover the `identityObject` from the seed via the identity provider's `recoveryStart` endpoint.
- **Fills the `Construct IdentityInput` TODO** in `transactions.md` with a runnable seed-based construction and links to the new page and to the mobile-export/user-cli alternatives.
- **Registers** the new page in `docs/typedoc.config.cjs`.

### Verification

- The three derivation functions (`getIdCredSec`, `getPrfKey`, `getSignatureBlindingRandomness`) return `HexString`, matching `IdentityInput`'s `string` fields, so the construction is encoding-correct.
- The recovery flow mirrors the official `examples/wallet` recovery worker.
- `markdownlint` and `markdown-link-check` pass on the changed files (all cross-file fragments resolve).

Docs-only; no package `CHANGELOG` entry (consistent with recent docs-page additions).