### PR TITLE
fix: deserialization of passive delegation transactions

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Deserializing a `configureDelegation` payload with a passive delegation target no longer fails with "Failed to read 8 bytes from the cursor." The deserializer was unconditionally reading an 8-byte baker ID even though passive delegation targets do not encode one.
+
 ## 12.0.2
 
 ### Changed

--- a/packages/sdk/src/accountTransactions.ts
+++ b/packages/sdk/src/accountTransactions.ts
@@ -29,7 +29,6 @@ import {
     encodeWord8FromString,
     encodeWord32,
     encodeWord64,
-    mapTagToType,
     packBufferWithWord8Length,
     packBufferWithWord16Length,
     packBufferWithWord32Length,
@@ -838,18 +837,24 @@ export class ConfigureDelegationHandler
 
         const restakeEarnings = hasRestakeEarnings ? serializedPayload.read(1).readUInt8(0) !== 0 : false;
 
-        let delegationTarget;
+        let delegationTarget: DelegationTarget | undefined;
         if (hasDelegationTarget) {
             const tag = serializedPayload.read(1).readUInt8(0);
 
             const tagMapping = DelegationTargetTypeNumeric[tag];
             if (tagMapping === undefined) throw new Error(`Unknown tag id ${tag}`);
 
-            const validatorId = serializedPayload.read(8).readBigUInt64BE(0);
-            delegationTarget = {
-                delegateType: mapTagToType[tag],
-                bakerId: validatorId,
-            };
+            if (tag === DelegationTargetTypeNumeric.Baker) {
+                const validatorId = serializedPayload.read(8).readBigUInt64BE(0);
+                delegationTarget = {
+                    delegateType: DelegationTargetType.Baker,
+                    bakerId: validatorId,
+                };
+            } else {
+                delegationTarget = {
+                    delegateType: DelegationTargetType.PassiveDelegation,
+                };
+            }
         }
 
         return {

--- a/packages/sdk/test/ci/deserialization.test.ts
+++ b/packages/sdk/test/ci/deserialization.test.ts
@@ -394,6 +394,25 @@ test('test deserialize ConfigureDelegation with no restake', () => {
     deserializeAccountTransactionBase(transaction);
 });
 
+test('test deserialize ConfigureDelegation with passive delegation', () => {
+    const payload: ConfigureDelegationPayload = {
+        stake: CcdAmount.fromMicroCcd(0),
+
+        restakeEarnings: true,
+
+        delegationTarget: {
+            delegateType: DelegationTargetType.PassiveDelegation,
+        },
+    };
+
+    const transaction: AccountTransaction = {
+        header,
+        type: AccountTransactionType.ConfigureDelegation,
+        payload,
+    };
+    deserializeAccountTransactionBase(transaction);
+});
+
 test('test deserialize ConfigureDelegation with no delegation', () => {
     const payload: ConfigureDelegationPayload = {
         stake: CcdAmount.fromMicroCcd(0),


### PR DESCRIPTION
## Purpose

Fixes issue https://github.com/Concordium/concordium-node-sdk-js/issues/693

## Changes

Only try to deserialise the baker ID if the TargetType is `Baker`, not if it is `Passive`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
